### PR TITLE
feat: add email field to users

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -62,4 +62,6 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Database Migrations
-src/migrations/*
+# (keep directory but allow committing migration files)
+!src/migrations/
+!src/migrations/*.ts

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -36,10 +36,15 @@ describe('AuthController', () => {
   });
 
   it('registers a new user without returning password', async () => {
-    const dto: RegisterDto = { username: 'user', password: 'pass' };
+    const dto: RegisterDto = {
+      username: 'user',
+      email: 'user@example.com',
+      password: 'pass',
+    };
     const user: User = {
       id: 1,
       username: 'user',
+      email: 'user@example.com',
       password: 'hashed',
       role: UserRole.Customer,
       passwordResetToken: null,
@@ -53,14 +58,17 @@ describe('AuthController', () => {
     expect(result).toEqual({
       id: 1,
       username: 'user',
+      email: 'user@example.com',
       role: UserRole.Customer,
     });
   });
 
   it('requests password reset', async () => {
-    const dto: RequestPasswordResetDto = { username: 'user' };
+    const dto: RequestPasswordResetDto = { email: 'user@example.com' };
     await controller.requestPasswordReset(dto);
-    expect(authService.requestPasswordReset).toHaveBeenCalledWith('user');
+    expect(authService.requestPasswordReset).toHaveBeenCalledWith(
+      'user@example.com',
+    );
   });
 
   it('resets password', async () => {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -47,7 +47,7 @@ export class AuthController {
   async requestPasswordReset(
     @Body() requestDto: RequestPasswordResetDto,
   ): Promise<{ message: string }> {
-    await this.authService.requestPasswordReset(requestDto.username);
+    await this.authService.requestPasswordReset(requestDto.email);
     return { message: 'Password reset token sent' };
   }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -39,6 +39,7 @@ export class AuthService {
       user: {
         id: user.id,
         username: user.username,
+        email: user.email,
         role: user.role,
       },
     };
@@ -51,8 +52,8 @@ export class AuthService {
     return this.usersService.create(registerDto);
   }
 
-  async requestPasswordReset(username: string): Promise<void> {
-    await this.usersService.requestPasswordReset(username);
+  async requestPasswordReset(email: string): Promise<void> {
+    await this.usersService.requestPasswordReset(email);
   }
 
   async resetPassword(token: string, password: string): Promise<void> {

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, MinLength, Matches } from 'class-validator';
+import { IsEmail, IsString, MinLength, Matches } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class RegisterDto {
@@ -6,6 +6,10 @@ export class RegisterDto {
   @IsString()
   @MinLength(3, { message: 'Username must be at least 3 characters long' })
   username: string;
+
+  @ApiProperty({ description: 'Email must be unique' })
+  @IsEmail()
+  email: string;
 
   @ApiProperty({
     description:

--- a/backend/src/auth/dto/request-password-reset.dto.ts
+++ b/backend/src/auth/dto/request-password-reset.dto.ts
@@ -1,8 +1,8 @@
-import { IsString } from 'class-validator';
+import { IsEmail } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class RequestPasswordResetDto {
   @ApiProperty()
-  @IsString()
-  username: string;
+  @IsEmail()
+  email: string;
 }

--- a/backend/src/migrations/1717000000000-add-email-to-user.ts
+++ b/backend/src/migrations/1717000000000-add-email-to-user.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEmailToUser1717000000000 implements MigrationInterface {
+  name = 'AddEmailToUser1717000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" ADD "email" character varying`);
+    await queryRunner.query(
+      `UPDATE "user" SET "email" = "username" WHERE "email" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "email" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "UQ_user_email" UNIQUE ("email")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP CONSTRAINT "UQ_user_email"`,
+    );
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "email"`);
+  }
+}

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -25,6 +25,7 @@ async function seed() {
     if (!adminExists) {
       const admin = userRepo.create({
         username: 'admin',
+        email: 'admin@example.com',
         password: 'AdminSecure123!', // More secure password
         role: UserRole.Admin,
       });

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -4,6 +4,7 @@ import {
   IsString,
   MinLength,
   Matches,
+  IsEmail,
 } from 'class-validator';
 import { UserRole } from '../user.entity';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -12,6 +13,10 @@ export class CreateUserDto {
   @ApiProperty()
   @IsString()
   username: string;
+
+  @ApiProperty()
+  @IsEmail()
+  email: string;
 
   @ApiProperty()
   @IsString()

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsEmail, IsOptional, IsString } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateUserDto {
@@ -11,4 +11,9 @@ export class UpdateUserDto {
   @IsOptional()
   @IsString()
   password?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEmail()
+  email?: string;
 }

--- a/backend/src/users/dto/user-response.dto.ts
+++ b/backend/src/users/dto/user-response.dto.ts
@@ -6,6 +6,8 @@ export class UserResponseDto {
   id!: number;
   @ApiProperty()
   username!: string;
+  @ApiProperty()
+  email!: string;
   @ApiProperty({ enum: UserRole })
   role!: UserRole;
   @ApiProperty({ nullable: true })

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -22,6 +22,9 @@ export class User {
   @Column({ unique: true })
   username: string;
 
+  @Column({ unique: true })
+  email: string;
+
   @Column()
   password: string;
 

--- a/backend/src/users/users.mapper.ts
+++ b/backend/src/users/users.mapper.ts
@@ -5,6 +5,7 @@ export function toUserResponseDto(user: User): UserResponseDto {
   return {
     id: user.id,
     username: user.username,
+    email: user.email,
     role: user.role,
     passwordResetToken: user.passwordResetToken ?? null,
     passwordResetExpires: user.passwordResetExpires ?? null,

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -28,6 +28,10 @@ export class UsersService {
     return this.usersRepository.findOne({ where: { username } });
   }
 
+  findByEmail(email: string): Promise<User | null> {
+    return this.usersRepository.findOne({ where: { email } });
+  }
+
   findById(id: number): Promise<User | null> {
     return this.usersRepository.findOne({ where: { id } });
   }
@@ -41,15 +45,15 @@ export class UsersService {
       if (error instanceof QueryFailedError) {
         const { code } = error.driverError as { code?: string };
         if (code === UNIQUE_VIOLATION) {
-          throw new ConflictException('Username already exists');
+          throw new ConflictException('Username or email already exists');
         }
       }
       throw error;
     }
   }
 
-  async requestPasswordReset(username: string): Promise<void> {
-    const user = await this.findByUsername(username);
+  async requestPasswordReset(email: string): Promise<void> {
+    const user = await this.findByEmail(email);
     if (!user) {
       return;
     }
@@ -58,7 +62,7 @@ export class UsersService {
     user.passwordResetToken = hashedToken;
     user.passwordResetExpires = new Date(Date.now() + 60 * 60 * 1000);
     await this.usersRepository.save(user);
-    await this.emailService.sendPasswordResetEmail(user.username, token);
+    await this.emailService.sendPasswordResetEmail(user.email, token);
   }
 
   async resetPassword(token: string, password: string): Promise<void> {
@@ -92,6 +96,10 @@ export class UsersService {
     if (dto.password !== undefined) {
       this.validatePasswordStrength(dto.password);
       user.password = dto.password;
+    }
+
+    if (dto.email !== undefined) {
+      user.email = dto.email;
     }
 
     return this.usersRepository.save(user);

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -31,7 +31,11 @@ describe('UsersController (e2e)', () => {
   it('POST /users returns 403 for non-admin', () => {
     return request(app.getHttpServer())
       .post('/users')
-      .send({ username: 'user', password: 'SecurePass123!' })
+      .send({
+        username: 'user',
+        email: 'user@example.com',
+        password: 'SecurePass123!',
+      })
       .expect(403);
   });
 });


### PR DESCRIPTION
## Summary
- add unique email to users and related DTOs
- reset passwords using email
- backfill existing users and enforce email uniqueness

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af65e3e67483259e857f1c69e964d8