### PR TITLE
feat: scope equipment listing by company

### DIFF
--- a/backend/src/equipment/equipment.controller.spec.ts
+++ b/backend/src/equipment/equipment.controller.spec.ts
@@ -1,28 +1,48 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { EquipmentController } from './equipment.controller';
 import { EquipmentService } from './equipment.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { Equipment } from './entities/equipment.entity';
+import { EquipmentStatus, EquipmentType } from './entities/equipment.entity';
 
 describe('EquipmentController', () => {
   let controller: EquipmentController;
+  let service: EquipmentService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [EquipmentController],
       providers: [
-        EquipmentService,
         {
-          provide: getRepositoryToken(Equipment),
-          useValue: {},
+          provide: EquipmentService,
+          useValue: {
+            findAll: jest.fn(),
+          },
         },
       ],
     }).compile();
 
     controller = module.get<EquipmentController>(EquipmentController);
+    service = module.get<EquipmentService>(EquipmentService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should call equipmentService.findAll with companyId', async () => {
+    const pagination = { page: 1, limit: 10 };
+    const req = { user: { companyId: 1 } };
+    const status = EquipmentStatus.AVAILABLE;
+    const type = EquipmentType.MOWER;
+    const expectedResult = { items: [], total: 0 };
+    (service.findAll as jest.Mock).mockResolvedValue(expectedResult);
+
+    const result = await controller.findAll(pagination, req, status, type);
+    expect(result).toEqual(expectedResult);
+    expect(service.findAll).toHaveBeenCalledWith(
+      pagination,
+      req.user.companyId,
+      status,
+      type,
+    );
   });
 });

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -64,12 +64,18 @@ export class EquipmentController {
   @ApiResponse({ status: 200, description: 'List of equipment' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('status', new ParseEnumPipe(EquipmentStatus, { optional: true }))
     status?: EquipmentStatus,
     @Query('type', new ParseEnumPipe(EquipmentType, { optional: true }))
     type?: EquipmentType,
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
-    return this.equipmentService.findAll(pagination, status, type);
+    return this.equipmentService.findAll(
+      pagination,
+      req.user.companyId,
+      status,
+      type,
+    );
   }
 
   @Get(':id')
@@ -118,10 +124,12 @@ export class EquipmentController {
   async updateStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateEquipmentStatusDto: UpdateEquipmentStatusDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<EquipmentResponseDto> {
     return this.equipmentService.updateStatus(
       id,
       updateEquipmentStatusDto.status,
+      req.user.companyId,
     );
   }
 


### PR DESCRIPTION
## Summary
- capture request company ID in equipment controller's list route
- ensure equipment service `findAll` receives company context
- verify controller calls service with company ID

## Testing
- `npm test src/equipment/equipment.controller.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af9b5c2cbc8325892c26bad16e059a