### PR TITLE
chore: split docker compose configs for prod and dev

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -262,14 +262,11 @@ src/
 
 ### **Docker Deployment**
 ```bash
-# Development with Docker Compose
-docker-compose up --build
+# Run with production settings
+docker compose up
 
-# Production build
-docker build -t rflandscaperpro-backend .
-
-# Run production container
-docker run -p 3000:3000 rflandscaperpro-backend
+# Run with local development overrides
+docker compose -f docker-compose.yml -f docker-compose.override.yml up
 ```
 
 ### **Fly.io Deployment**

--- a/backend/docker-compose.override.yml
+++ b/backend/docker-compose.override.yml
@@ -1,0 +1,11 @@
+services:
+  backend:
+    build:
+      dockerfile: Dockerfile.dev
+    volumes:
+      - .:/app
+      - /app/node_modules
+    env_file:
+      - .env.development
+    environment:
+      - NODE_ENV=development

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,16 +1,11 @@
 services:
   backend:
-    image: rflandscaperpro/backend:dev
-    container_name: rflandscaperpro_backend_dev
+    image: rflandscaperpro/backend
+    container_name: rflandscaperpro_backend
     build:
       context: .
-      dockerfile: Dockerfile.dev
+      dockerfile: Dockerfile
     ports:
       - "3000:3000"
-    volumes:
-      - .:/app
-      - /app/node_modules
     env_file:
-      - .env.development
-    environment:
-      - NODE_ENV=development
+      - .env


### PR DESCRIPTION
## Summary
- switch base docker-compose to production Dockerfile with generic env settings
- add docker-compose.override.yml for local development
- document compose usage for prod parity and local dev

## Testing
- `npm test` *(fails: runs but hangs with 0 tests, likely due to environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68af139135f88325a67016e8d208720b