### PR TITLE
Inject company context into job queries

### DIFF
--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -62,10 +62,15 @@ export class CustomersController {
   @ApiResponse({ status: 200, description: 'List of customers' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('active', new ParseBoolPipe({ optional: true }))
     active?: boolean,
   ): Promise<{ items: CustomerResponseDto[]; total: number }> {
-    return this.customersService.findAll(pagination, active);
+    return this.customersService.findAll(
+      pagination,
+      req.user.companyId,
+      active,
+    );
   }
 
   @Get('profile')
@@ -130,8 +135,9 @@ export class CustomersController {
   })
   async activate(
     @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.activate(id);
+    return this.customersService.activate(id, req.user.companyId);
   }
 
   @Patch(':id/deactivate')
@@ -144,8 +150,9 @@ export class CustomersController {
   })
   async deactivate(
     @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.deactivate(id);
+    return this.customersService.deactivate(id, req.user.companyId);
   }
 
   @Delete(':id')

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -64,12 +64,18 @@ export class EquipmentController {
   @ApiResponse({ status: 200, description: 'List of equipment' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('status', new ParseEnumPipe(EquipmentStatus, { optional: true }))
     status?: EquipmentStatus,
     @Query('type', new ParseEnumPipe(EquipmentType, { optional: true }))
     type?: EquipmentType,
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
-    return this.equipmentService.findAll(pagination, status, type);
+    return this.equipmentService.findAll(
+      pagination,
+      req.user.companyId,
+      status,
+      type,
+    );
   }
 
   @Get(':id')
@@ -118,10 +124,12 @@ export class EquipmentController {
   async updateStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateEquipmentStatusDto: UpdateEquipmentStatusDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<EquipmentResponseDto> {
     return this.equipmentService.updateStatus(
       id,
       updateEquipmentStatusDto.status,
+      req.user.companyId,
     );
   }
 

--- a/backend/src/jobs/jobs.controller.spec.ts
+++ b/backend/src/jobs/jobs.controller.spec.ts
@@ -4,14 +4,19 @@ import { JobsService } from './jobs.service';
 
 describe('JobsController', () => {
   let controller: JobsController;
+  let jobsService: { findAll: jest.Mock };
 
   beforeEach(async () => {
+    jobsService = {
+      findAll: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [JobsController],
       providers: [
         {
           provide: JobsService,
-          useValue: {},
+          useValue: jobsService,
         },
       ],
     }).compile();
@@ -21,5 +26,31 @@ describe('JobsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should call jobsService.findAll with companyId', async () => {
+      const pagination = { page: 1, limit: 10 } as any;
+      const completed = true;
+      const customerId = 2;
+      const req = { user: { companyId: 1 } } as any;
+      const result = { items: [], total: 0 };
+      jobsService.findAll.mockResolvedValue(result);
+
+      const response = await controller.findAll(
+        pagination,
+        req,
+        completed,
+        customerId,
+      );
+
+      expect(jobsService.findAll).toHaveBeenCalledWith(
+        pagination,
+        req.user.companyId,
+        completed,
+        customerId,
+      );
+      expect(response).toBe(result);
+    });
   });
 });

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -63,13 +63,18 @@ export class JobsController {
   @ApiResponse({ status: 200, description: 'List of jobs' })
   findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('completed', new ParseBoolPipe({ optional: true }))
     completed?: boolean,
     @Query('customerId', new ParseIntPipe({ optional: true }))
     customerId?: number,
   ): Promise<{ items: JobResponseDto[]; total: number }> {
-    return this.jobsService.findAll(pagination, completed, customerId);
-
+    return this.jobsService.findAll(
+      pagination,
+      req.user.companyId,
+      completed,
+      customerId,
+    );
   }
 
   @Get(':id')


### PR DESCRIPTION
## Summary
- Inject request object into jobs controller list endpoint and pass companyId to service
- Update unit tests and mocks to account for companyId
- Ensure equipment and customer controllers forward companyId to their services

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af9b58dd5883258fb791cba04bcb91