### PR TITLE
refactor: map customer during job creation

### DIFF
--- a/backend/src/jobs/dto/create-job.dto.ts
+++ b/backend/src/jobs/dto/create-job.dto.ts
@@ -26,4 +26,9 @@ export class CreateJobDto {
 
   @IsNumber()
   customerId: number;
+
+  toEntity() {
+    const { customerId, ...jobData } = this;
+    return { ...jobData, customer: { id: customerId } };
+  }
 }

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -14,10 +14,9 @@ export class JobsService {
   ) {}
 
   async create(createJobDto: CreateJobDto): Promise<JobResponseDto> {
-    const { customerId, ...jobData } = createJobDto;
     const job = this.jobRepository.create({
-      ...jobData,
-      customer: { id: customerId },
+      ...createJobDto,
+      customer: { id: createJobDto.customerId },
     });
     const savedJob = await this.jobRepository.save(job);
     return this.toJobResponseDto(savedJob);


### PR DESCRIPTION
## Summary
- map `customerId` onto the Job entity in `JobsService.create` using `jobRepository.create`
- add helper to `CreateJobDto` that removes `customerId` when producing an entity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e9f5fae08325a06c12e1203ef6e7