### PR TITLE
refactor: build jobs without DTO entity conversion

### DIFF
--- a/backend/src/jobs/dto/create-job.dto.ts
+++ b/backend/src/jobs/dto/create-job.dto.ts
@@ -33,9 +33,4 @@ export class CreateJobDto {
   @Type(() => Number)
   @IsNumber()
   customerId: number;
-
-  toEntity() {
-    const { customerId, ...jobData } = this;
-    return { ...jobData, customer: { id: customerId } };
-  }
 }

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -28,16 +28,17 @@ export class JobsService {
   ) {}
 
   async create(createJobDto: CreateJobDto): Promise<JobResponseDto> {
+    const { customerId, ...jobData } = createJobDto;
     const customer = await this.customerRepository.findOne({
-      where: { id: createJobDto.customerId },
+      where: { id: customerId },
     });
     if (!customer) {
       throw new NotFoundException(
-        `Customer with ID ${createJobDto.customerId} not found.`,
+        `Customer with ID ${customerId} not found.`,
       );
     }
     const job = this.jobRepository.create({
-      ...createJobDto,
+      ...jobData,
       customer,
     });
     const savedJob = await this.jobRepository.save(job);


### PR DESCRIPTION
## Summary
- remove obsolete `toEntity` helper from job creation DTO
- construct `Job` entities in service using DTO fields directly

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a62ac5b4dc8325b63ed93272a93a66