### PR TITLE
feat: document CORS allowed origins

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -9,6 +9,10 @@ NODE_ENV=development
 PORT=3000
 HOST=0.0.0.0
 
+# CORS Configuration
+# Comma-separated list of allowed origins
+ALLOWED_ORIGINS=https://example.com,https://admin.example.com
+
 # Database Configuration
 DB_HOST=localhost
 DB_PORT=5432


### PR DESCRIPTION
## Summary
- document `ALLOWED_ORIGINS` in backend env example for CORS configuration

## Testing
- `npm test`
- `curl -i -H "Origin: http://allowed.com" http://localhost:3000/metrics`
- `curl -s -i -H "Origin: http://disallowed.com" http://localhost:3000/metrics`

------
https://chatgpt.com/codex/tasks/task_e_68af87d75bfc8325949fc46be0decbb9