### PR TITLE
Enable transformation for numeric DTO fields

### DIFF
--- a/backend/src/equipment/dto/create-equipment.dto.ts
+++ b/backend/src/equipment/dto/create-equipment.dto.ts
@@ -1,4 +1,5 @@
 import { IsString, IsOptional, IsNumber } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class CreateEquipmentDto {
   @IsString()
@@ -15,6 +16,7 @@ export class CreateEquipmentDto {
   location?: string;
 
   @IsOptional()
+  @Type(() => Number)
   @IsNumber()
   assignedTruckId?: number;
 }

--- a/backend/src/jobs/dto/create-job.dto.ts
+++ b/backend/src/jobs/dto/create-job.dto.ts
@@ -1,6 +1,9 @@
 import { IsString, IsNumber } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class CreateJobDto {
   @IsString() title: string;
-  @IsNumber() customerId: number;
+  @Type(() => Number)
+  @IsNumber()
+  customerId: number;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,11 +6,17 @@ import { Logger } from '@nestjs/common';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
-  logger.log(`Starting backend in ${process.env.NODE_ENV || 'development'} mode`);
+  logger.log(
+    `Starting backend in ${process.env.NODE_ENV || 'development'} mode`,
+  );
   const app = await NestFactory.create(AppModule);
   app.enableCors();
   app.useGlobalPipes(
-    new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
   );
   app.useGlobalFilters(new HttpExceptionFilter() satisfies ExceptionFilter);
   await app.listen(process.env.PORT || 3000, '0.0.0.0');


### PR DESCRIPTION
## Summary
- Enable transformation in global ValidationPipe
- Ensure numeric DTO fields transform from strings using `@Type(() => Number)`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4c424380c83259d0a726dc395f231