### PR TITLE
feat: add user registration

### DIFF
--- a/backend/src/users/__tests__/users.service.spec.ts
+++ b/backend/src/users/__tests__/users.service.spec.ts
@@ -1,0 +1,29 @@
+import * as bcrypt from 'bcrypt';
+import { UsersService } from '../users.service';
+import { UserRole } from '../user.entity';
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  beforeEach(() => {
+    const usersRepository = {
+      create: jest.fn((dto) => ({ ...dto, role: dto.role ?? UserRole.Customer })),
+      save: jest.fn((user) => Promise.resolve(user)),
+      findOne: jest.fn(),
+    };
+    service = new UsersService(usersRepository as any);
+  });
+
+  it('hashes passwords before saving', async () => {
+    const password = 'plainpassword';
+    const user = await service.create({ username: 'user1', password });
+    expect(user.password).not.toBe(password);
+    const isMatch = await bcrypt.compare(password, user.password);
+    expect(isMatch).toBe(true);
+  });
+
+  it('assigns default role when none provided', async () => {
+    const user = await service.create({ username: 'user2', password: 'secret' });
+    expect(user.role).toBe(UserRole.Customer);
+  });
+});

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -1,0 +1,14 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { UserRole } from '../user.entity';
+
+export class CreateUserDto {
+  @IsString()
+  username: string;
+
+  @IsString()
+  password: string;
+
+  @IsEnum(UserRole)
+  @IsOptional()
+  role?: UserRole;
+}

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,4 +1,5 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, BeforeInsert } from 'typeorm';
+import * as bcrypt from 'bcrypt';
 
 export enum UserRole {
   Admin = 'admin',
@@ -19,4 +20,11 @@ export class User {
 
   @Column({ type: 'enum', enum: UserRole, default: UserRole.Customer })
   role: UserRole;
+
+  @BeforeInsert()
+  async hashPassword(): Promise<void> {
+    if (!this.password.startsWith('$2')) {
+      this.password = await bcrypt.hash(this.password, 10);
+    }
+  }
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,0 +1,14 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { User } from './user.entity';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Post()
+  create(@Body() createUserDto: CreateUserDto): Promise<User> {
+    return this.usersService.create(createUserDto);
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
 import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
   providers: [UsersService],
+  controllers: [UsersController],
   exports: [UsersService],
 })
 export class UsersModule {}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+
 import { User } from './user.entity';
+import { CreateUserDto } from './dto/create-user.dto';
 
 @Injectable()
 export class UsersService {
@@ -12,5 +15,12 @@ export class UsersService {
 
   findByUsername(username: string): Promise<User | null> {
     return this.usersRepository.findOne({ where: { username } });
+  }
+
+  async create(createUserDto: CreateUserDto): Promise<User> {
+    const { password, ...rest } = createUserDto;
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const user = this.usersRepository.create({ ...rest, password: hashedPassword });
+    return this.usersRepository.save(user);
   }
 }


### PR DESCRIPTION
## Summary
- add DTO and controller for user registration
- hash passwords on creation and via entity hook
- test password hashing and default role assignment

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f458e12483259d7f8dac1c434edd