### PR TITLE
feat: add query filters to list endpoints

### DIFF
--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   Param,
   ParseIntPipe,
+  ParseBoolPipe,
   Query,
   HttpCode,
   HttpStatus,
@@ -53,11 +54,14 @@ export class CustomersController {
   @ApiOperation({ summary: 'List customers' })
   @ApiQuery({ name: 'page', required: false })
   @ApiQuery({ name: 'limit', required: false })
+  @ApiQuery({ name: 'active', required: false, type: Boolean })
   @ApiResponse({ status: 200, description: 'List of customers' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Query('active', new ParseBoolPipe({ optional: true }))
+    active?: boolean,
   ): Promise<{ items: CustomerResponseDto[]; total: number }> {
-    return this.customersService.findAll(pagination);
+    return this.customersService.findAll(pagination, active);
   }
 
   @Get('profile')

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   Param,
   ParseIntPipe,
+  ParseEnumPipe,
   Query,
   HttpCode,
   HttpStatus,
@@ -15,6 +16,7 @@ import { EquipmentService } from './equipment.service';
 import { CreateEquipmentDto } from './dto/create-equipment.dto';
 import { UpdateEquipmentDto } from './dto/update-equipment.dto';
 import { EquipmentResponseDto } from './dto/equipment-response.dto';
+import { EquipmentStatus, EquipmentType } from './entities/equipment.entity';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../users/user.entity';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
@@ -51,11 +53,17 @@ export class EquipmentController {
   @ApiOperation({ summary: 'List equipment' })
   @ApiQuery({ name: 'page', required: false })
   @ApiQuery({ name: 'limit', required: false })
+  @ApiQuery({ name: 'status', required: false, enum: EquipmentStatus })
+  @ApiQuery({ name: 'type', required: false, enum: EquipmentType })
   @ApiResponse({ status: 200, description: 'List of equipment' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Query('status', new ParseEnumPipe(EquipmentStatus, { optional: true }))
+    status?: EquipmentStatus,
+    @Query('type', new ParseEnumPipe(EquipmentType, { optional: true }))
+    type?: EquipmentType,
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
-    return this.equipmentService.findAll(pagination);
+    return this.equipmentService.findAll(pagination, status, type);
   }
 
   @Get(':id')

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Delete,
   ParseIntPipe,
+  ParseBoolPipe,
   Query,
   HttpCode,
   HttpStatus,
@@ -53,11 +54,17 @@ export class JobsController {
   @ApiOperation({ summary: 'List jobs' })
   @ApiQuery({ name: 'page', required: false })
   @ApiQuery({ name: 'limit', required: false })
+  @ApiQuery({ name: 'completed', required: false, type: Boolean })
+  @ApiQuery({ name: 'customerId', required: false, type: Number })
   @ApiResponse({ status: 200, description: 'List of jobs' })
   findAll(
     @Query() pagination: PaginationQueryDto,
+    @Query('completed', new ParseBoolPipe({ optional: true }))
+    completed?: boolean,
+    @Query('customerId', new ParseIntPipe({ optional: true }))
+    customerId?: number,
   ): Promise<{ items: JobResponseDto[]; total: number }> {
-    return this.jobsService.findAll(pagination);
+    return this.jobsService.findAll(pagination, completed, customerId);
   }
 
   @Get(':id')


### PR DESCRIPTION
## Summary
- allow filtering customers by active flag
- filter equipment by status and type
- filter jobs by completion and customer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af951a77f88325baa064e7257905f3