### PR TITLE
feat: add job scheduling details

### DIFF
--- a/backend/src/jobs/dto/create-job.dto.ts
+++ b/backend/src/jobs/dto/create-job.dto.ts
@@ -1,8 +1,28 @@
-import { IsString, IsNumber } from 'class-validator';
+import {
+  IsString,
+  IsNumber,
+  IsOptional,
+  IsBoolean,
+  IsDate,
+} from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class CreateJobDto {
   @IsString()
   title: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  scheduledDate?: Date;
+
+  @IsOptional()
+  @IsBoolean()
+  completed?: boolean;
 
   @IsNumber()
   customerId: number;

--- a/backend/src/jobs/dto/update-job.dto.ts
+++ b/backend/src/jobs/dto/update-job.dto.ts
@@ -1,4 +1,5 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateJobDto } from './create-job.dto';
 
+// Extends CreateJobDto with all fields optional
 export class UpdateJobDto extends PartialType(CreateJobDto) {}

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -14,9 +14,10 @@ export class JobsService {
   ) {}
 
   async create(createJobDto: CreateJobDto): Promise<JobResponseDto> {
+    const { customerId, ...jobData } = createJobDto;
     const job = this.jobRepository.create({
-      ...createJobDto,
-      customer: { id: createJobDto.customerId },
+      ...jobData,
+      customer: { id: customerId },
     });
     const savedJob = await this.jobRepository.save(job);
     return this.toJobResponseDto(savedJob);
@@ -41,7 +42,11 @@ export class JobsService {
     if (!job) {
       throw new NotFoundException(`Job with ID ${id} not found.`);
     }
-    Object.assign(job, updateJobDto);
+    const { customerId, ...updateData } = updateJobDto;
+    if (customerId !== undefined) {
+      job.customer = { id: customerId } as Job['customer'];
+    }
+    Object.assign(job, updateData);
     const updatedJob = await this.jobRepository.save(job);
     return this.toJobResponseDto(updatedJob);
   }


### PR DESCRIPTION
## Summary
- allow optional description, scheduled date, and completion flag when creating or updating jobs
- handle new job fields in service methods and responses

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4cc95299c832583e252c81ec86ada