### PR TITLE
refactor: format exception messages

### DIFF
--- a/backend/src/common/filters/http-exception/http-exception.filter.ts
+++ b/backend/src/common/filters/http-exception/http-exception.filter.ts
@@ -36,15 +36,16 @@ export class HttpExceptionFilter implements ExceptionFilter {
       typeof errorResponse === 'string'
         ? errorResponse
         : (errorResponse as { message?: string | string[] }).message;
+    const msg = Array.isArray(message) ? message.join(', ') : (message ?? '');
 
     this.logger.error(
-      `HTTP ${status} ${request.method} ${request.url} - ${message}`,
-      (exception as any)?.stack,
+      `HTTP ${status} ${request.method} ${request.url} - ${msg}`,
+      exception instanceof Error ? exception.stack : undefined,
     );
 
     response.status(status).json({
       statusCode: status,
-      message,
+      message: msg,
       timestamp: new Date().toISOString(),
       path: request.url,
     });


### PR DESCRIPTION
## Summary
- normalize error messages in HttpExceptionFilter
- log stack only when exception is an Error instance

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access .save on an `any` value, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ae452ae0d483258e17a8569e4b690f