### PR TITLE
feat: add pagination to list endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,15 @@ DB_NAME=postgres
 - `PATCH /equipment/:id` - Update equipment
 - `DELETE /equipment/:id` - Delete equipment
 
+### Pagination
+
+All list endpoints support optional pagination parameters:
+
+- `page` (number, default `1`) – page number to retrieve
+- `limit` (number, default `10`) – number of items per page
+
+Responses are wrapped in an object containing the retrieved `items` array and the `total` number of available records.
+
 ### Request/Response Examples
 
 #### Create Customer

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -7,6 +7,8 @@ import {
   Body,
   Param,
   ParseIntPipe,
+  Query,
+  DefaultValuePipe,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -32,8 +34,11 @@ export class CustomersController {
 
   @Get()
   @Roles(UserRole.Admin, UserRole.Worker)
-  async findAll(): Promise<CustomerResponseDto[]> {
-    return this.customersService.findAll();
+  async findAll(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit = 10,
+  ): Promise<{ items: CustomerResponseDto[]; total: number }> {
+    return this.customersService.findAll(page, limit);
   }
 
   @Get(':id')

--- a/backend/src/customers/customers.service.ts
+++ b/backend/src/customers/customers.service.ts
@@ -40,9 +40,18 @@ export class CustomersService {
     }
   }
 
-  async findAll(): Promise<CustomerResponseDto[]> {
-    const customers = await this.customerRepository.find();
-    return customers.map((customer) => this.toCustomerResponseDto(customer));
+  async findAll(
+    page = 1,
+    limit = 10,
+  ): Promise<{ items: CustomerResponseDto[]; total: number }> {
+    const [customers, total] = await this.customerRepository.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return {
+      items: customers.map((customer) => this.toCustomerResponseDto(customer)),
+      total,
+    };
   }
 
   async findOne(id: number): Promise<CustomerResponseDto> {

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -7,6 +7,8 @@ import {
   Body,
   Param,
   ParseIntPipe,
+  Query,
+  DefaultValuePipe,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -31,8 +33,11 @@ export class EquipmentController {
 
   @Get()
   @Roles(UserRole.Admin, UserRole.Worker, UserRole.Customer)
-  async findAll(): Promise<EquipmentResponseDto[]> {
-    return this.equipmentService.findAll();
+  async findAll(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit = 10,
+  ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
+    return this.equipmentService.findAll(page, limit);
   }
 
   @Get(':id')

--- a/backend/src/equipment/equipment.service.ts
+++ b/backend/src/equipment/equipment.service.ts
@@ -21,9 +21,18 @@ export class EquipmentService {
     return this.toEquipmentResponseDto(savedEquipment);
   }
 
-  async findAll(): Promise<EquipmentResponseDto[]> {
-    const equipments = await this.equipmentRepository.find();
-    return equipments.map((eq) => this.toEquipmentResponseDto(eq));
+  async findAll(
+    page = 1,
+    limit = 10,
+  ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
+    const [equipments, total] = await this.equipmentRepository.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return {
+      items: equipments.map((eq) => this.toEquipmentResponseDto(eq)),
+      total,
+    };
   }
 
   async findOne(id: number): Promise<EquipmentResponseDto> {
@@ -55,9 +64,7 @@ export class EquipmentService {
     await this.equipmentRepository.remove(equipment);
   }
 
-  private toEquipmentResponseDto(
-    equipment: Equipment,
-  ): EquipmentResponseDto {
+  private toEquipmentResponseDto(equipment: Equipment): EquipmentResponseDto {
     return {
       id: equipment.id,
       name: equipment.name,

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -7,6 +7,8 @@ import {
   Param,
   Delete,
   ParseIntPipe,
+  Query,
+  DefaultValuePipe,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -30,8 +32,11 @@ export class JobsController {
 
   @Get()
   @Roles(UserRole.Admin, UserRole.Worker, UserRole.Customer)
-  findAll(): Promise<JobResponseDto[]> {
-    return this.jobsService.findAll();
+  findAll(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit = 10,
+  ): Promise<{ items: JobResponseDto[]; total: number }> {
+    return this.jobsService.findAll(page, limit);
   }
 
   @Get(':id')

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -33,12 +33,20 @@ export class JobsService {
     return this.toJobResponseDto(savedJob);
   }
 
-  async findAll(): Promise<JobResponseDto[]> {
-    const jobs = await this.jobRepository.find({
+  async findAll(
+    page = 1,
+    limit = 10,
+  ): Promise<{ items: JobResponseDto[]; total: number }> {
+    const [jobs, total] = await this.jobRepository.findAndCount({
       relations: ['customer'],
+      skip: (page - 1) * limit,
+      take: limit,
     });
 
-    return jobs.map((job) => this.toJobResponseDto(job));
+    return {
+      items: jobs.map((job) => this.toJobResponseDto(job)),
+      total,
+    };
   }
 
   async update(


### PR DESCRIPTION
## Summary
- add `page` and `limit` query params for customers, jobs, and equipment listings
- use TypeORM `findAndCount` with `skip`/`take` for pagination
- document pagination parameters in README

## Testing
- `npm run lint` *(fails: Unsafe member access and prettier errors in unrelated files)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a525bfce18832583e80acd98221033