### PR TITLE
feat(jobs): add assignments and scheduling

### DIFF
--- a/backend/src/jobs/dto/assign-job.dto.ts
+++ b/backend/src/jobs/dto/assign-job.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt } from 'class-validator';
+
+export class AssignJobDto {
+  @ApiProperty()
+  @Type(() => Number)
+  @IsInt()
+  userId: number;
+
+  @ApiProperty()
+  @Type(() => Number)
+  @IsInt()
+  equipmentId: number;
+}

--- a/backend/src/jobs/dto/job-response.dto.ts
+++ b/backend/src/jobs/dto/job-response.dto.ts
@@ -9,6 +9,29 @@ class JobCustomerDto {
   email: string;
 }
 
+class JobAssignmentUserDto {
+  @ApiProperty()
+  id: number;
+  @ApiProperty()
+  username: string;
+}
+
+class JobAssignmentEquipmentDto {
+  @ApiProperty()
+  id: number;
+  @ApiProperty()
+  name: string;
+}
+
+class JobAssignmentDto {
+  @ApiProperty()
+  id: number;
+  @ApiProperty({ type: JobAssignmentUserDto })
+  user: JobAssignmentUserDto;
+  @ApiProperty({ type: JobAssignmentEquipmentDto })
+  equipment: JobAssignmentEquipmentDto;
+}
+
 export class JobResponseDto {
   @ApiProperty()
   id: number;
@@ -22,6 +45,8 @@ export class JobResponseDto {
   completed: boolean;
   @ApiProperty({ type: JobCustomerDto })
   customer: JobCustomerDto;
+  @ApiProperty({ type: [JobAssignmentDto] })
+  assignments?: JobAssignmentDto[];
   @ApiProperty()
   createdAt: Date;
   @ApiProperty()

--- a/backend/src/jobs/dto/schedule-job.dto.ts
+++ b/backend/src/jobs/dto/schedule-job.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsDate } from 'class-validator';
+
+export class ScheduleJobDto {
+  @ApiProperty()
+  @Type(() => Date)
+  @IsDate()
+  scheduledDate: Date;
+}

--- a/backend/src/jobs/entities/assignment.entity.ts
+++ b/backend/src/jobs/entities/assignment.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { Job } from './job.entity';
+import { User } from '../../users/user.entity';
+import { Equipment } from '../../equipment/entities/equipment.entity';
+
+@Entity()
+export class Assignment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Job, (job) => job.assignments, { onDelete: 'CASCADE', eager: true })
+  job: Job;
+
+  @ManyToOne(() => User, { eager: true })
+  user: User;
+
+  @ManyToOne(() => Equipment, { eager: true })
+  equipment: Equipment;
+}

--- a/backend/src/jobs/entities/job.entity.ts
+++ b/backend/src/jobs/entities/job.entity.ts
@@ -3,10 +3,12 @@ import {
   PrimaryGeneratedColumn,
   Column,
   ManyToOne,
+  OneToMany,
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { Customer } from '../../customers/entities/customer.entity';
+import { Assignment } from './assignment.entity';
 
 @Entity()
 export class Job {
@@ -27,6 +29,9 @@ export class Job {
 
   @ManyToOne(() => Customer, (customer) => customer.jobs, { eager: true })
   customer: Customer;
+
+  @OneToMany(() => Assignment, (assignment) => assignment.job, { eager: true })
+  assignments: Assignment[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -19,6 +19,8 @@ import { UpdateJobDto } from './dto/update-job.dto';
 import { JobResponseDto } from './dto/job-response.dto';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../users/user.entity';
+import { ScheduleJobDto } from './dto/schedule-job.dto';
+import { AssignJobDto } from './dto/assign-job.dto';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -83,6 +85,36 @@ export class JobsController {
     @Body() updateJobDto: UpdateJobDto,
   ): Promise<JobResponseDto> {
     return this.jobsService.update(id, updateJobDto);
+  }
+
+  @Post(':id/schedule')
+  @Roles(UserRole.Admin, UserRole.Worker)
+  @ApiOperation({ summary: 'Schedule job' })
+  @ApiResponse({
+    status: 200,
+    description: 'Job scheduled',
+    type: JobResponseDto,
+  })
+  schedule(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() scheduleJobDto: ScheduleJobDto,
+  ): Promise<JobResponseDto> {
+    return this.jobsService.schedule(id, scheduleJobDto);
+  }
+
+  @Post(':id/assign')
+  @Roles(UserRole.Admin, UserRole.Worker)
+  @ApiOperation({ summary: 'Assign resources to job' })
+  @ApiResponse({
+    status: 200,
+    description: 'Job assignment added',
+    type: JobResponseDto,
+  })
+  assign(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() assignJobDto: AssignJobDto,
+  ): Promise<JobResponseDto> {
+    return this.jobsService.assign(id, assignJobDto);
   }
 
   @Delete(':id')

--- a/backend/src/jobs/jobs.module.ts
+++ b/backend/src/jobs/jobs.module.ts
@@ -5,9 +5,14 @@ import { JobsService } from './jobs.service';
 import { JobsController } from './jobs.controller';
 import { Job } from './entities/job.entity';
 import { Customer } from '../customers/entities/customer.entity';
+import { Assignment } from './entities/assignment.entity';
+import { User } from '../users/user.entity';
+import { Equipment } from '../equipment/entities/equipment.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Job, Customer])],
+  imports: [
+    TypeOrmModule.forFeature([Job, Customer, Assignment, User, Equipment]),
+  ],
   controllers: [JobsController],
   providers: [JobsService],
   exports: [JobsService],

--- a/backend/src/jobs/jobs.service.spec.ts
+++ b/backend/src/jobs/jobs.service.spec.ts
@@ -4,6 +4,9 @@ import { NotFoundException } from '@nestjs/common';
 import { JobsService } from './jobs.service';
 import { Job } from './entities/job.entity';
 import { Customer } from '../customers/entities/customer.entity';
+import { User } from '../users/user.entity';
+import { Equipment } from '../equipment/entities/equipment.entity';
+import { Assignment } from './entities/assignment.entity';
 
 describe('JobsService', () => {
   let service: JobsService;
@@ -13,10 +16,32 @@ describe('JobsService', () => {
     save: jest.Mock;
   };
   let customerRepository: { findOne: jest.Mock };
+  let userRepository: { findOne: jest.Mock };
+  let equipmentRepository: { findOne: jest.Mock };
+  let assignmentRepository: {
+    create: jest.Mock;
+    save: jest.Mock;
+    findOne: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
 
   beforeEach(async () => {
     jobRepository = { findOne: jest.fn(), create: jest.fn(), save: jest.fn() };
     customerRepository = { findOne: jest.fn() };
+    userRepository = { findOne: jest.fn() };
+    equipmentRepository = { findOne: jest.fn() };
+    assignmentRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        leftJoin: () => ({
+          where: () => ({
+            andWhere: () => ({ getOne: jest.fn() }),
+          }),
+        }),
+      }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -29,6 +54,9 @@ describe('JobsService', () => {
           provide: getRepositoryToken(Customer),
           useValue: customerRepository,
         },
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        { provide: getRepositoryToken(Equipment), useValue: equipmentRepository },
+        { provide: getRepositoryToken(Assignment), useValue: assignmentRepository },
       ],
     }).compile();
 

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Job } from './entities/job.entity';
@@ -6,6 +6,11 @@ import { Customer } from '../customers/entities/customer.entity';
 import { JobResponseDto } from './dto/job-response.dto';
 import { CreateJobDto } from './dto/create-job.dto';
 import { UpdateJobDto } from './dto/update-job.dto';
+import { User } from '../users/user.entity';
+import { Equipment } from '../equipment/entities/equipment.entity';
+import { Assignment } from './entities/assignment.entity';
+import { AssignJobDto } from './dto/assign-job.dto';
+import { ScheduleJobDto } from './dto/schedule-job.dto';
 
 @Injectable()
 export class JobsService {
@@ -14,6 +19,12 @@ export class JobsService {
     private readonly jobRepository: Repository<Job>,
     @InjectRepository(Customer)
     private readonly customerRepository: Repository<Customer>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(Equipment)
+    private readonly equipmentRepository: Repository<Equipment>,
+    @InjectRepository(Assignment)
+    private readonly assignmentRepository: Repository<Assignment>,
   ) {}
 
   async create(createJobDto: CreateJobDto): Promise<JobResponseDto> {
@@ -38,7 +49,7 @@ export class JobsService {
     limit = 10,
   ): Promise<{ items: JobResponseDto[]; total: number }> {
     const [jobs, total] = await this.jobRepository.findAndCount({
-      relations: ['customer'],
+      relations: ['customer', 'assignments', 'assignments.user', 'assignments.equipment'],
       skip: (page - 1) * limit,
       take: limit,
     });
@@ -55,7 +66,7 @@ export class JobsService {
   ): Promise<JobResponseDto> {
     const job = await this.jobRepository.findOne({
       where: { id },
-      relations: ['customer'],
+      relations: ['customer', 'assignments', 'assignments.user', 'assignments.equipment'],
     });
     if (!job) {
       throw new NotFoundException(`Job with ID ${id} not found.`);
@@ -80,7 +91,7 @@ export class JobsService {
   async findOne(id: number): Promise<JobResponseDto> {
     const job = await this.jobRepository.findOne({
       where: { id },
-      relations: ['customer'],
+      relations: ['customer', 'assignments', 'assignments.user', 'assignments.equipment'],
     });
 
     if (!job) {
@@ -110,8 +121,107 @@ export class JobsService {
         name: job.customer.name,
         email: job.customer.email,
       },
+      assignments: job.assignments?.map((assignment) => ({
+        id: assignment.id,
+        user: { id: assignment.user.id, username: assignment.user.username },
+        equipment: { id: assignment.equipment.id, name: assignment.equipment.name },
+      })),
       createdAt: job.createdAt,
       updatedAt: job.updatedAt,
     };
+  }
+
+  async schedule(
+    id: number,
+    scheduleJobDto: ScheduleJobDto,
+  ): Promise<JobResponseDto> {
+    const job = await this.jobRepository.findOne({
+      where: { id },
+      relations: ['customer', 'assignments', 'assignments.user', 'assignments.equipment'],
+    });
+    if (!job) {
+      throw new NotFoundException(`Job with ID ${id} not found.`);
+    }
+
+    for (const assignment of job.assignments || []) {
+      const conflict = await this.assignmentRepository
+        .createQueryBuilder('assignment')
+        .leftJoin('assignment.job', 'job')
+        .where('job.scheduledDate = :date', {
+          date: scheduleJobDto.scheduledDate,
+        })
+        .andWhere('job.id != :jobId', { jobId: id })
+        .andWhere(
+          '(assignment.userId = :userId OR assignment.equipmentId = :equipmentId)',
+          {
+            userId: assignment.user.id,
+            equipmentId: assignment.equipment.id,
+          },
+        )
+        .getOne();
+      if (conflict) {
+        throw new ConflictException(
+          'Resource conflict: assigned user or equipment is already booked on this date.',
+        );
+      }
+    }
+
+    job.scheduledDate = scheduleJobDto.scheduledDate;
+    const saved = await this.jobRepository.save(job);
+    return this.toJobResponseDto(saved);
+  }
+
+  async assign(id: number, dto: AssignJobDto): Promise<JobResponseDto> {
+    const job = await this.jobRepository.findOne({
+      where: { id },
+      relations: ['customer'],
+    });
+    if (!job) {
+      throw new NotFoundException(`Job with ID ${id} not found.`);
+    }
+
+    const user = await this.userRepository.findOne({ where: { id: dto.userId } });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${dto.userId} not found.`);
+    }
+
+    const equipment = await this.equipmentRepository.findOne({
+      where: { id: dto.equipmentId },
+    });
+    if (!equipment) {
+      throw new NotFoundException(
+        `Equipment with ID ${dto.equipmentId} not found.`,
+      );
+    }
+
+    if (job.scheduledDate) {
+      const conflict = await this.assignmentRepository
+        .createQueryBuilder('assignment')
+        .leftJoin('assignment.job', 'job')
+        .where('job.scheduledDate = :date', { date: job.scheduledDate })
+        .andWhere(
+          '(assignment.userId = :userId OR assignment.equipmentId = :equipmentId)',
+          { userId: dto.userId, equipmentId: dto.equipmentId },
+        )
+        .getOne();
+      if (conflict) {
+        throw new ConflictException(
+          'Resource conflict: user or equipment is already assigned on this date.',
+        );
+      }
+    }
+
+    const assignment = this.assignmentRepository.create({
+      job,
+      user,
+      equipment,
+    });
+    await this.assignmentRepository.save(assignment);
+
+    const updatedJob = await this.jobRepository.findOne({
+      where: { id },
+      relations: ['customer', 'assignments', 'assignments.user', 'assignments.equipment'],
+    });
+    return this.toJobResponseDto(updatedJob!);
   }
 }

--- a/backend/src/migrations/20250205000000-add-assignments-table.ts
+++ b/backend/src/migrations/20250205000000-add-assignments-table.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAssignmentsTable20250205000000 implements MigrationInterface {
+  name = 'AddAssignmentsTable20250205000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "assignment" ("id" SERIAL NOT NULL, "jobId" integer, "userId" integer, "equipmentId" integer, CONSTRAINT "PK_assignment_id" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "assignment" ADD CONSTRAINT "FK_assignment_job" FOREIGN KEY ("jobId") REFERENCES "job"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "assignment" ADD CONSTRAINT "FK_assignment_user" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "assignment" ADD CONSTRAINT "FK_assignment_equipment" FOREIGN KEY ("equipmentId") REFERENCES "equipment"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "assignment" DROP CONSTRAINT "FK_assignment_equipment"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "assignment" DROP CONSTRAINT "FK_assignment_user"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "assignment" DROP CONSTRAINT "FK_assignment_job"`,
+    );
+    await queryRunner.query(`DROP TABLE "assignment"`);
+  }
+}


### PR DESCRIPTION
## Summary
- add Assignment entity linking jobs, users, and equipment
- expose scheduling and assignment endpoints for jobs
- prevent resource conflicts when scheduling or assigning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a62368fd5c8325aecfef48d3ddb820