### PR TITLE
test: use valid DTOs in service specs

### DIFF
--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -4,6 +4,7 @@ import { CustomersService } from './customers.service';
 import { Customer } from './entities/customer.entity';
 import { Repository, QueryFailedError } from 'typeorm';
 import { ConflictException } from '@nestjs/common';
+import { CreateCustomerDto } from './dto/create-customer.dto';
 
 describe('CustomersService', () => {
   let service: CustomersService;
@@ -38,10 +39,23 @@ describe('CustomersService', () => {
       new QueryFailedError('', [], { code: '23505' } as any),
     );
 
-    await expect(service.create({} as any)).rejects.toBeInstanceOf(
+    const createCustomerDto: CreateCustomerDto = {
+      name: 'John Doe',
+      email: 'john@example.com',
+      addresses: [
+        {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'CA',
+          zip: '12345',
+        },
+      ],
+    };
+
+    await expect(service.create(createCustomerDto)).rejects.toBeInstanceOf(
       ConflictException,
     );
-    await expect(service.create({} as any)).rejects.toHaveProperty(
+    await expect(service.create(createCustomerDto)).rejects.toHaveProperty(
       'message',
       'Email already exists',
     );

--- a/backend/src/jobs/jobs.service.spec.ts
+++ b/backend/src/jobs/jobs.service.spec.ts
@@ -7,6 +7,9 @@ import { Customer } from '../customers/entities/customer.entity';
 import { User } from '../users/user.entity';
 import { Equipment } from '../equipment/entities/equipment.entity';
 import { Assignment } from './entities/assignment.entity';
+import { CreateJobDto } from './dto/create-job.dto';
+import { ScheduleJobDto } from './dto/schedule-job.dto';
+import { AssignJobDto } from './dto/assign-job.dto';
 
 describe('JobsService', () => {
   let service: JobsService;
@@ -85,12 +88,13 @@ describe('JobsService', () => {
 
   it('should throw NotFoundException when customer does not exist on create', async () => {
     customerRepository.findOne.mockResolvedValue(null);
-    await expect(
-      service.create({
-        title: 'Test',
-        customerId: 1,
-      } as any),
-    ).rejects.toBeInstanceOf(NotFoundException);
+    const createJobDto: CreateJobDto = {
+      title: 'Test',
+      customerId: 1,
+    };
+    await expect(service.create(createJobDto)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
   });
 
   it('should throw ConflictException when scheduling with existing assignment conflict', async () => {
@@ -114,8 +118,9 @@ describe('JobsService', () => {
     };
     assignmentRepository.createQueryBuilder.mockReturnValue(qb);
 
+    const scheduleJobDto: ScheduleJobDto = { scheduledDate: date };
     await expect(
-      service.schedule(1, { scheduledDate: date } as any),
+      service.schedule(1, scheduleJobDto),
     ).rejects.toBeInstanceOf(ConflictException);
   });
 
@@ -137,8 +142,9 @@ describe('JobsService', () => {
     };
     assignmentRepository.createQueryBuilder.mockReturnValue(qb);
 
+    const assignJobDto: AssignJobDto = { userId: 1, equipmentId: 2 };
     await expect(
-      service.assign(1, { userId: 1, equipmentId: 2 } as any),
+      service.assign(1, assignJobDto),
     ).rejects.toBeInstanceOf(ConflictException);
   });
 });


### PR DESCRIPTION
## Summary
- use a complete `CreateCustomerDto` in customer service tests
- instantiate job DTOs with minimal data in job service tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae67f2791083258d2416095f72d97b