### PR TITLE
docs: clarify Quick Start container usage

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -64,6 +64,17 @@ npm run seed
 ```
 
 ### **4. Start Development Server**
+
+**Recommended (Docker):** Use a fully managed environment:
+
+```bash
+npm run dev:compose
+# or
+docker compose -f docker-compose.yml -f docker-compose.override.yml up
+```
+
+`npm run start:dev` and the other commands below are executed **inside the Docker container**. Run them directly only if all dependent services (e.g., PostgreSQL) are available locally.
+
 ```bash
 # Start with hot reload
 npm run start:dev


### PR DESCRIPTION
## Summary
- clarify that `start:dev` runs inside the container and requires local services when used directly
- recommend `npm run dev:compose`/Docker Compose for a fully managed dev environment

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af4e790da48325849f614a7975996f