### PR TITLE
fix(users): remove redundant await in resetPassword

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -67,7 +67,7 @@ export class UsersService {
       throw new BadRequestException('Invalid or expired token');
     }
     user.password = password;
-    await user.hashPassword();
+    user.hashPassword();
     user.passwordResetToken = null;
     user.passwordResetExpires = null;
     await this.usersRepository.save(user);


### PR DESCRIPTION
## Summary
- remove unnecessary `await` when hashing passwords during reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae680200308325a5bf8456a8f2e7ee