### PR TITLE
fix: return promise in metrics guard

### DIFF
--- a/backend/src/common/guards/metrics-throttler.guard.ts
+++ b/backend/src/common/guards/metrics-throttler.guard.ts
@@ -4,7 +4,7 @@ import { Request } from 'express';
 
 @Injectable()
 export class MetricsThrottlerGuard extends ThrottlerGuard {
-  canActivate(context: ExecutionContext) {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest<Request>();
     if (req.path?.startsWith('/metrics')) {
       return true;


### PR DESCRIPTION
## Summary
- ensure MetricsThrottlerGuard.canActivate returns a Promise

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af8446a8ac8325aaa9d93d55d38875