### PR TITLE
Restrict user creation to admins

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,12 +1,14 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { Roles } from '../common/decorators/roles.decorator';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
-import { User } from './user.entity';
+import { User, UserRole } from './user.entity';
 
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
+  @Roles(UserRole.Admin)
   @Post()
   create(@Body() createUserDto: CreateUserDto): Promise<User> {
     return this.usersService.create(createUserDto);

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { UserRole } from '../src/users/user.entity';
+
+describe('UsersController (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use((req, _res, next) => {
+      (req as any).user = { role: UserRole.Customer };
+      next();
+    });
+    await app.init();
+  });
+
+  it('POST /users returns 403 for non-admin', () => {
+    return request(app.getHttpServer())
+      .post('/users')
+      .send({ username: 'user', password: 'pass' })
+      .expect(403);
+  });
+});


### PR DESCRIPTION
## Summary
- secure the user creation endpoint by requiring `Admin` role
- add e2e coverage ensuring non-admin attempts return `403`

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Unable to connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_68a52137a8508325801c86a2d0bf90ac