### PR TITLE
Scope resources by company and add company management

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -27,7 +27,12 @@ export class AuthService {
   }
 
   async login(user: User) {
-    const payload = { username: user.username, sub: user.id, role: user.role };
+    const payload = {
+      username: user.username,
+      sub: user.id,
+      role: user.role,
+      companyId: user.companyId,
+    };
     return {
       access_token: await this.jwtService.signAsync(payload),
       refresh_token: await this.jwtService.signAsync(payload, {
@@ -66,12 +71,14 @@ export class AuthService {
         username: string;
         sub: number;
         role: UserRole;
+        companyId: number;
       }>(token);
       return {
         access_token: await this.jwtService.signAsync({
           username: payload.username,
           sub: payload.sub,
           role: payload.role,
+          companyId: payload.companyId,
         }),
       };
     } catch {

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -8,6 +8,7 @@ interface JwtPayload {
   sub: number;
   username: string;
   role: UserRole;
+  companyId: number;
 }
 
 @Injectable()
@@ -25,6 +26,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       userId: payload.sub,
       username: payload.username,
       role: payload.role,
+      companyId: payload.companyId,
     };
   }
 }

--- a/backend/src/companies/companies.service.ts
+++ b/backend/src/companies/companies.service.ts
@@ -1,8 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Company } from './entities/company.entity';
 import { User, UserRole } from '../users/user.entity';
+import { CreateCompanyDto } from './dto/create-company.dto';
+import { UpdateCompanyDto } from './dto/update-company.dto';
 
 @Injectable()
 export class CompaniesService {
@@ -24,5 +26,20 @@ export class CompaniesService {
     return this.usersRepository.find({
       where: { companyId, role: UserRole.Worker },
     });
+  }
+
+  async create(
+    dto: CreateCompanyDto,
+    ownerId: number,
+  ): Promise<Company> {
+    const company = this.companyRepository.create({ ...dto, ownerId });
+    return this.companyRepository.save(company);
+  }
+
+  async update(id: number, dto: UpdateCompanyDto): Promise<Company> {
+    const company = await this.companyRepository.findOne({ where: { id } });
+    if (!company) throw new NotFoundException('Company not found');
+    Object.assign(company, dto);
+    return this.companyRepository.save(company);
   }
 }

--- a/backend/src/companies/dto/create-company.dto.ts
+++ b/backend/src/companies/dto/create-company.dto.ts
@@ -1,0 +1,7 @@
+import { IsString } from 'class-validator';
+
+export class CreateCompanyDto {
+  @IsString()
+  name: string;
+}
+

--- a/backend/src/companies/dto/update-company.dto.ts
+++ b/backend/src/companies/dto/update-company.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateCompanyDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+}
+

--- a/backend/src/companies/entities/company.entity.ts
+++ b/backend/src/companies/entities/company.entity.ts
@@ -7,6 +7,9 @@ import {
   JoinColumn,
 } from 'typeorm';
 import { User } from '../../users/user.entity';
+import { Customer } from '../../customers/entities/customer.entity';
+import { Equipment } from '../../equipment/entities/equipment.entity';
+import { Job } from '../../jobs/entities/job.entity';
 
 @Entity()
 export class Company {
@@ -25,4 +28,13 @@ export class Company {
 
   @OneToMany(() => User, (user) => user.company)
   users: User[];
+
+  @OneToMany(() => Customer, (customer) => customer.company)
+  customers: Customer[];
+
+  @OneToMany(() => Equipment, (equipment) => equipment.company)
+  equipment: Equipment[];
+
+  @OneToMany(() => Job, (job) => job.company)
+  jobs: Job[];
 }

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -44,8 +44,12 @@ export class CustomersController {
   })
   async create(
     @Body() createCustomerDto: CreateCustomerDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.create(createCustomerDto);
+    return this.customersService.create(
+      createCustomerDto,
+      req.user.companyId,
+    );
   }
 
   @Get()
@@ -56,8 +60,12 @@ export class CustomersController {
   @ApiResponse({ status: 200, description: 'List of customers' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<{ items: CustomerResponseDto[]; total: number }> {
-    return this.customersService.findAll(pagination);
+    return this.customersService.findAll(
+      pagination,
+      req.user.companyId,
+    );
   }
 
   @Get('profile')
@@ -69,9 +77,12 @@ export class CustomersController {
     type: CustomerResponseDto,
   })
   async getProfile(
-    @Req() req: { user: { userId: number } },
+    @Req() req: { user: { userId: number; companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.findByUserId(req.user.userId);
+    return this.customersService.findByUserId(
+      req.user.userId,
+      req.user.companyId,
+    );
   }
 
   @Get(':id')
@@ -84,8 +95,9 @@ export class CustomersController {
   })
   async findOne(
     @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.findOne(id);
+    return this.customersService.findOne(id, req.user.companyId);
   }
 
   @Patch(':id')
@@ -99,8 +111,13 @@ export class CustomersController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateCustomerDto: UpdateCustomerDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.update(id, updateCustomerDto);
+    return this.customersService.update(
+      id,
+      updateCustomerDto,
+      req.user.companyId,
+    );
   }
 
   @Delete(':id')
@@ -108,7 +125,10 @@ export class CustomersController {
   @Roles(UserRole.Admin)
   @ApiOperation({ summary: 'Delete customer' })
   @ApiResponse({ status: 204, description: 'Customer deleted' })
-  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
-    await this.customersService.remove(id);
+  async remove(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
+  ): Promise<void> {
+    await this.customersService.remove(id, req.user.companyId);
   }
 }

--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -52,12 +52,11 @@ describe('CustomersService', () => {
       ],
     };
 
-    await expect(service.create(createCustomerDto)).rejects.toBeInstanceOf(
-      ConflictException,
-    );
-    await expect(service.create(createCustomerDto)).rejects.toHaveProperty(
-      'message',
-      'Email already exists',
-    );
+    await expect(
+      service.create(createCustomerDto, 1),
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.create(createCustomerDto, 1),
+    ).rejects.toHaveProperty('message', 'Email already exists');
   });
 });

--- a/backend/src/customers/entities/customer.entity.ts
+++ b/backend/src/customers/entities/customer.entity.ts
@@ -1,6 +1,7 @@
 import { Job } from '../../jobs/entities/job.entity';
 import { Address } from './address.entity';
 import { User } from '../../users/user.entity';
+import { Company } from '../../companies/entities/company.entity';
 
 import {
   Entity,
@@ -12,6 +13,7 @@ import {
   OneToOne,
   JoinColumn,
   Index,
+  ManyToOne,
 } from 'typeorm';
 
 @Entity()
@@ -35,6 +37,15 @@ export class Customer {
 
   @Column({ type: 'boolean', default: true })
   active: boolean;
+
+  @Column()
+  companyId: number;
+
+  @ManyToOne(() => Company, (company) => company.customers, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'companyId' })
+  company: Company;
 
   @Column({ nullable: true })
   userId?: number;

--- a/backend/src/equipment/entities/equipment.entity.ts
+++ b/backend/src/equipment/entities/equipment.entity.ts
@@ -5,7 +5,10 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  ManyToOne,
+  JoinColumn,
 } from 'typeorm';
+import { Company } from '../../companies/entities/company.entity';
 
 export enum EquipmentType {
   MOWER = 'mower',
@@ -52,6 +55,15 @@ export class Equipment {
 
   @Column({ type: 'date', nullable: true })
   lastMaintenanceDate?: Date;
+
+  @Column()
+  companyId: number;
+
+  @ManyToOne(() => Company, (company) => company.equipment, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'companyId' })
+  company: Company;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -10,6 +10,7 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  Req,
 } from '@nestjs/common';
 import { EquipmentService } from './equipment.service';
 import { CreateEquipmentDto } from './dto/create-equipment.dto';
@@ -42,8 +43,12 @@ export class EquipmentController {
   })
   async create(
     @Body() createEquipmentDto: CreateEquipmentDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<EquipmentResponseDto> {
-    return this.equipmentService.create(createEquipmentDto);
+    return this.equipmentService.create(
+      createEquipmentDto,
+      req.user.companyId,
+    );
   }
 
   @Get()
@@ -54,8 +59,9 @@ export class EquipmentController {
   @ApiResponse({ status: 200, description: 'List of equipment' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
-    return this.equipmentService.findAll(pagination);
+    return this.equipmentService.findAll(pagination, req.user.companyId);
   }
 
   @Get(':id')
@@ -68,8 +74,9 @@ export class EquipmentController {
   })
   async findOne(
     @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<EquipmentResponseDto> {
-    return this.equipmentService.findOne(id);
+    return this.equipmentService.findOne(id, req.user.companyId);
   }
 
   @Patch(':id')
@@ -83,8 +90,13 @@ export class EquipmentController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateEquipmentDto: UpdateEquipmentDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<EquipmentResponseDto> {
-    return this.equipmentService.update(id, updateEquipmentDto);
+    return this.equipmentService.update(
+      id,
+      updateEquipmentDto,
+      req.user.companyId,
+    );
   }
 
   @Delete(':id')
@@ -92,7 +104,10 @@ export class EquipmentController {
   @Roles(UserRole.Admin, UserRole.Worker)
   @ApiOperation({ summary: 'Delete equipment' })
   @ApiResponse({ status: 204, description: 'Equipment deleted' })
-  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
-    await this.equipmentService.remove(id);
+  async remove(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
+  ): Promise<void> {
+    await this.equipmentService.remove(id, req.user.companyId);
   }
 }

--- a/backend/src/jobs/entities/job.entity.ts
+++ b/backend/src/jobs/entities/job.entity.ts
@@ -7,9 +7,11 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  JoinColumn,
 } from 'typeorm';
 import { Customer } from '../../customers/entities/customer.entity';
 import { Assignment } from './assignment.entity';
+import { Company } from '../../companies/entities/company.entity';
 
 @Entity()
 @Index(['scheduledDate', 'completed']) // Add index for common queries
@@ -38,6 +40,15 @@ export class Job {
 
   @Column({ type: 'text', nullable: true })
   notes?: string;
+
+  @Column()
+  companyId: number;
+
+  @ManyToOne(() => Company, (company) => company.jobs, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'companyId' })
+  company: Company;
 
   @ManyToOne(() => Customer, (customer) => customer.jobs, {
     onDelete: 'CASCADE',

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -10,6 +10,7 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  Req,
 } from '@nestjs/common';
 
 import { JobsService } from './jobs.service';
@@ -44,8 +45,11 @@ export class JobsController {
     description: 'Job created',
     type: JobResponseDto,
   })
-  create(@Body() createJobDto: CreateJobDto): Promise<JobResponseDto> {
-    return this.jobsService.create(createJobDto);
+  create(
+    @Body() createJobDto: CreateJobDto,
+    @Req() req: { user: { companyId: number } },
+  ): Promise<JobResponseDto> {
+    return this.jobsService.create(createJobDto, req.user.companyId);
   }
 
   @Get()
@@ -56,8 +60,9 @@ export class JobsController {
   @ApiResponse({ status: 200, description: 'List of jobs' })
   findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<{ items: JobResponseDto[]; total: number }> {
-    return this.jobsService.findAll(pagination);
+    return this.jobsService.findAll(pagination, req.user.companyId);
   }
 
   @Get(':id')
@@ -68,8 +73,11 @@ export class JobsController {
     description: 'Job retrieved',
     type: JobResponseDto,
   })
-  findOne(@Param('id', ParseIntPipe) id: number): Promise<JobResponseDto> {
-    return this.jobsService.findOne(id);
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
+  ): Promise<JobResponseDto> {
+    return this.jobsService.findOne(id, req.user.companyId);
   }
 
   @Patch(':id')
@@ -83,8 +91,9 @@ export class JobsController {
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateJobDto: UpdateJobDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<JobResponseDto> {
-    return this.jobsService.update(id, updateJobDto);
+    return this.jobsService.update(id, updateJobDto, req.user.companyId);
   }
 
   @Post(':id/schedule')
@@ -98,8 +107,9 @@ export class JobsController {
   schedule(
     @Param('id', ParseIntPipe) id: number,
     @Body() scheduleJobDto: ScheduleJobDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<JobResponseDto> {
-    return this.jobsService.schedule(id, scheduleJobDto);
+    return this.jobsService.schedule(id, scheduleJobDto, req.user.companyId);
   }
 
   @Post(':id/assign')
@@ -113,8 +123,9 @@ export class JobsController {
   assign(
     @Param('id', ParseIntPipe) id: number,
     @Body() assignJobDto: AssignJobDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<JobResponseDto> {
-    return this.jobsService.assign(id, assignJobDto);
+    return this.jobsService.assign(id, assignJobDto, req.user.companyId);
   }
 
   @Post(':id/bulk-assign')
@@ -128,8 +139,13 @@ export class JobsController {
   bulkAssign(
     @Param('id', ParseIntPipe) id: number,
     @Body() bulkAssignJobDto: BulkAssignJobDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<JobResponseDto> {
-    return this.jobsService.bulkAssign(id, bulkAssignJobDto);
+    return this.jobsService.bulkAssign(
+      id,
+      bulkAssignJobDto,
+      req.user.companyId,
+    );
   }
 
   @Delete(':id/assignments/:assignmentId')
@@ -143,8 +159,13 @@ export class JobsController {
   removeAssignment(
     @Param('id', ParseIntPipe) jobId: number,
     @Param('assignmentId', ParseIntPipe) assignmentId: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<JobResponseDto> {
-    return this.jobsService.removeAssignment(jobId, assignmentId);
+    return this.jobsService.removeAssignment(
+      jobId,
+      assignmentId,
+      req.user.companyId,
+    );
   }
 
   @Delete(':id')
@@ -152,7 +173,10 @@ export class JobsController {
   @Roles(UserRole.Admin, UserRole.Worker)
   @ApiOperation({ summary: 'Delete job' })
   @ApiResponse({ status: 204, description: 'Job deleted' })
-  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
-    await this.jobsService.remove(id);
+  async remove(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
+  ): Promise<void> {
+    await this.jobsService.remove(id, req.user.companyId);
   }
 }

--- a/backend/src/jobs/jobs.service.spec.ts
+++ b/backend/src/jobs/jobs.service.spec.ts
@@ -77,13 +77,10 @@ describe('JobsService', () => {
   });
 
   it('should throw NotFoundException when job does not exist', async () => {
-    const qb = {
-      leftJoinAndSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      getOne: jest.fn().mockResolvedValue(null),
-    };
-    jobRepository.createQueryBuilder.mockReturnValue(qb);
-    await expect(service.findOne(1)).rejects.toBeInstanceOf(NotFoundException);
+    jobRepository.findOne.mockResolvedValue(null);
+    await expect(service.findOne(1, 1)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
   });
 
   it('should throw NotFoundException when customer does not exist on create', async () => {
@@ -92,7 +89,7 @@ describe('JobsService', () => {
       title: 'Test',
       customerId: 1,
     };
-    await expect(service.create(createJobDto)).rejects.toBeInstanceOf(
+    await expect(service.create(createJobDto, 1)).rejects.toBeInstanceOf(
       NotFoundException,
     );
   });
@@ -119,9 +116,9 @@ describe('JobsService', () => {
     assignmentRepository.createQueryBuilder.mockReturnValue(qb);
 
     const scheduleJobDto: ScheduleJobDto = { scheduledDate: date };
-    await expect(service.schedule(1, scheduleJobDto)).rejects.toBeInstanceOf(
-      ConflictException,
-    );
+    await expect(
+      service.schedule(1, scheduleJobDto, 1),
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 
   it('should throw ConflictException when assigning user or equipment already booked', async () => {
@@ -143,8 +140,8 @@ describe('JobsService', () => {
     assignmentRepository.createQueryBuilder.mockReturnValue(qb);
 
     const assignJobDto: AssignJobDto = { userId: 1, equipmentId: 2 };
-    await expect(service.assign(1, assignJobDto)).rejects.toBeInstanceOf(
-      ConflictException,
-    );
+    await expect(
+      service.assign(1, assignJobDto, 1),
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/backend/src/migrations/1719000003000-add-companyid-to-entities.ts
+++ b/backend/src/migrations/1719000003000-add-companyid-to-entities.ts
@@ -1,0 +1,84 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableColumn,
+  TableForeignKey,
+} from 'typeorm';
+
+export class AddCompanyIdToEntities1719000003000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Customer
+    await queryRunner.addColumn(
+      'customer',
+      new TableColumn({ name: 'companyId', type: 'int' }),
+    );
+    await queryRunner.createForeignKey(
+      'customer',
+      new TableForeignKey({
+        columnNames: ['companyId'],
+        referencedTableName: 'company',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    // Equipment
+    await queryRunner.addColumn(
+      'equipment',
+      new TableColumn({ name: 'companyId', type: 'int' }),
+    );
+    await queryRunner.createForeignKey(
+      'equipment',
+      new TableForeignKey({
+        columnNames: ['companyId'],
+        referencedTableName: 'company',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    // Job
+    await queryRunner.addColumn(
+      'job',
+      new TableColumn({ name: 'companyId', type: 'int' }),
+    );
+    await queryRunner.createForeignKey(
+      'job',
+      new TableForeignKey({
+        columnNames: ['companyId'],
+        referencedTableName: 'company',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Job
+    const jobTable = await queryRunner.getTable('job');
+    const jobFk = jobTable!.foreignKeys.find((fk) =>
+      fk.columnNames.includes('companyId'),
+    );
+    if (jobFk) await queryRunner.dropForeignKey('job', jobFk);
+    await queryRunner.dropColumn('job', 'companyId');
+
+    // Equipment
+    const equipmentTable = await queryRunner.getTable('equipment');
+    const equipmentFk = equipmentTable!.foreignKeys.find((fk) =>
+      fk.columnNames.includes('companyId'),
+    );
+    if (equipmentFk) await queryRunner.dropForeignKey('equipment', equipmentFk);
+    await queryRunner.dropColumn('equipment', 'companyId');
+
+    // Customer
+    const customerTable = await queryRunner.getTable('customer');
+    const customerFk = customerTable!.foreignKeys.find((fk) =>
+      fk.columnNames.includes('companyId'),
+    );
+    if (customerFk) await queryRunner.dropForeignKey('customer', customerFk);
+    await queryRunner.dropColumn('customer', 'companyId');
+  }
+}
+


### PR DESCRIPTION
## Summary
- attach companies to customers, equipment, and jobs and filter queries by company
- expose company create/update endpoints guarded by Owner/Admin roles
- include companyId in JWT payload for per-company scoping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af94f2e9e08325a4fd6452187ff538