### PR TITLE
feat: add job reminders

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^11.0.0",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^5.0.0",
         "@nestjs/swagger": "^11.2.0",
         "@nestjs/typeorm": "^11.0.0",
         "@willsoto/nestjs-prometheus": "^6.0.2",
@@ -26,6 +27,7 @@
         "express-basic-auth": "^1.2.1",
         "joi": "^17.13.3",
         "nest-winston": "^1.10.2",
+        "nodemailer": "^6.9.8",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.16.3",
@@ -2746,6 +2748,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-5.0.1.tgz",
+      "integrity": "sha512-kFoel84I4RyS2LNPH6yHYTKxB16tb3auAEciFuc788C3ph6nABkUfzX5IE+unjVaRX+3GuruJwurNepMlHXpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "3.5.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.5.tgz",
@@ -3677,6 +3692,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -5959,6 +5980,16 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.5.0.tgz",
+      "integrity": "sha512-0eYZqCnapmxYcV06uktql93wNWdlTmmBFP2iYz+JPVcQqlyFYcn1lFuIk4R54pkOmE7mcldTAPZv6X5XA4Q46A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.5.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -9326,6 +9357,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -9765,6 +9805,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/typeorm": "^11.0.0",
+    "@nestjs/schedule": "^5.0.0",
     "@willsoto/nestjs-prometheus": "^6.0.2",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
@@ -50,7 +51,8 @@
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.25",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "nodemailer": "^6.9.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module, LoggerService } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import {
   PrometheusModule,
   makeHistogramProvider,
@@ -22,6 +23,7 @@ import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
   imports: [
     PrometheusModule.register(),
     LoggerModule,
+    ScheduleModule.forRoot(),
     ConfigModule.forRoot({
       envFilePath: `.env.${process.env.NODE_ENV}`,
       isGlobal: true,

--- a/backend/src/common/notification.service.ts
+++ b/backend/src/common/notification.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+import { Job } from '../jobs/entities/job.entity';
+
+@Injectable()
+export class NotificationService {
+  private readonly logger = new Logger(NotificationService.name);
+  private readonly transporter: nodemailer.Transporter;
+
+  constructor() {
+    this.transporter = nodemailer.createTransport({
+      // For development/testing, output emails to console as JSON
+      jsonTransport: true,
+    });
+  }
+
+  async sendEmail(to: string, subject: string, text: string): Promise<void> {
+    try {
+      await this.transporter.sendMail({
+        from: 'no-reply@example.com',
+        to,
+        subject,
+        text,
+      });
+      this.logger.log(`Email sent to ${to}`);
+    } catch (err) {
+      this.logger.error(`Failed to send email to ${to}`, err as Error);
+    }
+  }
+
+  async sendJobReminder(job: Job): Promise<void> {
+    const customer = job.customer;
+    if (!customer) {
+      this.logger.warn(`Job ${job.id} has no customer for notification`);
+      return;
+    }
+    const message = `Reminder: Job "${job.title}" scheduled for ${job.scheduledDate}`;
+    switch (customer.notificationPreference) {
+      case 'email':
+        if (customer.email) {
+          await this.sendEmail(customer.email, 'Job Reminder', message);
+        }
+        break;
+      case 'sms':
+        if (customer.phone) {
+          // Placeholder for SMS provider integration
+          this.logger.log(`SMS to ${customer.phone}: ${message}`);
+        }
+        break;
+      default:
+        this.logger.log(`No notifications sent for customer ${customer.id}`);
+    }
+  }
+}

--- a/backend/src/customers/customers.service.ts
+++ b/backend/src/customers/customers.service.ts
@@ -88,6 +88,7 @@ export class CustomersService {
       id: customer.id,
       name: customer.name,
       email: customer.email,
+      notificationPreference: customer.notificationPreference,
       createdAt: customer.createdAt,
       updatedAt: customer.updatedAt,
       jobs: customer.jobs?.map((job) => ({

--- a/backend/src/customers/dto/create-customer.dto.ts
+++ b/backend/src/customers/dto/create-customer.dto.ts
@@ -1,4 +1,10 @@
-import { IsString, IsEmail, ValidateNested, IsArray } from 'class-validator';
+import {
+  IsString,
+  IsEmail,
+  ValidateNested,
+  IsArray,
+  IsEnum,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -34,4 +40,8 @@ export class CreateCustomerDto {
   @ValidateNested({ each: true })
   @Type(() => CreateAddressDto)
   addresses: CreateAddressDto[];
+
+  @ApiProperty({ enum: ['email', 'sms', 'none'], default: 'email' })
+  @IsEnum(['email', 'sms', 'none'])
+  notificationPreference?: 'email' | 'sms' | 'none';
 }

--- a/backend/src/customers/dto/customer-response.dto.ts
+++ b/backend/src/customers/dto/customer-response.dto.ts
@@ -23,6 +23,8 @@ export class CustomerResponseDto {
   email: string;
   @ApiProperty({ type: [AddressResponseDto] })
   addresses: AddressResponseDto[];
+  @ApiProperty()
+  notificationPreference: 'email' | 'sms' | 'none';
   @ApiPropertyOptional({ type: [JobResponseDto] })
   jobs?: Partial<JobResponseDto>[];
   @ApiProperty()

--- a/backend/src/customers/entities/customer.entity.ts
+++ b/backend/src/customers/entities/customer.entity.ts
@@ -24,6 +24,9 @@ export class Customer {
   @Column({ nullable: true })
   phone?: string;
 
+  @Column({ default: 'email' })
+  notificationPreference: 'email' | 'sms' | 'none';
+
   @CreateDateColumn()
   createdAt: Date;
 
@@ -34,9 +37,8 @@ export class Customer {
   jobs: Job[];
 
   @OneToMany(() => Address, (address) => address.customer, {
-  cascade: true,
-  eager: true,
+    cascade: true,
+    eager: true,
   })
   addresses: Address[];
-
 }

--- a/backend/src/jobs/jobs.module.ts
+++ b/backend/src/jobs/jobs.module.ts
@@ -1,15 +1,17 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 
 import { JobsService } from './jobs.service';
 import { JobsController } from './jobs.controller';
 import { Job } from './entities/job.entity';
 import { Customer } from '../customers/entities/customer.entity';
+import { NotificationService } from '../common/notification.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Job, Customer])],
+  imports: [TypeOrmModule.forFeature([Job, Customer]), ScheduleModule],
   controllers: [JobsController],
-  providers: [JobsService],
+  providers: [JobsService, NotificationService],
   exports: [JobsService],
 })
 export class JobsModule {}

--- a/backend/src/jobs/jobs.service.spec.ts
+++ b/backend/src/jobs/jobs.service.spec.ts
@@ -1,9 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { NotFoundException } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import { JobsService } from './jobs.service';
 import { Job } from './entities/job.entity';
 import { Customer } from '../customers/entities/customer.entity';
+import { NotificationService } from '../common/notification.service';
 
 describe('JobsService', () => {
   let service: JobsService;
@@ -13,10 +15,22 @@ describe('JobsService', () => {
     save: jest.Mock;
   };
   let customerRepository: { findOne: jest.Mock };
+  let schedulerRegistry: {
+    doesExist: jest.Mock;
+    deleteTimeout: jest.Mock;
+    addTimeout: jest.Mock;
+  };
+  let notificationService: { sendJobReminder: jest.Mock };
 
   beforeEach(async () => {
     jobRepository = { findOne: jest.fn(), create: jest.fn(), save: jest.fn() };
     customerRepository = { findOne: jest.fn() };
+    schedulerRegistry = {
+      doesExist: jest.fn().mockReturnValue(false),
+      deleteTimeout: jest.fn(),
+      addTimeout: jest.fn(),
+    };
+    notificationService = { sendJobReminder: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -29,6 +43,8 @@ describe('JobsService', () => {
           provide: getRepositoryToken(Customer),
           useValue: customerRepository,
         },
+        { provide: SchedulerRegistry, useValue: schedulerRegistry },
+        { provide: NotificationService, useValue: notificationService },
       ],
     }).compile();
 

--- a/backend/src/migrations/20251201000000-add-notification-preference-to-customer.ts
+++ b/backend/src/migrations/20251201000000-add-notification-preference-to-customer.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNotificationPreferenceToCustomer20251201000000
+  implements MigrationInterface
+{
+  name = 'AddNotificationPreferenceToCustomer20251201000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "customer" ADD "notificationPreference" character varying NOT NULL DEFAULT 'email'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "customer" DROP COLUMN "notificationPreference"`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add notification service backed by nodemailer
- schedule job reminder emails when jobs are created or updated
- store customer notification preferences with migration support

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Unsafe member access .listen on an `any` value, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a624d57a2c8325b10c18fb441bf3e0