### PR TITLE
feat: expand user profile fields

### DIFF
--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,5 +1,11 @@
-import { IsEmail, IsString, MinLength, Matches } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsEmail,
+  IsOptional,
+  IsString,
+  MinLength,
+  Matches,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PASSWORD_REGEX } from '../password.util';
 
 export class RegisterDto {
@@ -24,4 +30,19 @@ export class RegisterDto {
       'Password must contain uppercase, lowercase, number, and special character',
   })
   password: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  firstName?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  lastName?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  phone?: string;
 }

--- a/backend/src/migrations/1718000000000-add-user-details.ts
+++ b/backend/src/migrations/1718000000000-add-user-details.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserDetails1718000000000 implements MigrationInterface {
+  name = 'AddUserDetails1718000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" ADD "firstName" character varying`);
+    await queryRunner.query(`ALTER TABLE "user" ADD "lastName" character varying`);
+    await queryRunner.query(`ALTER TABLE "user" ADD "phone" character varying`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "phone"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "lastName"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "firstName"`);
+  }
+}

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -27,6 +27,9 @@ async function seed() {
         email: 'admin@example.com',
         password: 'AdminSecure123!',
         role: UserRole.Admin,
+        firstName: 'Admin',
+        lastName: 'User',
+        phone: '555-0000',
       });
       await userRepo.save(admin);
       console.log('Admin user created successfully');

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -31,4 +31,19 @@ export class CreateUserDto {
   @IsEnum(UserRole)
   @IsOptional()
   role?: UserRole;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  firstName?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  lastName?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  phone?: string;
 }

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -16,4 +16,19 @@ export class UpdateUserDto {
   @IsOptional()
   @IsEmail()
   email?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  phone?: string;
 }

--- a/backend/src/users/dto/user-response.dto.ts
+++ b/backend/src/users/dto/user-response.dto.ts
@@ -11,7 +11,9 @@ export class UserResponseDto {
   @ApiProperty({ enum: UserRole })
   role!: UserRole;
   @ApiProperty({ nullable: true })
-  passwordResetToken!: string | null;
-  @ApiProperty({ nullable: true, type: String, format: 'date-time' })
-  passwordResetExpires!: Date | null;
+  firstName!: string | null;
+  @ApiProperty({ nullable: true })
+  lastName!: string | null;
+  @ApiProperty({ nullable: true })
+  phone!: string | null;
 }

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -31,6 +31,15 @@ export class User {
   @Column({ type: 'enum', enum: UserRole, default: UserRole.Customer })
   role: UserRole;
 
+  @Column({ nullable: true })
+  firstName: string | null;
+
+  @Column({ nullable: true })
+  lastName: string | null;
+
+  @Column({ nullable: true })
+  phone: string | null;
+
   @Index('IDX_user_password_reset_token')
   @Column({ type: 'varchar', length: 64, nullable: true })
   passwordResetToken: string | null;

--- a/backend/src/users/users.mapper.ts
+++ b/backend/src/users/users.mapper.ts
@@ -7,7 +7,8 @@ export function toUserResponseDto(user: User): UserResponseDto {
     username: user.username,
     email: user.email,
     role: user.role,
-    passwordResetToken: user.passwordResetToken ?? null,
-    passwordResetExpires: user.passwordResetExpires ?? null,
+    firstName: user.firstName ?? null,
+    lastName: user.lastName ?? null,
+    phone: user.phone ?? null,
   };
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -102,6 +102,18 @@ export class UsersService {
       user.email = dto.email;
     }
 
+    if (dto.firstName !== undefined) {
+      user.firstName = dto.firstName;
+    }
+
+    if (dto.lastName !== undefined) {
+      user.lastName = dto.lastName;
+    }
+
+    if (dto.phone !== undefined) {
+      user.phone = dto.phone;
+    }
+
     return this.usersRepository.save(user);
   }
 }


### PR DESCRIPTION
## Summary
- add optional first name, last name, and phone fields to user profile
- hide password reset fields from user response
- include new columns in migrations and seed data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8c44fc808325b09fda975eea658d