### PR TITLE
feat: add compose dev script

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -63,9 +63,12 @@ npm run migration:run
 npm run seed
 ```
 
-### **4. Start Development Server**
+### **4. Start Development Environment**
 ```bash
-# Start with hot reload
+# Preferred: start the full environment with Docker
+npm run dev:compose
+
+# Alternatively, run the NestJS server with hot reload
 npm run start:dev
 
 # Start with debugger

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "start:dev": "node -r dotenv/config -r ts-node/register ./node_modules/.bin/nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "dev:compose": "docker compose -f docker-compose.yml -f docker-compose.override.yml up --build",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
## Summary
- add dev:compose script to run Docker Compose for development
- document dev:compose as preferred development start method

## Testing
- `npm test` (fails: Cannot find module 'nodemailer')
- `npm run lint` (fails: unsafe assignments in src/common/email.service.ts)


------
https://chatgpt.com/codex/tasks/task_e_68af4e753c9483258da4319a7bf08be1