### PR TITLE
feat(auth): add refresh token persistence

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -15,6 +15,7 @@ describe('AuthController', () => {
     requestPasswordReset: jest.Mock;
     resetPassword: jest.Mock;
     refresh: jest.Mock;
+    logout: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -25,6 +26,7 @@ describe('AuthController', () => {
       requestPasswordReset: jest.fn(),
       resetPassword: jest.fn(),
       refresh: jest.fn(),
+      logout: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -78,9 +80,20 @@ describe('AuthController', () => {
   });
 
   it('refreshes token', async () => {
-    authService.refresh.mockResolvedValue({ access_token: 'new' });
+    authService.refresh.mockResolvedValue({
+      access_token: 'newAccess',
+      refresh_token: 'newRefresh',
+    });
     const result = await controller.refresh({ refreshToken: 'token' });
     expect(authService.refresh).toHaveBeenCalledWith('token');
-    expect(result).toEqual({ access_token: 'new' });
+    expect(result).toEqual({
+      access_token: 'newAccess',
+      refresh_token: 'newRefresh',
+    });
+  });
+
+  it('logs out', async () => {
+    await controller.logout({ refreshToken: 'token' });
+    expect(authService.logout).toHaveBeenCalledWith('token');
   });
 });

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -74,7 +74,8 @@ export class AuthController {
   @Post('logout')
   @ApiOperation({ summary: 'Logout current user' })
   @ApiResponse({ status: 200, description: 'Logged out' })
-  logout(): { message: string } {
+  async logout(@Body() dto: RefreshTokenDto): Promise<{ message: string }> {
+    await this.authService.logout(dto.refreshToken);
     return { message: 'Logged out' };
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,15 +1,18 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from '../users/users.module';
 import { JwtStrategy } from './jwt.strategy';
+import { RefreshToken } from './refresh-token.entity';
 
 @Module({
   imports: [
     UsersModule,
     ConfigModule,
+    TypeOrmModule.forFeature([RefreshToken]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,15 +1,21 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
 import { UsersService } from '../users/users.service';
 import { User, UserRole } from '../users/user.entity';
 import { RegisterDto } from './dto/register.dto';
 import { validatePasswordStrength } from './password.util';
+import { RefreshToken } from './refresh-token.entity';
 
 @Injectable()
 export class AuthService {
   constructor(
     private readonly usersService: UsersService,
     private readonly jwtService: JwtService,
+    @InjectRepository(RefreshToken)
+    private readonly refreshTokenRepository: Repository<RefreshToken>,
   ) {}
 
   async validateUser(username: string, pass: string): Promise<User> {
@@ -28,11 +34,13 @@ export class AuthService {
 
   async login(user: User) {
     const payload = { username: user.username, sub: user.id, role: user.role };
+    const refreshToken = await this.jwtService.signAsync(payload, {
+      expiresIn: '7d',
+    });
+    await this.saveRefreshToken(user.id, refreshToken);
     return {
       access_token: await this.jwtService.signAsync(payload),
-      refresh_token: await this.jwtService.signAsync(payload, {
-        expiresIn: '7d',
-      }),
+      refresh_token: refreshToken,
       user: {
         id: user.id,
         username: user.username,
@@ -57,7 +65,13 @@ export class AuthService {
     // Validate new password strength
     validatePasswordStrength(password);
 
-    await this.usersService.resetPassword(token, password);
+    const user = await this.usersService.resetPassword(token, password);
+    await this.refreshTokenRepository.update(
+      { userId: user.id },
+      {
+        isRevoked: true,
+      },
+    );
   }
 
   async refresh(token: string) {
@@ -67,15 +81,59 @@ export class AuthService {
         sub: number;
         role: UserRole;
       }>(token);
+      const hashed = this.hashToken(token);
+      const tokenEntity = await this.refreshTokenRepository.findOne({
+        where: { token: hashed, userId: payload.sub, isRevoked: false },
+      });
+      if (!tokenEntity || tokenEntity.expiresAt < new Date()) {
+        throw new UnauthorizedException('Invalid refresh token');
+      }
+      tokenEntity.isRevoked = true;
+      await this.refreshTokenRepository.save(tokenEntity);
+      const newRefresh = await this.jwtService.signAsync(
+        {
+          username: payload.username,
+          sub: payload.sub,
+          role: payload.role,
+        },
+        { expiresIn: '7d' },
+      );
+      await this.saveRefreshToken(payload.sub, newRefresh);
       return {
         access_token: await this.jwtService.signAsync({
           username: payload.username,
           sub: payload.sub,
           role: payload.role,
         }),
+        refresh_token: newRefresh,
       };
     } catch {
       throw new UnauthorizedException('Invalid refresh token');
     }
+  }
+
+  async logout(token: string): Promise<void> {
+    const hashed = this.hashToken(token);
+    await this.refreshTokenRepository.update(
+      { token: hashed },
+      {
+        isRevoked: true,
+      },
+    );
+  }
+
+  private hashToken(token: string): string {
+    return crypto.createHash('sha256').update(token).digest('hex');
+  }
+
+  private async saveRefreshToken(userId: number, token: string): Promise<void> {
+    const hashed = this.hashToken(token);
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    const entity = this.refreshTokenRepository.create({
+      token: hashed,
+      userId,
+      expiresAt,
+    });
+    await this.refreshTokenRepository.save(entity);
   }
 }

--- a/backend/src/auth/refresh-token.entity.ts
+++ b/backend/src/auth/refresh-token.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+
+@Entity()
+export class RefreshToken {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  token: string;
+
+  @Column({ type: 'timestamptz' })
+  expiresAt: Date;
+
+  @Column({ default: false })
+  isRevoked: boolean;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column()
+  userId: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/migrations/1719000000000-add-refresh-token.ts
+++ b/backend/src/migrations/1719000000000-add-refresh-token.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRefreshToken1719000000000 implements MigrationInterface {
+  name = 'AddRefreshToken1719000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "refresh_token" ("id" SERIAL NOT NULL, "token" character varying NOT NULL, "expiresAt" TIMESTAMP WITH TIME ZONE NOT NULL, "isRevoked" boolean NOT NULL DEFAULT false, "userId" integer NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_refresh_token_id" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "refresh_token" ADD CONSTRAINT "FK_refresh_token_user" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "refresh_token" DROP CONSTRAINT "FK_refresh_token_user"`,
+    );
+    await queryRunner.query(`DROP TABLE "refresh_token"`);
+  }
+}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -108,7 +108,7 @@ export class UsersService {
     await this.emailService.sendPasswordResetEmail(user.email, token);
   }
 
-  async resetPassword(token: string, password: string): Promise<void> {
+  async resetPassword(token: string, password: string): Promise<User> {
     const hashedToken = crypto.createHash('sha256').update(token).digest('hex');
     const user = await this.usersRepository.findOne({
       where: {
@@ -123,6 +123,7 @@ export class UsersService {
     user.passwordResetToken = null;
     user.passwordResetExpires = null;
     await this.usersRepository.save(user);
+    return user;
   }
 
   async updateProfile(id: number, dto: UpdateUserDto): Promise<User> {


### PR DESCRIPTION
## Summary
- add RefreshToken entity and migration
- persist refresh tokens and rotate on refresh
- revoke tokens on logout or password reset

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af94d44af083259e536a889c2d52bd