### PR TITLE
fix: propagate not found job error

### DIFF
--- a/backend/src/customers/customers.controller.spec.ts
+++ b/backend/src/customers/customers.controller.spec.ts
@@ -8,7 +8,12 @@ describe('CustomersController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CustomersController],
-      providers: [CustomersService],
+      providers: [
+        {
+          provide: CustomersService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<CustomersController>(CustomersController);

--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -1,12 +1,20 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { CustomersService } from './customers.service';
+import { Customer } from './entities/customer.entity';
 
 describe('CustomersService', () => {
   let service: CustomersService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CustomersService],
+      providers: [
+        CustomersService,
+        {
+          provide: getRepositoryToken(Customer),
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<CustomersService>(CustomersService);

--- a/backend/src/jobs/jobs.controller.spec.ts
+++ b/backend/src/jobs/jobs.controller.spec.ts
@@ -8,7 +8,12 @@ describe('JobsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [JobsController],
-      providers: [JobsService],
+      providers: [
+        {
+          provide: JobsService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<JobsController>(JobsController);

--- a/backend/src/jobs/jobs.service.spec.ts
+++ b/backend/src/jobs/jobs.service.spec.ts
@@ -1,12 +1,24 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
 import { JobsService } from './jobs.service';
+import { Job } from './entities/job.entity';
 
 describe('JobsService', () => {
   let service: JobsService;
+  let jobRepository: { findOne: jest.Mock };
 
   beforeEach(async () => {
+    jobRepository = { findOne: jest.fn() };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [JobsService],
+      providers: [
+        JobsService,
+        {
+          provide: getRepositoryToken(Job),
+          useValue: jobRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<JobsService>(JobsService);
@@ -14,5 +26,10 @@ describe('JobsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should throw NotFoundException when job does not exist', async () => {
+    jobRepository.findOne.mockResolvedValue(null);
+    await expect(service.findOne(1)).rejects.toBeInstanceOf(NotFoundException);
   });
 });

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  NotFoundException,
-  InternalServerErrorException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Job } from './entities/job.entity';
@@ -52,20 +48,16 @@ export class JobsService {
   }
 
   async findOne(id: number): Promise<JobResponseDto> {
-    try {
-      const job = await this.jobRepository.findOne({
-        where: { id },
-        relations: ['customer'],
-      });
+    const job = await this.jobRepository.findOne({
+      where: { id },
+      relations: ['customer'],
+    });
 
-      if (!job) {
-        throw new NotFoundException(`Job with ID ${id} not found.`);
-      }
-
-      return this.toJobResponseDto(job);
-    } catch {
-      throw new InternalServerErrorException('Failed to retrieve job');
+    if (!job) {
+      throw new NotFoundException(`Job with ID ${id} not found.`);
     }
+
+    return this.toJobResponseDto(job);
   }
 
   async remove(id: number): Promise<void> {


### PR DESCRIPTION
## Summary
- let `JobsService.findOne` surface `NotFoundException` instead of masking it
- add unit test for missing job lookup and simplify related specs with mock injections
- drop unused error import in `JobsService`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a77a2cac832587d6551f3b5dc5a6