### PR TITLE
Handle duplicate username on user creation

### DIFF
--- a/backend/src/users/__tests__/users.service.spec.ts
+++ b/backend/src/users/__tests__/users.service.spec.ts
@@ -4,6 +4,8 @@ import { QueryFailedError } from 'typeorm';
 import { UsersService } from '../users.service';
 import { UserRole } from '../user.entity';
 
+const UNIQUE_VIOLATION = '23505';
+
 describe('UsersService', () => {
   let service: UsersService;
   let usersRepository: {
@@ -35,7 +37,11 @@ describe('UsersService', () => {
   });
 
   it('throws conflict when username exists', async () => {
-    const error = new QueryFailedError('', [], { code: '23505' } as any);
+    const error = new QueryFailedError(
+      '',
+      [],
+      Object.assign(new Error(), { code: UNIQUE_VIOLATION }),
+    );
     usersRepository.save.mockRejectedValueOnce(error);
 
     await expect(

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -6,6 +6,8 @@ import * as bcrypt from 'bcrypt';
 import { User } from './user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 
+const UNIQUE_VIOLATION = '23505';
+
 @Injectable()
 export class UsersService {
   constructor(
@@ -25,11 +27,11 @@ export class UsersService {
     try {
       return await this.usersRepository.save(user);
     } catch (error) {
-      if (
-        error instanceof QueryFailedError &&
-        (error as any).driverError?.code === '23505'
-      ) {
-        throw new ConflictException('Username already exists');
+      if (error instanceof QueryFailedError) {
+        const { code } = error.driverError as { code?: string };
+        if (code === UNIQUE_VIOLATION) {
+          throw new ConflictException('Username already exists');
+        }
       }
       throw error;
     }


### PR DESCRIPTION
## Summary
- ensure UsersService.create throws ConflictException when saving duplicate username
- test duplicate username conflict behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5213e8bd88325b70c207559b20fd1