### PR TITLE
Scope customer activation by company

### DIFF
--- a/backend/src/customers/customers.controller.spec.ts
+++ b/backend/src/customers/customers.controller.spec.ts
@@ -1,9 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CustomersController } from './customers.controller';
 import { CustomersService } from './customers.service';
+import { CustomerResponseDto } from './dto/customer-response.dto';
 
 describe('CustomersController', () => {
   let controller: CustomersController;
+  let service: { activate: jest.Mock };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -11,15 +13,27 @@ describe('CustomersController', () => {
       providers: [
         {
           provide: CustomersService,
-          useValue: {},
+          useValue: {
+            activate: jest.fn(),
+          },
         },
       ],
     }).compile();
 
     controller = module.get<CustomersController>(CustomersController);
+    service = module.get(CustomersService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('activates a customer scoped to company', async () => {
+    const customer = {} as CustomerResponseDto;
+    service.activate.mockResolvedValue(customer);
+    const req = { user: { companyId: 1 } };
+    const result = await controller.activate(10, req as any);
+    expect(result).toBe(customer);
+    expect(service.activate).toHaveBeenCalledWith(10, 1);
   });
 });

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -62,10 +62,15 @@ export class CustomersController {
   @ApiResponse({ status: 200, description: 'List of customers' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('active', new ParseBoolPipe({ optional: true }))
     active?: boolean,
   ): Promise<{ items: CustomerResponseDto[]; total: number }> {
-    return this.customersService.findAll(pagination, active);
+    return this.customersService.findAll(
+      pagination,
+      req.user.companyId,
+      active,
+    );
   }
 
   @Get('profile')
@@ -130,8 +135,9 @@ export class CustomersController {
   })
   async activate(
     @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.activate(id);
+    return this.customersService.activate(id, req.user.companyId);
   }
 
   @Patch(':id/deactivate')
@@ -144,8 +150,9 @@ export class CustomersController {
   })
   async deactivate(
     @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.deactivate(id);
+    return this.customersService.deactivate(id, req.user.companyId);
   }
 
   @Delete(':id')


### PR DESCRIPTION
## Summary
- scope customer listing, activation, and deactivation to the requesting company
- add controller unit test verifying activation uses companyId

## Testing
- `npm test src/customers/customers.controller.spec.ts`
- `npm test` *(fails: equipment.controller.spec.ts, jobs.controller.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68af9b6fbc608325a94eb72bdf8d07fc