### PR TITLE
Add TypeORM migration and seeding support

### DIFF
--- a/backend/data-source.ts
+++ b/backend/data-source.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import { DataSource } from 'typeorm';
+import { join } from 'path';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -10,10 +11,11 @@ export default new DataSource({
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,
-  // Discover entity files in both TS source and compiled JS output
-  entities: [__dirname + '/**/*.entity{.ts,.js}'],
-  migrations: [__dirname + '/**/migrations/*{.ts,.js}'],
+  entities: [join(__dirname, '**/*.entity{.ts,.js}')],
+  migrations: [join(__dirname, 'src/migrations/*{.ts,.js}')],
+  migrationsRun: true,
+  synchronize: false,
   ssl: isProduction
     ? { rejectUnauthorized: false }
-    : false
+    : false,
 });

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,8 @@
     "migration:create": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:create",
     "migration:generate": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:generate -d data-source.ts src/migrations",
     "migration:run": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:run -d data-source.ts",
-    "migration:revert": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:revert -d data-source.ts"
+    "migration:revert": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:revert -d data-source.ts",
+    "seed": "ts-node -r dotenv/config src/seed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -1,0 +1,51 @@
+import dataSource from '../data-source';
+import { User, UserRole } from './users/user.entity';
+import { Customer } from './customers/entities/customer.entity';
+
+async function seed() {
+  await dataSource.initialize();
+
+  const userRepo = dataSource.getRepository(User);
+  const customerRepo = dataSource.getRepository(Customer);
+
+  const adminExists = await userRepo.findOne({ where: { username: 'admin' } });
+  if (!adminExists) {
+    const admin = userRepo.create({
+      username: 'admin',
+      password: 'adminpass',
+      role: UserRole.Admin,
+    });
+    await userRepo.save(admin);
+  }
+
+  const customerExists = await customerRepo.findOne({
+    where: { email: 'customer@example.com' },
+  });
+  if (!customerExists) {
+    const customer = customerRepo.create({
+      name: 'John Doe',
+      email: 'customer@example.com',
+      phone: '555-1234',
+      addresses: [
+        {
+          street: '123 Main St',
+          city: 'Townsville',
+          state: 'CA',
+          zip: '12345',
+        },
+      ],
+    });
+    await customerRepo.save(customer);
+  }
+
+  await dataSource.destroy();
+}
+
+seed()
+  .then(() => {
+    console.log('Database seeded');
+  })
+  .catch((err) => {
+    console.error('Seeding failed', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- configure TypeORM data source to discover and run migrations
- expose npm scripts for migrations and seeding
- add seed script with sample admin user and customer

## Testing
- `npm test`
- `npx eslint "{src,apps,libs,test}/**/*.ts"` *(fails: Unsafe return of a value of type `any` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a61f6f584c8325bc80bcc18f00a324