### PR TITLE
feat: enforce jwt secret configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=password
 DB_NAME=rflandscaperpro
+JWT_SECRET=your_jwt_secret
 LOG_LEVEL=debug
 ```
 
@@ -103,6 +104,7 @@ DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=your-supabase-db-password
 DB_NAME=postgres
+JWT_SECRET=your_jwt_secret
 LOG_LEVEL=info
 ```
 
@@ -115,8 +117,11 @@ DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=password
 DB_NAME=rflandscaperpro_test
+JWT_SECRET=your_jwt_secret
 LOG_LEVEL=error
 ```
+
+The `JWT_SECRET` variable is required for token signing in all environments. The application will throw an error if it is not set.
 
 4. **Start Development Server**
 ```bash

--- a/backend/env.example
+++ b/backend/env.example
@@ -16,6 +16,7 @@ DB_PASSWORD=your_password
 DB_NAME=rflandscaperpro
 
 # Authentication
+# JWT_SECRET is required; the application will not start without it
 JWT_SECRET=your_jwt_secret
 
 # Optional: Logging

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -13,10 +13,17 @@ import { JwtStrategy } from './jwt.strategy';
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (config: ConfigService) => ({
-        secret: config.get<string>('JWT_SECRET') || 'secret',
-        signOptions: { expiresIn: '1h' },
-      }),
+      useFactory: (config: ConfigService) => {
+        const secret = config.get<string>('JWT_SECRET');
+        if (!secret) {
+          throw new Error('JWT_SECRET is not defined');
+        }
+
+        return {
+          secret,
+          signOptions: { expiresIn: '1h' },
+        };
+      },
     }),
   ],
   providers: [AuthService, JwtStrategy],


### PR DESCRIPTION
## Summary
- enforce explicit JWT secret by throwing when undefined
- document JWT_SECRET as required in environment setup

## Testing
- `DB_HOST=localhost DB_PORT=5432 DB_USERNAME=postgres DB_PASSWORD=password DB_NAME=rflandscaperpro_test JWT_SECRET=test npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a521361900832580ded19d658e5a79