### PR TITLE
refactor: centralize password validation

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,12 +1,9 @@
-import {
-  Injectable,
-  UnauthorizedException,
-  BadRequestException,
-} from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
 import { User, UserRole } from '../users/user.entity';
 import { RegisterDto } from './dto/register.dto';
+import { validatePasswordStrength } from './password.util';
 
 @Injectable()
 export class AuthService {
@@ -46,7 +43,7 @@ export class AuthService {
 
   async register(registerDto: RegisterDto): Promise<User> {
     // Validate password strength
-    this.validatePasswordStrength(registerDto.password);
+    validatePasswordStrength(registerDto.password);
 
     return this.usersService.create(registerDto);
   }
@@ -57,7 +54,7 @@ export class AuthService {
 
   async resetPassword(token: string, password: string): Promise<void> {
     // Validate new password strength
-    this.validatePasswordStrength(password);
+    validatePasswordStrength(password);
 
     await this.usersService.resetPassword(token, password);
   }
@@ -78,38 +75,6 @@ export class AuthService {
       };
     } catch {
       throw new UnauthorizedException('Invalid refresh token');
-    }
-  }
-
-  private validatePasswordStrength(password: string): void {
-    if (password.length < 8) {
-      throw new BadRequestException(
-        'Password must be at least 8 characters long',
-      );
-    }
-
-    if (!/(?=.*[a-z])/.test(password)) {
-      throw new BadRequestException(
-        'Password must contain at least one lowercase letter',
-      );
-    }
-
-    if (!/(?=.*[A-Z])/.test(password)) {
-      throw new BadRequestException(
-        'Password must contain at least one uppercase letter',
-      );
-    }
-
-    if (!/(?=.*\d)/.test(password)) {
-      throw new BadRequestException(
-        'Password must contain at least one number',
-      );
-    }
-
-    if (!/(?=.*[@$!%*?&])/.test(password)) {
-      throw new BadRequestException(
-        'Password must contain at least one special character (@$!%*?&)',
-      );
     }
   }
 }

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,5 +1,6 @@
 import { IsString, MinLength, Matches } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { PASSWORD_REGEX } from '../password.util';
 
 export class RegisterDto {
   @ApiProperty({ description: 'Username must be unique' })
@@ -14,7 +15,7 @@ export class RegisterDto {
   })
   @IsString()
   @MinLength(8, { message: 'Password must be at least 8 characters long' })
-  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/, {
+  @Matches(PASSWORD_REGEX, {
     message:
       'Password must contain uppercase, lowercase, number, and special character',
   })

--- a/backend/src/auth/password.util.ts
+++ b/backend/src/auth/password.util.ts
@@ -1,0 +1,30 @@
+import { BadRequestException } from '@nestjs/common';
+
+export const PASSWORD_REGEX =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/;
+
+export function validatePasswordStrength(password: string): void {
+  if (password.length < 8) {
+    throw new BadRequestException(
+      'Password must be at least 8 characters long',
+    );
+  }
+  if (!/(?=.*[a-z])/.test(password)) {
+    throw new BadRequestException(
+      'Password must contain at least one lowercase letter',
+    );
+  }
+  if (!/(?=.*[A-Z])/.test(password)) {
+    throw new BadRequestException(
+      'Password must contain at least one uppercase letter',
+    );
+  }
+  if (!/(?=.*\d)/.test(password)) {
+    throw new BadRequestException('Password must contain at least one number');
+  }
+  if (!/(?=.*[@$!%*?&])/.test(password)) {
+    throw new BadRequestException(
+      'Password must contain at least one special character (@$!%*?&)',
+    );
+  }
+}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -13,6 +13,7 @@ import { EmailService } from '../common/email.service';
 import { User } from './user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { validatePasswordStrength } from '../auth/password.util';
 
 const UNIQUE_VIOLATION = '23505';
 
@@ -90,42 +91,10 @@ export class UsersService {
     }
 
     if (dto.password !== undefined) {
-      this.validatePasswordStrength(dto.password);
+      validatePasswordStrength(dto.password);
       user.password = dto.password;
     }
 
     return this.usersRepository.save(user);
-  }
-
-  private validatePasswordStrength(password: string): void {
-    if (password.length < 8) {
-      throw new BadRequestException(
-        'Password must be at least 8 characters long',
-      );
-    }
-
-    if (!/(?=.*[a-z])/.test(password)) {
-      throw new BadRequestException(
-        'Password must contain at least one lowercase letter',
-      );
-    }
-
-    if (!/(?=.*[A-Z])/.test(password)) {
-      throw new BadRequestException(
-        'Password must contain at least one uppercase letter',
-      );
-    }
-
-    if (!/(?=.*\d)/.test(password)) {
-      throw new BadRequestException(
-        'Password must contain at least one number',
-      );
-    }
-
-    if (!/(?=.*[@$!%*?&])/.test(password)) {
-      throw new BadRequestException(
-        'Password must contain at least one special character (@$!%*?&)',
-      );
-    }
   }
 }


### PR DESCRIPTION
## Summary
- create shared password validator and regex
- reuse validator in RegisterDto, AuthService, and UsersService

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af65ca3c608325bb8f1cb7c3d1d73b