### PR TITLE
feat: add job image uploads

### DIFF
--- a/backend/src/jobs/entities/job-image.entity.ts
+++ b/backend/src/jobs/entities/job-image.entity.ts
@@ -1,0 +1,35 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+} from 'typeorm';
+import { Job } from './job.entity';
+
+@Entity()
+export class JobImage {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  filename: string;
+
+  @Column()
+  originalName: string;
+
+  @Column()
+  mimeType: string;
+
+  @Column()
+  size: number;
+
+  @Column()
+  path: string;
+
+  @ManyToOne(() => Job, (job) => job.images, { onDelete: 'CASCADE' })
+  job: Job;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/jobs/entities/job.entity.ts
+++ b/backend/src/jobs/entities/job.entity.ts
@@ -3,10 +3,12 @@ import {
   PrimaryGeneratedColumn,
   Column,
   ManyToOne,
+  OneToMany,
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { Customer } from '../../customers/entities/customer.entity';
+import { JobImage } from './job-image.entity';
 
 @Entity()
 export class Job {
@@ -27,6 +29,9 @@ export class Job {
 
   @ManyToOne(() => Customer, (customer) => customer.jobs, { eager: true })
   customer: Customer;
+
+  @OneToMany(() => JobImage, (image) => image.job, { cascade: true })
+  images: JobImage[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/jobs/jobs.controller.spec.ts
+++ b/backend/src/jobs/jobs.controller.spec.ts
@@ -1,12 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
+import { MulterModule } from '@nestjs/platform-express';
 
 describe('JobsController', () => {
   let controller: JobsController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [MulterModule.register({})],
       controllers: [JobsController],
       providers: [
         {

--- a/backend/src/jobs/jobs.module.ts
+++ b/backend/src/jobs/jobs.module.ts
@@ -1,13 +1,18 @@
 import { Module } from '@nestjs/common';
+import { MulterModule } from '@nestjs/platform-express';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { JobsService } from './jobs.service';
 import { JobsController } from './jobs.controller';
 import { Job } from './entities/job.entity';
 import { Customer } from '../customers/entities/customer.entity';
+import { JobImage } from './entities/job-image.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Job, Customer])],
+  imports: [
+    MulterModule.register({ dest: './uploads' }),
+    TypeOrmModule.forFeature([Job, Customer, JobImage]),
+  ],
   controllers: [JobsController],
   providers: [JobsService],
   exports: [JobsService],

--- a/backend/src/jobs/jobs.service.spec.ts
+++ b/backend/src/jobs/jobs.service.spec.ts
@@ -4,6 +4,7 @@ import { NotFoundException } from '@nestjs/common';
 import { JobsService } from './jobs.service';
 import { Job } from './entities/job.entity';
 import { Customer } from '../customers/entities/customer.entity';
+import { JobImage } from './entities/job-image.entity';
 
 describe('JobsService', () => {
   let service: JobsService;
@@ -13,10 +14,20 @@ describe('JobsService', () => {
     save: jest.Mock;
   };
   let customerRepository: { findOne: jest.Mock };
+  let imageRepository: {
+    findOne: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+  };
 
   beforeEach(async () => {
     jobRepository = { findOne: jest.fn(), create: jest.fn(), save: jest.fn() };
     customerRepository = { findOne: jest.fn() };
+    imageRepository = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -28,6 +39,10 @@ describe('JobsService', () => {
         {
           provide: getRepositoryToken(Customer),
           useValue: customerRepository,
+        },
+        {
+          provide: getRepositoryToken(JobImage),
+          useValue: imageRepository,
         },
       ],
     }).compile();


### PR DESCRIPTION
## Summary
- allow uploading and serving job images via Multer
- persist job image metadata in new JobImage entity
- expose controller endpoints for upload and retrieval

## Testing
- `npm test`
- `npm run lint` *(fails: invalid type or unsafe access warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a6251e0b7883259f77c733dabd6512