### PR TITLE
Add shared pagination DTO and apply to list endpoints

### DIFF
--- a/backend/src/common/dto/pagination-query.dto.ts
+++ b/backend/src/common/dto/pagination-query.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class PaginationQueryDto {
+  @ApiPropertyOptional({ default: 1 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ default: 10, maximum: 100 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -8,7 +8,6 @@ import {
   Param,
   ParseIntPipe,
   Query,
-  DefaultValuePipe,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -19,6 +18,7 @@ import { UpdateCustomerDto } from './dto/update-customer.dto';
 import { CustomerResponseDto } from './dto/customer-response.dto';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../users/user.entity';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -54,10 +54,9 @@ export class CustomersController {
   @ApiQuery({ name: 'limit', required: false })
   @ApiResponse({ status: 200, description: 'List of customers' })
   async findAll(
-    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
-    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit = 10,
+    @Query() pagination: PaginationQueryDto,
   ): Promise<{ items: CustomerResponseDto[]; total: number }> {
-    return this.customersService.findAll(page, limit);
+    return this.customersService.findAll(pagination);
   }
 
   @Get(':id')

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -8,7 +8,6 @@ import {
   Param,
   ParseIntPipe,
   Query,
-  DefaultValuePipe,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -18,6 +17,7 @@ import { UpdateEquipmentDto } from './dto/update-equipment.dto';
 import { EquipmentResponseDto } from './dto/equipment-response.dto';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../users/user.entity';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -53,10 +53,9 @@ export class EquipmentController {
   @ApiQuery({ name: 'limit', required: false })
   @ApiResponse({ status: 200, description: 'List of equipment' })
   async findAll(
-    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
-    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit = 10,
+    @Query() pagination: PaginationQueryDto,
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
-    return this.equipmentService.findAll(page, limit);
+    return this.equipmentService.findAll(pagination);
   }
 
   @Get(':id')

--- a/backend/src/equipment/equipment.service.ts
+++ b/backend/src/equipment/equipment.service.ts
@@ -5,6 +5,7 @@ import { Equipment, EquipmentStatus } from './entities/equipment.entity';
 import { CreateEquipmentDto } from './dto/create-equipment.dto';
 import { UpdateEquipmentDto } from './dto/update-equipment.dto';
 import { EquipmentResponseDto } from './dto/equipment-response.dto';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 @Injectable()
 export class EquipmentService {
@@ -22,24 +23,25 @@ export class EquipmentService {
   }
 
   async findAll(
-    page = 1,
-    limit = 10,
+    pagination: PaginationQueryDto,
     status?: EquipmentStatus,
     type?: string,
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
+    const { page = 1, limit = 10 } = pagination;
+    const cappedLimit = Math.min(limit, 100);
     const queryBuilder = this.equipmentRepository.createQueryBuilder('equipment');
-    
+
     if (status) {
       queryBuilder.andWhere('equipment.status = :status', { status });
     }
-    
+
     if (type) {
       queryBuilder.andWhere('equipment.type = :type', { type });
     }
 
     const [equipments, total] = await queryBuilder
-      .skip((page - 1) * limit)
-      .take(limit)
+      .skip((page - 1) * cappedLimit)
+      .take(cappedLimit)
       .getManyAndCount();
 
     return {

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -8,7 +8,6 @@ import {
   Delete,
   ParseIntPipe,
   Query,
-  DefaultValuePipe,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -22,6 +21,7 @@ import { UserRole } from '../users/user.entity';
 import { ScheduleJobDto } from './dto/schedule-job.dto';
 import { AssignJobDto } from './dto/assign-job.dto';
 import { BulkAssignJobDto } from './dto/bulk-assign-job.dto';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -55,10 +55,9 @@ export class JobsController {
   @ApiQuery({ name: 'limit', required: false })
   @ApiResponse({ status: 200, description: 'List of jobs' })
   findAll(
-    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
-    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit = 10,
+    @Query() pagination: PaginationQueryDto,
   ): Promise<{ items: JobResponseDto[]; total: number }> {
-    return this.jobsService.findAll(page, limit);
+    return this.jobsService.findAll(pagination);
   }
 
   @Get(':id')


### PR DESCRIPTION
## Summary
- add reusable `PaginationQueryDto` with validation and defaults
- refactor equipment, customers, and jobs endpoints to consume pagination DTO and cap page size at 100

## Testing
- `npm test`
- `npx eslint "{src,apps,libs,test}/**/*.ts"` *(fails: Unsafe member access .create on an `any` value @typescript-eslint/no-unsafe-member-access, Unsafe call of a(n) `any` typed value @typescript-eslint/no-unsafe-call, Unsafe member access .findOne on an `any` value @typescript-eslint/no-unsafe-member-access, Unsafe assignment of an `any` value @typescript-eslint/no-unsafe-assignment, Unsafe member access .create on an `any` value @typescript-eslint/no-unsafe-member-access, Unsafe call of a(n) `any` typed value @typescript-eslint/no-unsafe-call, Unsafe member access .save on an `any` value @typescript-eslint/no-unsafe-member-access, Unsafe member access .isInitialized on an `any` value @typescript-eslint/no-unsafe-member-access, Unsafe call of a(n) `any` typed value @typescript-eslint/no-unsafe-call, Unsafe member access .destroy on an `any` value @typescript-eslint/no-unsafe-member-access, Replace `·Entity,·PrimaryGeneratedColumn,·Column,·BeforeInsert,·BeforeUpdate·` with `⏎··Entity,⏎··PrimaryGeneratedColumn,⏎··Column,⏎··BeforeInsert,⏎··BeforeUpdate,⏎`  prettier/prettier)*

------
https://chatgpt.com/codex/tasks/task_e_68ae388ffd448325a2459a0e81bc5ba9