### PR TITLE
feat: enforce unique customer email

### DIFF
--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -2,9 +2,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { CustomersService } from './customers.service';
 import { Customer } from './entities/customer.entity';
+import { Repository, QueryFailedError } from 'typeorm';
+import { ConflictException } from '@nestjs/common';
 
 describe('CustomersService', () => {
   let service: CustomersService;
+
+  let repo: jest.Mocked<Repository<Customer>>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -12,15 +16,34 @@ describe('CustomersService', () => {
         CustomersService,
         {
           provide: getRepositoryToken(Customer),
-          useValue: {},
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+          },
         },
       ],
     }).compile();
 
     service = module.get<CustomersService>(CustomersService);
+    repo = module.get(getRepositoryToken(Customer));
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('throws ConflictException when email already exists', async () => {
+    repo.create.mockReturnValue({} as Customer);
+    repo.save.mockRejectedValue(
+      new QueryFailedError('', [], { code: '23505' } as any),
+    );
+
+    await expect(service.create({} as any)).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+    await expect(service.create({} as any)).rejects.toHaveProperty(
+      'message',
+      'Email already exists',
+    );
   });
 });

--- a/backend/src/customers/entities/customer.entity.ts
+++ b/backend/src/customers/entities/customer.entity.ts
@@ -18,7 +18,7 @@ export class Customer {
   @Column()
   name: string;
 
-  @Column()
+  @Column({ unique: true })
   email: string;
 
   @Column({ nullable: true })

--- a/backend/src/migrations/20250819192350-add-unique-email-to-customer.ts
+++ b/backend/src/migrations/20250819192350-add-unique-email-to-customer.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUniqueEmailToCustomer20250819192350 implements MigrationInterface {
+  name = 'AddUniqueEmailToCustomer20250819192350';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "customer" ADD CONSTRAINT "UQ_customer_email" UNIQUE ("email")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "customer" DROP CONSTRAINT "UQ_customer_email"`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- ensure customer email is unique in database
- handle duplicate emails with a clear error message
- cover duplicate email error in service tests

## Testing
- `npm test`
- `npm run migration:run` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ce9d1d788325b37b7a091fcdd125