### PR TITLE
feat(customers): add activation endpoints

### DIFF
--- a/backend/src/customers/customers.controller.spec.ts
+++ b/backend/src/customers/customers.controller.spec.ts
@@ -1,17 +1,34 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CustomersController } from './customers.controller';
 import { CustomersService } from './customers.service';
+import { CustomerResponseDto } from './dto/customer-response.dto';
 
 describe('CustomersController', () => {
   let controller: CustomersController;
+  let service: {
+    activate: jest.Mock;
+    deactivate: jest.Mock;
+  };
+  const customer: CustomerResponseDto = {
+    id: 1,
+    name: 'Test Customer',
+    email: 'test@example.com',
+    active: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
 
   beforeEach(async () => {
+    service = {
+      activate: jest.fn().mockResolvedValue(customer),
+      deactivate: jest.fn().mockResolvedValue({ ...customer, active: false }),
+    };
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CustomersController],
       providers: [
         {
           provide: CustomersService,
-          useValue: {},
+          useValue: service,
         },
       ],
     }).compile();
@@ -21,5 +38,17 @@ describe('CustomersController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('activates a customer', async () => {
+    const result = await controller.activate(1);
+    expect(service.activate).toHaveBeenCalledWith(1);
+    expect(result).toEqual(customer);
+  });
+
+  it('deactivates a customer', async () => {
+    const result = await controller.deactivate(1);
+    expect(service.deactivate).toHaveBeenCalledWith(1);
+    expect(result).toEqual({ ...customer, active: false });
   });
 });

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -88,6 +88,34 @@ export class CustomersController {
     return this.customersService.update(id, updateCustomerDto);
   }
 
+  @Patch(':id/activate')
+  @Roles(UserRole.Admin)
+  @ApiOperation({ summary: 'Activate customer' })
+  @ApiResponse({
+    status: 200,
+    description: 'Customer activated',
+    type: CustomerResponseDto,
+  })
+  async activate(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<CustomerResponseDto> {
+    return this.customersService.activate(id);
+  }
+
+  @Patch(':id/deactivate')
+  @Roles(UserRole.Admin)
+  @ApiOperation({ summary: 'Deactivate customer' })
+  @ApiResponse({
+    status: 200,
+    description: 'Customer deactivated',
+    type: CustomerResponseDto,
+  })
+  async deactivate(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<CustomerResponseDto> {
+    return this.customersService.deactivate(id);
+  }
+
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @Roles(UserRole.Admin)

--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -60,4 +60,36 @@ describe('CustomersService', () => {
       'Email already exists',
     );
   });
+
+  it('activates a customer', async () => {
+    const customer = {} as any;
+    const findOneSpy = jest
+      .spyOn(service, 'findOne')
+      .mockResolvedValue(customer);
+    const updateSpy = jest
+      .spyOn(service, 'update')
+      .mockResolvedValue(customer);
+
+    const result = await service.activate(1);
+
+    expect(findOneSpy).toHaveBeenCalledWith(1);
+    expect(updateSpy).toHaveBeenCalledWith(1, { active: true });
+    expect(result).toBe(customer);
+  });
+
+  it('deactivates a customer', async () => {
+    const customer = {} as any;
+    const findOneSpy = jest
+      .spyOn(service, 'findOne')
+      .mockResolvedValue(customer);
+    const updateSpy = jest
+      .spyOn(service, 'update')
+      .mockResolvedValue(customer);
+
+    const result = await service.deactivate(2);
+
+    expect(findOneSpy).toHaveBeenCalledWith(2);
+    expect(updateSpy).toHaveBeenCalledWith(2, { active: false });
+    expect(result).toBe(customer);
+  });
 });


### PR DESCRIPTION
## Summary
- add PATCH /customers/:id/activate and /customers/:id/deactivate routes
- cover activate/deactivate flows with controller and service tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8c7505d483258f63158ecb81de9a