### PR TITLE
refactor: hash user password via entity hook

### DIFF
--- a/backend/src/users/__tests__/users.service.spec.ts
+++ b/backend/src/users/__tests__/users.service.spec.ts
@@ -1,38 +1,54 @@
 import * as bcrypt from 'bcrypt';
-import { QueryFailedError } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 
 import { UsersService } from '../users.service';
-import { UserRole } from '../user.entity';
+import { User, UserRole } from '../user.entity';
 
 const UNIQUE_VIOLATION = '23505';
 
 describe('UsersService', () => {
   let service: UsersService;
-  let usersRepository: {
-    create: jest.Mock;
-    save: jest.Mock;
-    findOne: jest.Mock;
-  };
+  let usersRepository: jest.Mocked<
+    Pick<Repository<User>, 'create' | 'save' | 'findOne'>
+  >;
 
   beforeEach(() => {
     usersRepository = {
-      create: jest.fn((dto) => ({ ...dto, role: dto.role ?? UserRole.Customer })),
-      save: jest.fn((user) => Promise.resolve(user)),
+      create: jest.fn(
+        (dto) =>
+          Object.assign(new User(), {
+            role: UserRole.Customer,
+            ...dto,
+          }) as User,
+      ),
+      save: jest.fn(async (user: User) => {
+        await user.hashPassword();
+        return user;
+      }),
       findOne: jest.fn(),
-    };
-    service = new UsersService(usersRepository as any);
+    } as unknown as jest.Mocked<
+      Pick<Repository<User>, 'create' | 'save' | 'findOne'>
+    >;
+    service = new UsersService(usersRepository as unknown as Repository<User>);
   });
 
   it('hashes passwords before saving', async () => {
     const password = 'plainpassword';
     const user = await service.create({ username: 'user1', password });
+    expect(usersRepository.create).toHaveBeenCalledWith({
+      username: 'user1',
+      password,
+    });
     expect(user.password).not.toBe(password);
     const isMatch = await bcrypt.compare(password, user.password);
     expect(isMatch).toBe(true);
   });
 
   it('assigns default role when none provided', async () => {
-    const user = await service.create({ username: 'user2', password: 'secret' });
+    const user = await service.create({
+      username: 'user2',
+      password: 'secret',
+    });
     expect(user.role).toBe(UserRole.Customer);
   });
 
@@ -46,6 +62,9 @@ describe('UsersService', () => {
 
     await expect(
       service.create({ username: 'existing', password: 'secret' }),
-    ).rejects.toMatchObject({ message: 'Username already exists', status: 409 });
+    ).rejects.toMatchObject({
+      message: 'Username already exists',
+      status: 409,
+    });
   });
 });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,7 +1,6 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { QueryFailedError, Repository } from 'typeorm';
-import * as bcrypt from 'bcrypt';
 
 import { User } from './user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -20,9 +19,7 @@ export class UsersService {
   }
 
   async create(createUserDto: CreateUserDto): Promise<User> {
-    const { password, ...rest } = createUserDto;
-    const hashedPassword = await bcrypt.hash(password, 10);
-    const user = this.usersRepository.create({ ...rest, password: hashedPassword });
+    const user = this.usersRepository.create(createUserDto);
 
     try {
       return await this.usersRepository.save(user);

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
+import { Request, Response, NextFunction } from 'express';
 import { AppModule } from './../src/app.module';
 import { UserRole } from '../src/users/user.entity';
 
@@ -14,10 +15,16 @@ describe('UsersController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
-    app.use((req, _res, next) => {
-      (req as any).user = { role: UserRole.Customer };
-      next();
-    });
+    app.use(
+      (
+        req: Request & { user?: unknown },
+        _res: Response,
+        next: NextFunction,
+      ) => {
+        req.user = { role: UserRole.Customer };
+        next();
+      },
+    );
     await app.init();
   });
 


### PR DESCRIPTION
## Summary
- remove bcrypt hashing from user service to rely on entity hook
- align UsersService unit tests with entity-driven hashing
- type Users e2e test middleware

## Testing
- `npm run lint` *(fails: Unsafe member access/call errors across project)*
- `npm test src/users`


------
https://chatgpt.com/codex/tasks/task_e_68a62ab4d6d08325a997c0cddd8dc0f4