### PR TITLE
refactor: type emailService mock in user service tests

### DIFF
--- a/backend/src/users/__tests__/users.service.spec.ts
+++ b/backend/src/users/__tests__/users.service.spec.ts
@@ -4,6 +4,7 @@ import { QueryFailedError, Repository } from 'typeorm';
 
 import { UsersService } from '../users.service';
 import { User, UserRole } from '../user.entity';
+import { EmailService } from '../../common/email.service';
 
 const UNIQUE_VIOLATION = '23505';
 
@@ -12,7 +13,7 @@ describe('UsersService', () => {
   let usersRepository: jest.Mocked<
     Pick<Repository<User>, 'create' | 'save' | 'findOne'>
   >;
-  let emailService: { sendPasswordResetEmail: jest.Mock };
+  let emailService: { sendPasswordResetEmail: jest.Mock<[string, string]> };
 
   beforeEach(() => {
     usersRepository = {
@@ -36,7 +37,7 @@ describe('UsersService', () => {
     emailService = { sendPasswordResetEmail: jest.fn() };
     service = new UsersService(
       usersRepository as unknown as Repository<User>,
-      emailService as any,
+      emailService as unknown as EmailService,
     );
   });
 
@@ -82,7 +83,7 @@ describe('UsersService', () => {
 
     await service.requestPasswordReset('user3');
     const [[emailUsername, rawToken]] =
-      emailService.sendPasswordResetEmail.mock.calls;
+      emailService.sendPasswordResetEmail.mock.calls as [string, string][];
     const hashedToken = crypto
       .createHash('sha256')
       .update(rawToken)


### PR DESCRIPTION
## Summary
- type password reset email mock with explicit jest.Mock signature
- cast mock call args to [string, string][] for safer destructuring
- inject typed emailService mock into UsersService without using any

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae67fb90708325a7eb36c074dd4e1c