### PR TITLE
feat: enforce JWT secret configuration

### DIFF
--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -16,7 +16,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: config.get<string>('JWT_SECRET') || 'secret',
+      secretOrKey: config.get<string>('JWT_SECRET'),
     });
   }
 


### PR DESCRIPTION
## Summary
- rely solely on JWT_SECRET config for JWT strategy

## Testing
- `npm test` (fails: JobsService should throw NotFoundException when job does not exist)
- `npm run lint` (fails: 78 problems)


------
https://chatgpt.com/codex/tasks/task_e_68ae388867d483258ed68cc40fd38a45