### PR TITLE
refactor(auth): remove unused password fields

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -31,12 +31,11 @@ export class AuthController {
   @ApiResponse({ status: 201, description: 'Created user' })
   async register(@Body() registerDto: RegisterDto) {
     const user = await this.authService.register(registerDto);
-    const {
-      password: _p,
-      passwordResetToken: _rt,
-      passwordResetExpires: _re,
-      ...result
-    } = user;
+    const { password, passwordResetToken, passwordResetExpires, ...result } =
+      user;
+    void passwordResetToken; // mark intentionally unused
+    void passwordResetExpires;
+    void password;
     return result;
   }
 


### PR DESCRIPTION
## Summary
- avoid unused password fields in auth controller during register

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe array destructuring; Unexpected await)*

------
https://chatgpt.com/codex/tasks/task_e_68ae67e7ec2c8325a3b97b0f5e9b8f9f