### PR TITLE
feat: add profile and token endpoints

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -60,6 +60,8 @@ createdb rflandscaperpro
 npm run migration:run
 
 # Seed initial data (creates admin user and sample customer)
+# This script is intended for local development only and will
+# automatically skip execution when `NODE_ENV=production`.
 npm run seed
 ```
 

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -14,6 +14,7 @@ describe('AuthController', () => {
     register: jest.Mock;
     requestPasswordReset: jest.Mock;
     resetPassword: jest.Mock;
+    refresh: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -23,6 +24,7 @@ describe('AuthController', () => {
       register: jest.fn(),
       requestPasswordReset: jest.fn(),
       resetPassword: jest.fn(),
+      refresh: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -65,5 +67,12 @@ describe('AuthController', () => {
     const dto: ResetPasswordDto = { token: 'abc', password: 'new' };
     await controller.resetPassword(dto);
     expect(authService.resetPassword).toHaveBeenCalledWith('abc', 'new');
+  });
+
+  it('refreshes token', async () => {
+    authService.refresh.mockResolvedValue({ access_token: 'new' });
+    const result = await controller.refresh({ refreshToken: 'token' });
+    expect(authService.refresh).toHaveBeenCalledWith('token');
+    expect(result).toEqual({ access_token: 'new' });
   });
 });

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { RequestPasswordResetDto } from './dto/request-password-reset.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { Public } from '../common/decorators/public.decorator';
 import { User } from '../users/user.entity';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -59,5 +60,21 @@ export class AuthController {
   ): Promise<{ message: string }> {
     await this.authService.resetPassword(dto.token, dto.password);
     return { message: 'Password reset successful' };
+  }
+
+  @Public()
+  @Post('refresh')
+  @ApiOperation({ summary: 'Refresh access token' })
+  @ApiResponse({ status: 200, description: 'New access token' })
+  async refresh(@Body() dto: RefreshTokenDto) {
+    return this.authService.refresh(dto.refreshToken);
+  }
+
+  @Public()
+  @Post('logout')
+  @ApiOperation({ summary: 'Logout current user' })
+  @ApiResponse({ status: 200, description: 'Logged out' })
+  logout(): { message: string } {
+    return { message: 'Logged out' };
   }
 }

--- a/backend/src/auth/dto/refresh-token.dto.ts
+++ b/backend/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,8 @@
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RefreshTokenDto {
+  @ApiProperty()
+  @IsString()
+  refreshToken: string;
+}

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -3,6 +3,11 @@ import { DataSource } from 'typeorm';
 import { User, UserRole } from './users/user.entity';
 import { Customer } from './customers/entities/customer.entity';
 
+if (process.env.NODE_ENV === 'production') {
+  console.log('Seeding skipped in production');
+  process.exit(0);
+}
+
 async function seed() {
   let dataSourceInstance: DataSource | undefined;
 

--- a/backend/src/users/__tests__/users.service.spec.ts
+++ b/backend/src/users/__tests__/users.service.spec.ts
@@ -120,4 +120,23 @@ describe('UsersService', () => {
     const isMatch = await bcrypt.compare('newpass', user.password);
     expect(isMatch).toBe(true);
   });
+
+  it('updates profile and hashes new password', async () => {
+    const user = Object.assign(new User(), {
+      id: 1,
+      username: 'old',
+      password: 'oldpass',
+    });
+    usersRepository.findOne.mockResolvedValue(user);
+
+    const updated = await service.updateProfile(1, {
+      username: 'new',
+      password: 'Newpass1!',
+    });
+
+    expect(updated.username).toBe('new');
+    const isMatch = await bcrypt.compare('Newpass1!', updated.password);
+    expect(isMatch).toBe(true);
+    expect(usersRepository.save).toHaveBeenCalledWith(user);
+  });
 });

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateUserDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  username?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  password?: string;
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Put, Req } from '@nestjs/common';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 import { User, UserRole } from './user.entity';
 import {
   ApiBearerAuth,
@@ -21,5 +22,33 @@ export class UsersController {
   @ApiResponse({ status: 201, description: 'User created', type: User })
   create(@Body() createUserDto: CreateUserDto): Promise<User> {
     return this.usersService.create(createUserDto);
+  }
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get current user profile' })
+  @ApiResponse({ status: 200, description: 'Current user', type: User })
+  async getMe(
+    @Req() req: { user: { userId: number } },
+  ): Promise<Omit<User, 'password'>> {
+    const user = await this.usersService.findById(req.user.userId);
+    const { password: _password, ...result } = user;
+    void _password;
+    return result;
+  }
+
+  @Put('me')
+  @ApiOperation({ summary: 'Update current user profile' })
+  @ApiResponse({ status: 200, description: 'Updated user', type: User })
+  async updateMe(
+    @Req() req: { user: { userId: number } },
+    @Body() updateUserDto: UpdateUserDto,
+  ): Promise<Omit<User, 'password'>> {
+    const user = await this.usersService.updateProfile(
+      req.user.userId,
+      updateUserDto,
+    );
+    const { password: _password, ...result } = user;
+    void _password;
+    return result;
   }
 }


### PR DESCRIPTION
## Summary
- support refresh token flow and add logout endpoint
- expose `/users/me` for profile retrieval and update
- skip database seeding when running in production

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af55a5cd9c83259d211ada6e2d4fae