### PR TITLE
feat: add customer activation and equipment status endpoints

### DIFF
--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -103,6 +103,34 @@ export class CustomersController {
     return this.customersService.update(id, updateCustomerDto);
   }
 
+  @Patch(':id/activate')
+  @Roles(UserRole.Admin)
+  @ApiOperation({ summary: 'Activate customer' })
+  @ApiResponse({
+    status: 200,
+    description: 'Customer activated',
+    type: CustomerResponseDto,
+  })
+  async activate(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<CustomerResponseDto> {
+    return this.customersService.activate(id);
+  }
+
+  @Patch(':id/deactivate')
+  @Roles(UserRole.Admin)
+  @ApiOperation({ summary: 'Deactivate customer' })
+  @ApiResponse({
+    status: 200,
+    description: 'Customer deactivated',
+    type: CustomerResponseDto,
+  })
+  async deactivate(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<CustomerResponseDto> {
+    return this.customersService.deactivate(id);
+  }
+
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @Roles(UserRole.Admin)

--- a/backend/src/equipment/dto/update-equipment-status.dto.ts
+++ b/backend/src/equipment/dto/update-equipment-status.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { EquipmentStatus } from '../entities/equipment.entity';
+
+export class UpdateEquipmentStatusDto {
+  @ApiProperty({ enum: EquipmentStatus, example: EquipmentStatus.AVAILABLE })
+  @IsEnum(EquipmentStatus)
+  status: EquipmentStatus;
+}

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -15,6 +15,7 @@ import { EquipmentService } from './equipment.service';
 import { CreateEquipmentDto } from './dto/create-equipment.dto';
 import { UpdateEquipmentDto } from './dto/update-equipment.dto';
 import { EquipmentResponseDto } from './dto/equipment-response.dto';
+import { UpdateEquipmentStatusDto } from './dto/update-equipment-status.dto';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../users/user.entity';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
@@ -85,6 +86,24 @@ export class EquipmentController {
     @Body() updateEquipmentDto: UpdateEquipmentDto,
   ): Promise<EquipmentResponseDto> {
     return this.equipmentService.update(id, updateEquipmentDto);
+  }
+
+  @Patch(':id/status')
+  @Roles(UserRole.Admin, UserRole.Worker)
+  @ApiOperation({ summary: 'Update equipment status' })
+  @ApiResponse({
+    status: 200,
+    description: 'Equipment status updated',
+    type: EquipmentResponseDto,
+  })
+  async updateStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateEquipmentStatusDto: UpdateEquipmentStatusDto,
+  ): Promise<EquipmentResponseDto> {
+    return this.equipmentService.updateStatus(
+      id,
+      updateEquipmentStatusDto.status,
+    );
   }
 
   @Delete(':id')


### PR DESCRIPTION
## Summary
- add endpoints to activate and deactivate customers
- support updating equipment status with dedicated DTO

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af95294a288325b90ed590ea367ff0