### PR TITLE
Ensure metrics endpoint serves plain text

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,11 +21,13 @@ import { MetricsThrottlerGuard } from './common/guards/metrics-throttler.guard';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { LoggerModule } from './logger/logger.module';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+import { MetricsModule } from './metrics/metrics.module';
 
 @Module({
   imports: [
-    PrometheusModule.register({ path: '/metrics' }),
+    PrometheusModule.register(),
     LoggerModule,
+    MetricsModule,
     ConfigModule.forRoot({
       envFilePath: `.env.${process.env.NODE_ENV}`,
       isGlobal: true,

--- a/backend/src/metrics/metrics.controller.ts
+++ b/backend/src/metrics/metrics.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { register } from 'prom-client';
+import { Public } from '../common/decorators/public.decorator';
+
+@Controller()
+export class MetricsController {
+  @Get('metrics')
+  @Public()
+  async getMetrics(@Res() res: Response): Promise<void> {
+    res.set('Content-Type', register.contentType);
+    res.send(await register.metrics());
+  }
+}

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { MetricsController } from './metrics.controller';
+
+@Module({
+  controllers: [MetricsController],
+})
+export class MetricsModule {}


### PR DESCRIPTION
## Summary
- Expose a dedicated `/metrics` controller that sets the `text/plain` content type for Prometheus
- Register new `MetricsModule` and remove auto-generated metrics route

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af854d444483258c311a1e5d3a8d0a