### PR TITLE
feat: load env per NODE_ENV for migrations and seeding

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -57,12 +57,12 @@ LOG_LEVEL=debug
 createdb rflandscaperpro
 
 # Run database migrations (when available)
-npm run migration:run
+npx cross-env NODE_ENV=development npm run migration:run
 
 # Seed initial data (creates admin user and sample customer)
 # This script is intended for local development only and will
 # automatically skip execution when `NODE_ENV=production`.
-npm run seed
+npx cross-env NODE_ENV=development npm run seed
 ```
 
 ### **4. Start Development Server**
@@ -189,19 +189,19 @@ npm run format
 ### **Database**
 ```bash
 # Create new migration
-npm run migration:create
+npx cross-env NODE_ENV=development npm run migration:create
 
 # Generate migration from entity changes
-npm run migration:generate
+npx cross-env NODE_ENV=development npm run migration:generate
 
 # Run pending migrations
-npm run migration:run
+npx cross-env NODE_ENV=development npm run migration:run
 
 # Revert last migration
-npm run migration:revert
+npx cross-env NODE_ENV=development npm run migration:revert
 
 # Seed database with sample data
-npm run seed
+npx cross-env NODE_ENV=development npm run seed
 ```
 
 ## 🗄️ **Database Schema**

--- a/backend/data-source.ts
+++ b/backend/data-source.ts
@@ -1,4 +1,5 @@
-import 'dotenv/config';
+import { config } from 'dotenv';
+config({ path: `.env.${process.env.NODE_ENV || 'development'}` });
 import { DataSource } from 'typeorm';
 import { join } from 'path';
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -55,6 +55,7 @@
         "@types/nodemailer": "^7.0.1",
         "@types/passport-jwt": "^3.0.9",
         "@types/supertest": "^6.0.2",
+        "cross-env": "^10.0.0",
         "dotenv-cli": "^10.0.0",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -1505,6 +1506,13 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -7390,6 +7398,24 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "migration:generate": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:generate -d data-source.ts src/migrations",
     "migration:run": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:run -d data-source.ts",
     "migration:revert": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:revert -d data-source.ts",
-    "seed": "ts-node -r dotenv/config src/seed.ts"
+    "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^3.0.1",
@@ -72,6 +72,7 @@
     "@types/nodemailer": "^7.0.1",
     "@types/passport-jwt": "^3.0.9",
     "@types/supertest": "^6.0.2",
+    "cross-env": "^10.0.0",
     "dotenv-cli": "^10.0.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",


### PR DESCRIPTION
## Summary
- load environment variables via dotenv using NODE_ENV to select .env file
- require NODE_ENV for migration and seeding scripts
- document setting NODE_ENV when running migrations and seeds
- add cross-env so migrations and seeds run on Windows
- delegate NODE_ENV to caller for migration and seed scripts

## Testing
- `NODE_ENV=development npm test`
- `NODE_ENV=development npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af72032f24832584fd4b8179e53a3d