### PR TITLE
Use DataSource type in seeding script

### DIFF
--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -1,9 +1,10 @@
 import dataSource from '../data-source';
+import { DataSource } from 'typeorm';
 import { User, UserRole } from './users/user.entity';
 import { Customer } from './customers/entities/customer.entity';
 
 async function seed() {
-  let dataSourceInstance: any;
+  let dataSourceInstance: DataSource;
 
   try {
     dataSourceInstance = await dataSource.initialize();


### PR DESCRIPTION
## Summary
- import DataSource from typeorm for the seeding script
- type `dataSourceInstance` as `DataSource` and remove unnecessary casts

## Testing
- `npm test`
- `npm run lint` *(fails: Async method 'useFactory' has no 'await' expression, plus other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae452e8c788325a727a7b2813cffcf