### PR TITLE
feat: add job filtering options

### DIFF
--- a/backend/src/jobs/jobs.controller.spec.ts
+++ b/backend/src/jobs/jobs.controller.spec.ts
@@ -4,14 +4,16 @@ import { JobsService } from './jobs.service';
 
 describe('JobsController', () => {
   let controller: JobsController;
+  let jobsService: { findAll: jest.Mock };
 
   beforeEach(async () => {
+    jobsService = { findAll: jest.fn() };
     const module: TestingModule = await Test.createTestingModule({
       controllers: [JobsController],
       providers: [
         {
           provide: JobsService,
-          useValue: {},
+          useValue: jobsService,
         },
       ],
     }).compile();
@@ -21,5 +23,31 @@ describe('JobsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should forward filters to service.findAll', async () => {
+    jobsService.findAll.mockResolvedValue({ items: [], total: 0 });
+    const pagination = { page: 1, limit: 10 } as any;
+    const result = await controller.findAll(
+      pagination,
+      { user: { companyId: 1 } },
+      true,
+      2,
+      '2023-01-01',
+      '2023-01-31',
+      3,
+      4,
+    );
+    expect(jobsService.findAll).toHaveBeenCalledWith(
+      pagination,
+      1,
+      true,
+      2,
+      new Date('2023-01-01'),
+      new Date('2023-01-31'),
+      3,
+      4,
+    );
+    expect(result).toEqual({ items: [], total: 0 });
   });
 });

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -60,16 +60,34 @@ export class JobsController {
   @ApiQuery({ name: 'limit', required: false })
   @ApiQuery({ name: 'completed', required: false, type: Boolean })
   @ApiQuery({ name: 'customerId', required: false, type: Number })
+  @ApiQuery({ name: 'startDate', required: false, type: String })
+  @ApiQuery({ name: 'endDate', required: false, type: String })
+  @ApiQuery({ name: 'workerId', required: false, type: Number })
+  @ApiQuery({ name: 'equipmentId', required: false, type: Number })
   @ApiResponse({ status: 200, description: 'List of jobs' })
   findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('completed', new ParseBoolPipe({ optional: true }))
     completed?: boolean,
     @Query('customerId', new ParseIntPipe({ optional: true }))
     customerId?: number,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+    @Query('workerId', new ParseIntPipe({ optional: true })) workerId?: number,
+    @Query('equipmentId', new ParseIntPipe({ optional: true }))
+    equipmentId?: number,
   ): Promise<{ items: JobResponseDto[]; total: number }> {
-    return this.jobsService.findAll(pagination, completed, customerId);
-
+    return this.jobsService.findAll(
+      pagination,
+      req.user.companyId,
+      completed,
+      customerId,
+      startDate ? new Date(startDate) : undefined,
+      endDate ? new Date(endDate) : undefined,
+      workerId,
+      equipmentId,
+    );
   }
 
   @Get(':id')

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -58,6 +58,10 @@ export class JobsService {
     companyId: number,
     completed?: boolean,
     customerId?: number,
+    startDate?: Date,
+    endDate?: Date,
+    workerId?: number,
+    equipmentId?: number,
   ): Promise<{ items: JobResponseDto[]; total: number }> {
     const { page = 1, limit = 10 } = pagination;
     const cappedLimit = Math.min(limit, 100);
@@ -75,6 +79,22 @@ export class JobsService {
 
     if (customerId) {
       queryBuilder.andWhere('job.customer.id = :customerId', { customerId });
+    }
+
+    if (startDate) {
+      queryBuilder.andWhere('job.scheduledDate >= :startDate', { startDate });
+    }
+
+    if (endDate) {
+      queryBuilder.andWhere('job.scheduledDate <= :endDate', { endDate });
+    }
+
+    if (workerId) {
+      queryBuilder.andWhere('user.id = :workerId', { workerId });
+    }
+
+    if (equipmentId) {
+      queryBuilder.andWhere('equipment.id = :equipmentId', { equipmentId });
     }
 
     const [jobs, total] = await queryBuilder


### PR DESCRIPTION
## Summary
- support filtering jobs by date range, worker, and equipment
- constrain job queries in service based on new filters
- document and test additional filtering options

## Testing
- `npm test src/jobs/jobs.service.spec.ts src/jobs/jobs.controller.spec.ts`
- `npm test` *(fails: Argument of type 'EquipmentStatus | undefined' is not assignable to parameter of type 'number')*

------
https://chatgpt.com/codex/tasks/task_e_68af9bd0152883259166453cdff54f64