### PR TITLE
feat: add Prometheus server configuration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -310,6 +310,16 @@ Ensure all required environment variables are set:
 - Database connection status
 - Application health indicators
 
+### **Prometheus server**
+Use the included Prometheus service to scrape and inspect metrics locally:
+
+```bash
+docker compose up prometheus
+```
+
+The container uses `prometheus.yml` to scrape the `backend` service and exposes
+the Prometheus UI at [http://localhost:9090](http://localhost:9090).
+
 ### **Logging**
 - Structured logging with Winston
 - Request ID tracking for debugging

--- a/backend/docker-compose.override.yml
+++ b/backend/docker-compose.override.yml
@@ -21,5 +21,13 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  prometheus:
+    image: prom/prometheus
+    container_name: rflandscaperpro_prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+
 volumes:
   postgres_data:

--- a/backend/prometheus.yml
+++ b/backend/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'backend'
+    static_configs:
+      - targets: ['backend:3000']


### PR DESCRIPTION
## Summary
- add a Prometheus configuration file that scrapes the backend service
- extend docker-compose override with a Prometheus service
- document how to run Prometheus locally

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af28944c048325a64f82d18b9c375e