### PR TITLE
Add remote logging env defaults

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -28,6 +28,12 @@ SWAGGER_PASSWORD=admin
 
 # Optional: Logging
 LOG_LEVEL=debug
+# Hostname of the remote logging server
+REMOTE_LOG_HOST=localhost
+# Port number for the remote logging server
+REMOTE_LOG_PORT=1234
+# URL path for remote logging endpoint
+REMOTE_LOG_PATH=/
 
 # Caching (in milliseconds)
 CACHE_TTL=60000


### PR DESCRIPTION
## Summary
- document remote logging configuration in backend env template

## Testing
- `npm test`
- `LOG_LEVEL=debug REMOTE_LOG_HOST=localhost REMOTE_LOG_PORT=4567 REMOTE_LOG_PATH=/logtest DB_HOST=localhost DB_PORT=5432 DB_USERNAME=test DB_PASSWORD=test DB_NAME=test JWT_SECRET=mysecret npm run start` (validated logger sent POST to http://localhost:4567/logtest)


------
https://chatgpt.com/codex/tasks/task_e_68af87ec9df8832582718879e856746e