### PR TITLE
Hash password reset tokens and index lookup column

### DIFF
--- a/backend/src/migrations/20250826224515-update-password-reset-token.ts
+++ b/backend/src/migrations/20250826224515-update-password-reset-token.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdatePasswordResetToken20250826224515 implements MigrationInterface {
+  name = 'UpdatePasswordResetToken20250826224515';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "passwordResetToken" TYPE character varying(64)`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_user_password_reset_token" ON "user" ("passwordResetToken")`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "IDX_user_password_reset_token"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "passwordResetToken" TYPE character varying(255)`
+    );
+  }
+}

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, BeforeInsert, BeforeUpdate } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  BeforeInsert,
+  BeforeUpdate,
+  Index,
+} from 'typeorm';
 import * as bcrypt from 'bcrypt';
 
 export enum UserRole {
@@ -21,7 +28,8 @@ export class User {
   @Column({ type: 'enum', enum: UserRole, default: UserRole.Customer })
   role: UserRole;
 
-  @Column({ nullable: true })
+  @Index('IDX_user_password_reset_token')
+  @Column({ length: 64, nullable: true })
   passwordResetToken: string | null;
 
   @Column({ type: 'timestamptz', nullable: true })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -48,16 +48,24 @@ export class UsersService {
       return;
     }
     const token = crypto.randomBytes(32).toString('hex');
-    user.passwordResetToken = token;
+    const hashedToken = crypto
+      .createHash('sha256')
+      .update(token)
+      .digest('hex');
+    user.passwordResetToken = hashedToken;
     user.passwordResetExpires = new Date(Date.now() + 60 * 60 * 1000);
     await this.usersRepository.save(user);
     await this.emailService.sendPasswordResetEmail(user.username, token);
   }
 
   async resetPassword(token: string, password: string): Promise<void> {
+    const hashedToken = crypto
+      .createHash('sha256')
+      .update(token)
+      .digest('hex');
     const user = await this.usersRepository.findOne({
       where: {
-        passwordResetToken: token,
+        passwordResetToken: hashedToken,
         passwordResetExpires: MoreThan(new Date()),
       },
     });


### PR DESCRIPTION
## Summary
- Hash password reset tokens before persisting and query by hashed value when resetting
- Ensure password reset token column supports SHA-256 and is indexed for lookups
- Adjust unit tests for hashed password reset tokens

## Testing
- `npm test` *(fails: JobsService › should throw NotFoundException when job does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ae387a5b6083259891783ab25051f3