### PR TITLE
Avoid awaiting password reset email

### DIFF
--- a/backend/src/users/__tests__/users.service.spec.ts
+++ b/backend/src/users/__tests__/users.service.spec.ts
@@ -13,7 +13,9 @@ describe('UsersService', () => {
   let usersRepository: jest.Mocked<
     Pick<Repository<User>, 'create' | 'save' | 'findOne'>
   >;
-  let emailService: { sendPasswordResetEmail: jest.Mock<[string, string]> };
+  let emailService: {
+    sendPasswordResetEmail: jest.Mock<void, [string, string]>;
+  };
 
   beforeEach(() => {
     usersRepository = {
@@ -34,7 +36,9 @@ describe('UsersService', () => {
     } as unknown as jest.Mocked<
       Pick<Repository<User>, 'create' | 'save' | 'findOne'>
     >;
-    emailService = { sendPasswordResetEmail: jest.fn() };
+    emailService = {
+      sendPasswordResetEmail: jest.fn<void, [string, string]>(),
+    };
     service = new UsersService(
       usersRepository as unknown as Repository<User>,
       emailService as unknown as EmailService,
@@ -83,7 +87,7 @@ describe('UsersService', () => {
 
     await service.requestPasswordReset('user3');
     const [[emailUsername, rawToken]] =
-      emailService.sendPasswordResetEmail.mock.calls as [string, string][];
+      emailService.sendPasswordResetEmail.mock.calls;
     const hashedToken = crypto
       .createHash('sha256')
       .update(rawToken)

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -52,7 +52,7 @@ export class UsersService {
     user.passwordResetToken = hashedToken;
     user.passwordResetExpires = new Date(Date.now() + 60 * 60 * 1000);
     await this.usersRepository.save(user);
-    await this.emailService.sendPasswordResetEmail(user.username, token);
+    this.emailService.sendPasswordResetEmail(user.username, token);
   }
 
   async resetPassword(token: string, password: string): Promise<void> {


### PR DESCRIPTION
## Summary
- stop awaiting password reset email dispatch to avoid async lint error
- properly type email service mock in tests

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae6b510850832590bca62c7349f5ee