### PR TITLE
refactor: specify email mock types

### DIFF
--- a/backend/src/users/__tests__/users.service.spec.ts
+++ b/backend/src/users/__tests__/users.service.spec.ts
@@ -13,7 +13,9 @@ describe('UsersService', () => {
   let usersRepository: jest.Mocked<
     Pick<Repository<User>, 'create' | 'save' | 'findOne'>
   >;
-  let emailService: { sendPasswordResetEmail: jest.Mock<[string, string]> };
+  let emailService: {
+    sendPasswordResetEmail: jest.Mock<void, [string, string]>;
+  };
 
   beforeEach(() => {
     usersRepository = {
@@ -34,7 +36,9 @@ describe('UsersService', () => {
     } as unknown as jest.Mocked<
       Pick<Repository<User>, 'create' | 'save' | 'findOne'>
     >;
-    emailService = { sendPasswordResetEmail: jest.fn() };
+    emailService = {
+      sendPasswordResetEmail: jest.fn<void, [string, string]>(),
+    };
     service = new UsersService(
       usersRepository as unknown as Repository<User>,
       emailService as unknown as EmailService,
@@ -83,7 +87,7 @@ describe('UsersService', () => {
 
     await service.requestPasswordReset('user3');
     const [[emailUsername, rawToken]] =
-      emailService.sendPasswordResetEmail.mock.calls as [string, string][];
+      emailService.sendPasswordResetEmail.mock.calls;
     const hashedToken = crypto
       .createHash('sha256')
       .update(rawToken)


### PR DESCRIPTION
## Summary
- type email service mock with jest.Mock<void, [string, string]>
- initialize sendPasswordResetEmail with typed jest.fn

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae6b4f5548832598bf1125b836e78d