### PR TITLE
feat: log requests with unique IDs

### DIFF
--- a/backend/src/common/interceptors/logging.interceptor.ts
+++ b/backend/src/common/interceptors/logging.interceptor.ts
@@ -1,0 +1,40 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  LoggerService,
+  NestInterceptor,
+} from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { Request, Response } from 'express';
+import { getRequestId } from '../middleware/request-id.middleware';
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const ctx = context.switchToHttp();
+    const request = ctx.getRequest<Request>();
+    const { method, url } = request;
+    const start = Date.now();
+
+    return next.handle().pipe(
+      finalize(() => {
+        const response = ctx.getResponse<Response>();
+        const { statusCode } = response;
+        const duration = Date.now() - start;
+        const requestId = getRequestId();
+        this.logger.log(
+          `HTTP ${method} ${url} ${statusCode} ${duration}ms - ${requestId}`,
+        );
+      }),
+    );
+  }
+}

--- a/backend/src/common/middleware/request-id.middleware.ts
+++ b/backend/src/common/middleware/request-id.middleware.ts
@@ -1,0 +1,26 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
+import { Request, Response, NextFunction } from 'express';
+
+interface RequestStore {
+  requestId: string;
+}
+
+export const requestIdStorage = new AsyncLocalStorage<RequestStore>();
+
+export function requestIdMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const requestId = randomUUID();
+  requestIdStorage.run({ requestId }, () => {
+    (req as any).requestId = requestId;
+    res.setHeader('X-Request-Id', requestId);
+    next();
+  });
+}
+
+export function getRequestId(): string | undefined {
+  return requestIdStorage.getStore()?.requestId;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -7,13 +7,17 @@ import {
   WinstonModule,
 } from 'nest-winston';
 import * as winston from 'winston';
+import { requestIdMiddleware } from './common/middleware/request-id.middleware';
+import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 
 async function bootstrap() {
   let app;
   try {
     app = await NestFactory.create(AppModule, { bufferLogs: true });
+    app.use(requestIdMiddleware);
     app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
     const logger = app.get(WINSTON_MODULE_NEST_PROVIDER);
+    app.useGlobalInterceptors(new LoggingInterceptor(logger));
     logger.log(
       `Starting backend in ${process.env.NODE_ENV || 'development'} mode`,
     );


### PR DESCRIPTION
## Summary
- add AsyncLocalStorage-powered request ID middleware
- log method, URL, status, duration, and request ID with a new interceptor
- register middleware and interceptor globally

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access and assignment errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a52ee03ad483259ced010e587cd9ab