### PR TITLE
Scope customer listing by authenticated company

### DIFF
--- a/backend/src/customers/customers.controller.spec.ts
+++ b/backend/src/customers/customers.controller.spec.ts
@@ -1,9 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CustomersController } from './customers.controller';
 import { CustomersService } from './customers.service';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 describe('CustomersController', () => {
   let controller: CustomersController;
+  let service: CustomersService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -11,15 +13,36 @@ describe('CustomersController', () => {
       providers: [
         {
           provide: CustomersService,
-          useValue: {},
+          useValue: {
+            findAll: jest.fn(),
+          },
         },
       ],
     }).compile();
 
     controller = module.get<CustomersController>(CustomersController);
+    service = module.get<CustomersService>(CustomersService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should call service with companyId and active flag', async () => {
+      const pagination = new PaginationQueryDto();
+      pagination.page = 1;
+      pagination.limit = 10;
+      const req = { user: { companyId: 1 } };
+      const result = { items: [], total: 0 };
+      const findAllSpy = jest
+        .spyOn(service, 'findAll')
+        .mockResolvedValue(result);
+
+      const response = await controller.findAll(pagination, req, true);
+
+      expect(findAllSpy).toHaveBeenCalledWith(pagination, 1, true);
+      expect(response).toBe(result);
+    });
   });
 });

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -47,25 +47,26 @@ export class CustomersController {
     @Body() createCustomerDto: CreateCustomerDto,
     @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.create(
-      createCustomerDto,
-      req.user.companyId,
-    );
+    return this.customersService.create(createCustomerDto, req.user.companyId);
   }
 
   @Get()
   @Roles(UserRole.Admin, UserRole.Worker)
-  @ApiOperation({ summary: 'List customers' })
+  @ApiOperation({ summary: 'List customers for the authenticated company' })
   @ApiQuery({ name: 'page', required: false })
   @ApiQuery({ name: 'limit', required: false })
   @ApiQuery({ name: 'active', required: false, type: Boolean })
   @ApiResponse({ status: 200, description: 'List of customers' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
-    @Query('active', new ParseBoolPipe({ optional: true }))
-    active?: boolean,
+    @Req() req: { user: { companyId: number } },
+    @Query('active', new ParseBoolPipe({ optional: true })) active?: boolean,
   ): Promise<{ items: CustomerResponseDto[]; total: number }> {
-    return this.customersService.findAll(pagination, active);
+    return this.customersService.findAll(
+      pagination,
+      req.user.companyId,
+      active,
+    );
   }
 
   @Get('profile')
@@ -130,8 +131,9 @@ export class CustomersController {
   })
   async activate(
     @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.activate(id);
+    return this.customersService.activate(id, req.user.companyId);
   }
 
   @Patch(':id/deactivate')
@@ -144,8 +146,9 @@ export class CustomersController {
   })
   async deactivate(
     @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.deactivate(id);
+    return this.customersService.deactivate(id, req.user.companyId);
   }
 
   @Delete(':id')

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -48,15 +48,12 @@ export class EquipmentController {
     @Body() createEquipmentDto: CreateEquipmentDto,
     @Req() req: { user: { companyId: number } },
   ): Promise<EquipmentResponseDto> {
-    return this.equipmentService.create(
-      createEquipmentDto,
-      req.user.companyId,
-    );
+    return this.equipmentService.create(createEquipmentDto, req.user.companyId);
   }
 
   @Get()
   @Roles(UserRole.Admin, UserRole.Worker, UserRole.Customer)
-  @ApiOperation({ summary: 'List equipment' })
+  @ApiOperation({ summary: 'List equipment for the authenticated company' })
   @ApiQuery({ name: 'page', required: false })
   @ApiQuery({ name: 'limit', required: false })
   @ApiQuery({ name: 'status', required: false, enum: EquipmentStatus })
@@ -64,12 +61,18 @@ export class EquipmentController {
   @ApiResponse({ status: 200, description: 'List of equipment' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('status', new ParseEnumPipe(EquipmentStatus, { optional: true }))
     status?: EquipmentStatus,
     @Query('type', new ParseEnumPipe(EquipmentType, { optional: true }))
     type?: EquipmentType,
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
-    return this.equipmentService.findAll(pagination, status, type);
+    return this.equipmentService.findAll(
+      pagination,
+      req.user.companyId,
+      status,
+      type,
+    );
   }
 
   @Get(':id')
@@ -118,10 +121,12 @@ export class EquipmentController {
   async updateStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateEquipmentStatusDto: UpdateEquipmentStatusDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<EquipmentResponseDto> {
     return this.equipmentService.updateStatus(
       id,
       updateEquipmentStatusDto.status,
+      req.user.companyId,
     );
   }
 

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -55,7 +55,7 @@ export class JobsController {
 
   @Get()
   @Roles(UserRole.Admin, UserRole.Worker, UserRole.Customer)
-  @ApiOperation({ summary: 'List jobs' })
+  @ApiOperation({ summary: 'List jobs for the authenticated company' })
   @ApiQuery({ name: 'page', required: false })
   @ApiQuery({ name: 'limit', required: false })
   @ApiQuery({ name: 'completed', required: false, type: Boolean })
@@ -63,13 +63,18 @@ export class JobsController {
   @ApiResponse({ status: 200, description: 'List of jobs' })
   findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('completed', new ParseBoolPipe({ optional: true }))
     completed?: boolean,
     @Query('customerId', new ParseIntPipe({ optional: true }))
     customerId?: number,
   ): Promise<{ items: JobResponseDto[]; total: number }> {
-    return this.jobsService.findAll(pagination, completed, customerId);
-
+    return this.jobsService.findAll(
+      pagination,
+      req.user.companyId,
+      completed,
+      customerId,
+    );
   }
 
   @Get(':id')


### PR DESCRIPTION
## Summary
- include request context in customers `findAll` and pass companyId to service
- document company-scoped listing endpoints and cover with a controller test
- align equipment and job listings/status updates with company scoping

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af9b67e0d08325a066a84a491758a5