### PR TITLE
Use glob patterns for TypeORM paths

### DIFF
--- a/backend/data-source.ts
+++ b/backend/data-source.ts
@@ -10,8 +10,9 @@ export default new DataSource({
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,
+  // Discover entity files in both TS source and compiled JS output
   entities: [__dirname + '/**/*.entity{.ts,.js}'],
-  migrations: ['src/migrations/*.ts'],
+  migrations: [__dirname + '/**/migrations/*{.ts,.js}'],
   ssl: isProduction
     ? { rejectUnauthorized: false }
     : false


### PR DESCRIPTION
## Summary
- discover entity and migration files via glob patterns so TypeORM loads both TS and JS artifacts
- document entity discovery configuration

## Testing
- `npm run build`
- `npm test`
- `npm run migration:run` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e9f6ea60832586fddf045fb3a2a7