### PR TITLE
feat: load env per NODE_ENV for migrations and seeding

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -57,12 +57,12 @@ LOG_LEVEL=debug
 createdb rflandscaperpro
 
 # Run database migrations (when available)
-npm run migration:run
+NODE_ENV=development npm run migration:run
 
 # Seed initial data (creates admin user and sample customer)
 # This script is intended for local development only and will
 # automatically skip execution when `NODE_ENV=production`.
-npm run seed
+NODE_ENV=development npm run seed
 ```
 
 ### **4. Start Development Server**
@@ -189,19 +189,19 @@ npm run format
 ### **Database**
 ```bash
 # Create new migration
-npm run migration:create
+NODE_ENV=development npm run migration:create
 
 # Generate migration from entity changes
-npm run migration:generate
+NODE_ENV=development npm run migration:generate
 
 # Run pending migrations
-npm run migration:run
+NODE_ENV=development npm run migration:run
 
 # Revert last migration
-npm run migration:revert
+NODE_ENV=development npm run migration:revert
 
 # Seed database with sample data
-npm run seed
+NODE_ENV=development npm run seed
 ```
 
 ## 🗄️ **Database Schema**

--- a/backend/data-source.ts
+++ b/backend/data-source.ts
@@ -1,4 +1,5 @@
-import 'dotenv/config';
+import { config } from 'dotenv';
+config({ path: `.env.${process.env.NODE_ENV || 'development'}` });
 import { DataSource } from 'typeorm';
 import { join } from 'path';
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,11 +19,11 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:watch": "jest --watch",
-    "migration:create": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:create",
-    "migration:generate": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:generate -d data-source.ts src/migrations",
-    "migration:run": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:run -d data-source.ts",
-    "migration:revert": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:revert -d data-source.ts",
-    "seed": "ts-node -r dotenv/config src/seed.ts"
+    "migration:create": "NODE_ENV=${NODE_ENV:-development} ts-node --transpile-only ./node_modules/typeorm/cli.js migration:create",
+    "migration:generate": "NODE_ENV=${NODE_ENV:-development} ts-node --transpile-only ./node_modules/typeorm/cli.js migration:generate -d data-source.ts src/migrations",
+    "migration:run": "NODE_ENV=${NODE_ENV:-development} ts-node --transpile-only ./node_modules/typeorm/cli.js migration:run -d data-source.ts",
+    "migration:revert": "NODE_ENV=${NODE_ENV:-development} ts-node --transpile-only ./node_modules/typeorm/cli.js migration:revert -d data-source.ts",
+    "seed": "NODE_ENV=${NODE_ENV:-development} ts-node src/seed.ts"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^3.0.1",


### PR DESCRIPTION
## Summary
- load environment variables via dotenv using NODE_ENV to select .env file
- require NODE_ENV for migration and seeding scripts
- document setting NODE_ENV when running migrations and seeds

## Testing
- `NODE_ENV=development npm test`
- `NODE_ENV=development npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af72032f24832584fd4b8179e53a3d