### PR TITLE
feat: add invoice and payment management

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { JobsModule } from './jobs/jobs.module';
 import { EquipmentModule } from './equipment/equipment.module';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { InvoicesModule } from './invoices/invoices.module';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
@@ -68,6 +69,7 @@ import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
     CustomersModule,
     JobsModule,
     EquipmentModule,
+    InvoicesModule,
     UsersModule,
     AuthModule,
   ],

--- a/backend/src/customers/entities/customer.entity.ts
+++ b/backend/src/customers/entities/customer.entity.ts
@@ -1,4 +1,6 @@
 import { Job } from '../../jobs/entities/job.entity';
+import { Invoice } from '../../invoices/entities/invoice.entity';
+import { Payment } from '../../payments/entities/payment.entity';
 import { Address } from './address.entity';
 
 import {
@@ -32,6 +34,12 @@ export class Customer {
 
   @OneToMany(() => Job, (job) => job.customer)
   jobs: Job[];
+
+  @OneToMany(() => Invoice, (invoice) => invoice.customer)
+  invoices: Invoice[];
+
+  @OneToMany(() => Payment, (payment) => payment.customer)
+  payments: Payment[];
 
   @OneToMany(() => Address, (address) => address.customer, {
   cascade: true,

--- a/backend/src/invoices/dto/create-invoice.dto.ts
+++ b/backend/src/invoices/dto/create-invoice.dto.ts
@@ -1,0 +1,35 @@
+import { IsNumber, IsOptional, IsDate } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateInvoiceDto {
+  @ApiProperty()
+  @Type(() => Number)
+  @IsNumber()
+  jobId: number;
+
+  @ApiProperty()
+  @Type(() => Number)
+  @IsNumber()
+  customerId: number;
+
+  @ApiProperty()
+  @Type(() => Number)
+  @IsNumber()
+  amount: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  dueDate?: Date;
+
+  toEntity() {
+    const { jobId, customerId, ...rest } = this;
+    return {
+      ...rest,
+      job: { id: jobId },
+      customer: { id: customerId },
+    };
+  }
+}

--- a/backend/src/invoices/dto/invoice-response.dto.ts
+++ b/backend/src/invoices/dto/invoice-response.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PaymentStatus } from '../../payments/entities/payment.entity';
+
+class InvoiceJobDto {
+  @ApiProperty()
+  id: number;
+  @ApiProperty()
+  title: string;
+}
+
+class InvoiceCustomerDto {
+  @ApiProperty()
+  id: number;
+  @ApiProperty()
+  name: string;
+  @ApiProperty()
+  email: string;
+}
+
+class InvoicePaymentDto {
+  @ApiProperty()
+  id: number;
+  @ApiProperty()
+  amount: number;
+  @ApiProperty({ enum: PaymentStatus })
+  status: PaymentStatus;
+  @ApiPropertyOptional()
+  paymentProcessor?: string;
+}
+
+export class InvoiceResponseDto {
+  @ApiProperty()
+  id: number;
+  @ApiProperty({ type: InvoiceJobDto })
+  job: InvoiceJobDto;
+  @ApiProperty({ type: InvoiceCustomerDto })
+  customer: InvoiceCustomerDto;
+  @ApiProperty()
+  amount: number;
+  @ApiPropertyOptional()
+  dueDate?: Date;
+  @ApiProperty({ type: [InvoicePaymentDto], required: false })
+  payments?: InvoicePaymentDto[];
+  @ApiProperty()
+  createdAt: Date;
+  @ApiProperty()
+  updatedAt: Date;
+}

--- a/backend/src/invoices/dto/update-invoice.dto.ts
+++ b/backend/src/invoices/dto/update-invoice.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateInvoiceDto } from './create-invoice.dto';
+
+export class UpdateInvoiceDto extends PartialType(CreateInvoiceDto) {}

--- a/backend/src/invoices/entities/invoice.entity.ts
+++ b/backend/src/invoices/entities/invoice.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Job } from '../../jobs/entities/job.entity';
+import { Customer } from '../../customers/entities/customer.entity';
+import { Payment } from '../../payments/entities/payment.entity';
+
+@Entity()
+export class Invoice {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Job, (job) => job.invoices, { eager: true })
+  job: Job;
+
+  @ManyToOne(() => Customer, (customer) => customer.invoices, { eager: true })
+  customer: Customer;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  amount: number;
+
+  @Column({ type: 'date', nullable: true })
+  dueDate?: Date;
+
+  @OneToMany(() => Payment, (payment) => payment.invoice, {
+    cascade: true,
+  })
+  payments: Payment[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/invoices/invoices.controller.spec.ts
+++ b/backend/src/invoices/invoices.controller.spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InvoicesController } from './invoices.controller';
+import { InvoicesService } from './invoices.service';
+
+describe('InvoicesController', () => {
+  let controller: InvoicesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InvoicesController],
+      providers: [
+        {
+          provide: InvoicesService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    controller = module.get<InvoicesController>(InvoicesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/invoices/invoices.controller.ts
+++ b/backend/src/invoices/invoices.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  ParseIntPipe,
+  Query,
+  DefaultValuePipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { InvoicesService } from './invoices.service';
+import { CreateInvoiceDto } from './dto/create-invoice.dto';
+import { UpdateInvoiceDto } from './dto/update-invoice.dto';
+import { InvoiceResponseDto } from './dto/invoice-response.dto';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '../users/user.entity';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+
+@ApiTags('invoices')
+@ApiBearerAuth()
+@Controller('invoices')
+export class InvoicesController {
+  constructor(private readonly invoicesService: InvoicesService) {}
+
+  @Post()
+  @Roles(UserRole.Admin)
+  @ApiOperation({ summary: 'Create invoice' })
+  @ApiResponse({ status: 201, description: 'Invoice created', type: InvoiceResponseDto })
+  async create(
+    @Body() createInvoiceDto: CreateInvoiceDto,
+  ): Promise<InvoiceResponseDto> {
+    return this.invoicesService.create(createInvoiceDto);
+  }
+
+  @Get()
+  @Roles(UserRole.Admin, UserRole.Worker)
+  @ApiOperation({ summary: 'List invoices' })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  @ApiResponse({ status: 200, description: 'List of invoices' })
+  async findAll(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit = 10,
+  ): Promise<{ items: InvoiceResponseDto[]; total: number }> {
+    return this.invoicesService.findAll(page, limit);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.Admin, UserRole.Worker)
+  @ApiOperation({ summary: 'Get invoice by id' })
+  @ApiResponse({ status: 200, description: 'Invoice retrieved', type: InvoiceResponseDto })
+  async findOne(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<InvoiceResponseDto> {
+    return this.invoicesService.findOne(id);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.Admin)
+  @ApiOperation({ summary: 'Update invoice' })
+  @ApiResponse({ status: 200, description: 'Invoice updated', type: InvoiceResponseDto })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateInvoiceDto: UpdateInvoiceDto,
+  ): Promise<InvoiceResponseDto> {
+    return this.invoicesService.update(id, updateInvoiceDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Roles(UserRole.Admin)
+  @ApiOperation({ summary: 'Delete invoice' })
+  @ApiResponse({ status: 204, description: 'Invoice deleted' })
+  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    await this.invoicesService.remove(id);
+  }
+}

--- a/backend/src/invoices/invoices.module.ts
+++ b/backend/src/invoices/invoices.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Invoice } from './entities/invoice.entity';
+import { Job } from '../jobs/entities/job.entity';
+import { Customer } from '../customers/entities/customer.entity';
+import { Payment } from '../payments/entities/payment.entity';
+import { InvoicesService } from './invoices.service';
+import { InvoicesController } from './invoices.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Invoice, Job, Customer, Payment])],
+  controllers: [InvoicesController],
+  providers: [InvoicesService],
+})
+export class InvoicesModule {}

--- a/backend/src/invoices/invoices.service.spec.ts
+++ b/backend/src/invoices/invoices.service.spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { InvoicesService } from './invoices.service';
+import { Invoice } from './entities/invoice.entity';
+import { Job } from '../jobs/entities/job.entity';
+import { Customer } from '../customers/entities/customer.entity';
+
+describe('InvoicesService', () => {
+  let service: InvoicesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InvoicesService,
+        { provide: getRepositoryToken(Invoice), useValue: {} },
+        { provide: getRepositoryToken(Job), useValue: {} },
+        { provide: getRepositoryToken(Customer), useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<InvoicesService>(InvoicesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/invoices/invoices.service.ts
+++ b/backend/src/invoices/invoices.service.ts
@@ -1,0 +1,141 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Invoice } from './entities/invoice.entity';
+import { Job } from '../jobs/entities/job.entity';
+import { Customer } from '../customers/entities/customer.entity';
+import { CreateInvoiceDto } from './dto/create-invoice.dto';
+import { UpdateInvoiceDto } from './dto/update-invoice.dto';
+import { InvoiceResponseDto } from './dto/invoice-response.dto';
+
+@Injectable()
+export class InvoicesService {
+  constructor(
+    @InjectRepository(Invoice)
+    private readonly invoiceRepository: Repository<Invoice>,
+    @InjectRepository(Job)
+    private readonly jobRepository: Repository<Job>,
+    @InjectRepository(Customer)
+    private readonly customerRepository: Repository<Customer>,
+  ) {}
+
+  async create(
+    createInvoiceDto: CreateInvoiceDto,
+  ): Promise<InvoiceResponseDto> {
+    const job = await this.jobRepository.findOne({
+      where: { id: createInvoiceDto.jobId },
+    });
+    if (!job) {
+      throw new NotFoundException(
+        `Job with ID ${createInvoiceDto.jobId} not found.`,
+      );
+    }
+    const customer = await this.customerRepository.findOne({
+      where: { id: createInvoiceDto.customerId },
+    });
+    if (!customer) {
+      throw new NotFoundException(
+        `Customer with ID ${createInvoiceDto.customerId} not found.`,
+      );
+    }
+    const invoice = this.invoiceRepository.create({
+      ...createInvoiceDto,
+      job,
+      customer,
+    });
+    const saved = await this.invoiceRepository.save(invoice);
+    return this.toInvoiceResponseDto(saved);
+  }
+
+  async findAll(
+    page = 1,
+    limit = 10,
+  ): Promise<{ items: InvoiceResponseDto[]; total: number }> {
+    const [invoices, total] = await this.invoiceRepository.findAndCount({
+      relations: ['job', 'customer', 'payments'],
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return {
+      items: invoices.map((inv) => this.toInvoiceResponseDto(inv)),
+      total,
+    };
+  }
+
+  async findOne(id: number): Promise<InvoiceResponseDto> {
+    const invoice = await this.invoiceRepository.findOne({
+      where: { id },
+      relations: ['job', 'customer', 'payments'],
+    });
+    if (!invoice) {
+      throw new NotFoundException(`Invoice with ID ${id} not found.`);
+    }
+    return this.toInvoiceResponseDto(invoice);
+  }
+
+  async update(
+    id: number,
+    updateInvoiceDto: UpdateInvoiceDto,
+  ): Promise<InvoiceResponseDto> {
+    const invoice = await this.invoiceRepository.findOne({
+      where: { id },
+      relations: ['job', 'customer', 'payments'],
+    });
+    if (!invoice) {
+      throw new NotFoundException(`Invoice with ID ${id} not found.`);
+    }
+    const { jobId, customerId, ...data } = updateInvoiceDto as any;
+    if (jobId !== undefined) {
+      const job = await this.jobRepository.findOne({ where: { id: jobId } });
+      if (!job) {
+        throw new NotFoundException(`Job with ID ${jobId} not found.`);
+      }
+      invoice.job = job;
+    }
+    if (customerId !== undefined) {
+      const customer = await this.customerRepository.findOne({
+        where: { id: customerId },
+      });
+      if (!customer) {
+        throw new NotFoundException(`Customer with ID ${customerId} not found.`);
+      }
+      invoice.customer = customer;
+    }
+    Object.assign(invoice, data);
+    const updated = await this.invoiceRepository.save(invoice);
+    return this.toInvoiceResponseDto(updated);
+  }
+
+  async remove(id: number): Promise<void> {
+    const invoice = await this.invoiceRepository.findOne({ where: { id } });
+    if (!invoice) {
+      throw new NotFoundException(`Invoice with ID ${id} not found.`);
+    }
+    await this.invoiceRepository.remove(invoice);
+  }
+
+  private toInvoiceResponseDto(invoice: Invoice): InvoiceResponseDto {
+    return {
+      id: invoice.id,
+      job: {
+        id: invoice.job.id,
+        title: invoice.job.title,
+      },
+      customer: {
+        id: invoice.customer.id,
+        name: invoice.customer.name,
+        email: invoice.customer.email,
+      },
+      amount: Number(invoice.amount),
+      dueDate: invoice.dueDate,
+      payments: invoice.payments?.map((p) => ({
+        id: p.id,
+        amount: Number(p.amount),
+        status: p.status,
+        paymentProcessor: p.paymentProcessor,
+      })),
+      createdAt: invoice.createdAt,
+      updatedAt: invoice.updatedAt,
+    };
+  }
+}

--- a/backend/src/jobs/entities/job.entity.ts
+++ b/backend/src/jobs/entities/job.entity.ts
@@ -5,8 +5,11 @@ import {
   ManyToOne,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany,
 } from 'typeorm';
 import { Customer } from '../../customers/entities/customer.entity';
+import { Invoice } from '../../invoices/entities/invoice.entity';
+import { Payment } from '../../payments/entities/payment.entity';
 
 @Entity()
 export class Job {
@@ -27,6 +30,12 @@ export class Job {
 
   @ManyToOne(() => Customer, (customer) => customer.jobs, { eager: true })
   customer: Customer;
+
+  @OneToMany(() => Invoice, (invoice) => invoice.job)
+  invoices: Invoice[];
+
+  @OneToMany(() => Payment, (payment) => payment.job)
+  payments: Payment[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/payments/entities/payment.entity.ts
+++ b/backend/src/payments/entities/payment.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Invoice } from '../../invoices/entities/invoice.entity';
+import { Job } from '../../jobs/entities/job.entity';
+import { Customer } from '../../customers/entities/customer.entity';
+
+export enum PaymentStatus {
+  Pending = 'pending',
+  Completed = 'completed',
+  Failed = 'failed',
+}
+
+@Entity()
+export class Payment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Invoice, (invoice) => invoice.payments, { eager: true })
+  invoice: Invoice;
+
+  @ManyToOne(() => Job, (job) => job.payments, { eager: true })
+  job: Job;
+
+  @ManyToOne(() => Customer, (customer) => customer.payments, { eager: true })
+  customer: Customer;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  amount: number;
+
+  @Column({ type: 'enum', enum: PaymentStatus, default: PaymentStatus.Pending })
+  status: PaymentStatus;
+
+  @Column({ nullable: true })
+  paymentProcessor?: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Summary
- add invoices and payments entities linked to jobs and customers
- expose CRUD APIs and DTOs for invoices
- track payment status and processor metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a624d307ac8325b14ef4b4544e6fb5