### PR TITLE
feat: record http request metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ npm run start:prod
 
 ## 📊 Monitoring
 
-- The backend exposes Prometheus-formatted metrics at `/metrics` via the `@willsoto/nestjs-prometheus` package. A Prometheus server can scrape this endpoint for application monitoring and alerting.
+- The backend exposes Prometheus-formatted metrics at `/metrics` via the `@willsoto/nestjs-prometheus` package. A Prometheus server can scrape this endpoint for application monitoring and alerting. A built-in `http_request_duration_seconds` histogram provides latency metrics by HTTP method, path, and status code.
 
 ## 🤝 Contributing
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -59,7 +59,7 @@ $ npm run test:cov
 
 ## Monitoring
 
-The application exposes a Prometheus metrics endpoint at `/metrics` using the `@willsoto/nestjs-prometheus` package. Configure a Prometheus server to scrape this endpoint for runtime metrics.
+The application exposes a Prometheus metrics endpoint at `/metrics` using the `@willsoto/nestjs-prometheus` package. Configure a Prometheus server to scrape this endpoint for runtime metrics. A built-in `http_request_duration_seconds` histogram records request latency by method, path, and status code.
 
 ## Deployment
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,5 +1,8 @@
 import { Module, LoggerService } from '@nestjs/common';
-import { PrometheusModule } from '@willsoto/nestjs-prometheus';
+import {
+  PrometheusModule,
+  makeHistogramProvider,
+} from '@willsoto/nestjs-prometheus';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import * as Joi from 'joi';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -13,6 +16,7 @@ import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { LoggerModule } from './logger/logger.module';
+import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 
 @Module({
   imports: [
@@ -69,6 +73,12 @@ import { LoggerModule } from './logger/logger.module';
   ],
   controllers: [],
   providers: [
+    makeHistogramProvider({
+      name: 'http_request_duration_seconds',
+      help: 'HTTP request duration in seconds',
+      labelNames: ['method', 'path', 'status_code'],
+    }),
+    LoggingInterceptor,
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,

--- a/backend/src/common/interceptors/logging.interceptor.ts
+++ b/backend/src/common/interceptors/logging.interceptor.ts
@@ -7,6 +7,8 @@ import {
   NestInterceptor,
 } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { Histogram } from 'prom-client';
 import { Observable } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 import { Request, Response } from 'express';
@@ -17,6 +19,8 @@ export class LoggingInterceptor implements NestInterceptor {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService,
+    @InjectMetric('http_request_duration_seconds')
+    private readonly histogram: Histogram<string>,
   ) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
@@ -34,6 +38,9 @@ export class LoggingInterceptor implements NestInterceptor {
         this.logger.log(
           `HTTP ${method} ${url} ${statusCode} ${duration}ms - ${requestId}`,
         );
+        this.histogram
+          .labels(method, request.route?.path ?? url, statusCode.toString())
+          .observe(duration / 1000);
       }),
     );
   }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -17,7 +17,7 @@ async function bootstrap() {
     app.use(requestIdMiddleware);
     app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
     const logger = app.get(WINSTON_MODULE_NEST_PROVIDER);
-    app.useGlobalInterceptors(new LoggingInterceptor(logger));
+    app.useGlobalInterceptors(app.get(LoggingInterceptor));
     logger.log(
       `Starting backend in ${process.env.NODE_ENV || 'development'} mode`,
     );


### PR DESCRIPTION
## Summary
- track HTTP request duration with Prometheus histogram
- expose request latency metrics on /metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a539761d888325bab444f70cafdd95