### PR TITLE
fix: allow unauthenticated metrics

### DIFF
--- a/backend/src/common/guards/jwt-auth.guard.ts
+++ b/backend/src/common/guards/jwt-auth.guard.ts
@@ -1,6 +1,7 @@
 import { ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
@@ -10,6 +11,11 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   }
 
   canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest<Request>();
+    if (req.path?.startsWith('/metrics')) {
+      return true;
+    }
+
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
       context.getClass(),


### PR DESCRIPTION
## Summary
- ignore `/metrics` in `JwtAuthGuard` so Prometheus can scrape without auth

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af7c263fc8832599d49ab14f89610d