### PR TITLE
Add PostgreSQL service to Docker Compose

### DIFF
--- a/backend/docker-compose.override.yml
+++ b/backend/docker-compose.override.yml
@@ -9,3 +9,17 @@ services:
       - .env.development
     environment:
       - NODE_ENV=development
+  db:
+    image: postgres:14
+    container_name: rflandscaperpro_db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: rflandscaperpro
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- move PostgreSQL database service into docker-compose override for local development

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Config validation error: "DB_HOST" is required. "DB_USERNAME" is required. "DB_PASSWORD" is required. "DB_NAME" is required. "JWT_SECRET" is required)*

------
https://chatgpt.com/codex/tasks/task_e_68af19601b5c8325b0c13bba4f61850d