### PR TITLE
fix: ensure password hashed before saving on reset

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -73,7 +73,6 @@ export class UsersService {
       throw new BadRequestException('Invalid or expired token');
     }
     user.password = password;
-    await user.hashPassword();
     user.passwordResetToken = null;
     user.passwordResetExpires = null;
     await this.usersRepository.save(user);


### PR DESCRIPTION
## Summary
- rely on entity lifecycle hooks for password hashing during password reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af65adea088325929ced99c048b127