### PR TITLE
refactor(logging): use route path for histogram labels

### DIFF
--- a/backend/src/common/interceptors/logging.interceptor.ts
+++ b/backend/src/common/interceptors/logging.interceptor.ts
@@ -27,6 +27,7 @@ export class LoggingInterceptor implements NestInterceptor {
     const ctx = context.switchToHttp();
     const request = ctx.getRequest<Request>();
     const { method, url } = request;
+    const routePath = (request.route?.path as string | undefined) ?? url;
     const start = Date.now();
 
     return next.handle().pipe(
@@ -39,7 +40,7 @@ export class LoggingInterceptor implements NestInterceptor {
           `HTTP ${method} ${url} ${statusCode} ${duration}ms - ${requestId}`,
         );
         this.histogram
-          .labels(method, request.route?.path ?? url, statusCode.toString())
+          .labels(method, routePath, statusCode.toString())
           .observe(duration / 1000);
       }),
     );


### PR DESCRIPTION
## Summary
- use Express route path when labeling Prometheus histograms

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access on `any` values)*

------
https://chatgpt.com/codex/tasks/task_e_68ae452bcce88325b6da98523f82fd53