### PR TITLE
refactor: prefix omitted user fields

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -31,8 +31,12 @@ export class AuthController {
   @ApiResponse({ status: 201, description: 'Created user' })
   async register(@Body() registerDto: RegisterDto) {
     const user = await this.authService.register(registerDto);
-    const { password, passwordResetToken, passwordResetExpires, ...result } =
-      user;
+    const {
+      password: _p,
+      passwordResetToken: _rt,
+      passwordResetExpires: _re,
+      ...result
+    } = user;
     return result;
   }
 


### PR DESCRIPTION
## Summary
- prefix unused user fields with underscores during registration

## Testing
- `npm test`
- `npm run lint` *(fails: unsafe any values in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ae452a0df4832596d38f6c04cef823