### PR TITLE
refactor: centralize postgres unique violation code

### DIFF
--- a/backend/src/common/constants/postgres-error-codes.ts
+++ b/backend/src/common/constants/postgres-error-codes.ts
@@ -1,0 +1,14 @@
+import { QueryFailedError } from 'typeorm';
+
+export const UNIQUE_VIOLATION = '23505';
+
+export function isUniqueViolation(
+  error: unknown,
+  code: string = UNIQUE_VIOLATION,
+): boolean {
+  return (
+    error instanceof QueryFailedError &&
+    (error as QueryFailedError & { driverError?: { code?: string } })
+      .driverError?.code === code
+  );
+}


### PR DESCRIPTION
## Summary
- add shared Postgres error codes with helper for unique violation
- use centralized unique violation check in users and customers services

## Testing
- `npm test`
- `npm run lint` *(fails: multiple unsafe access warnings and errors)*


------
https://chatgpt.com/codex/tasks/task_e_68a62abc646c832585abf47dd1985cb8