### PR TITLE
Add search filter to equipment list

### DIFF
--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -62,10 +62,11 @@ export class CustomersController {
   @ApiResponse({ status: 200, description: 'List of customers' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('active', new ParseBoolPipe({ optional: true }))
     active?: boolean,
   ): Promise<{ items: CustomerResponseDto[]; total: number }> {
-    return this.customersService.findAll(pagination, active);
+    return this.customersService.findAll(pagination, req.user.companyId, active);
   }
 
   @Get('profile')
@@ -130,8 +131,9 @@ export class CustomersController {
   })
   async activate(
     @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.activate(id);
+    return this.customersService.activate(id, req.user.companyId);
   }
 
   @Patch(':id/deactivate')
@@ -144,8 +146,9 @@ export class CustomersController {
   })
   async deactivate(
     @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
   ): Promise<CustomerResponseDto> {
-    return this.customersService.deactivate(id);
+    return this.customersService.deactivate(id, req.user.companyId);
   }
 
   @Delete(':id')

--- a/backend/src/equipment/equipment.controller.spec.ts
+++ b/backend/src/equipment/equipment.controller.spec.ts
@@ -3,9 +3,11 @@ import { EquipmentController } from './equipment.controller';
 import { EquipmentService } from './equipment.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Equipment } from './entities/equipment.entity';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 describe('EquipmentController', () => {
   let controller: EquipmentController;
+  let service: EquipmentService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -20,9 +22,33 @@ describe('EquipmentController', () => {
     }).compile();
 
     controller = module.get<EquipmentController>(EquipmentController);
+    service = module.get<EquipmentService>(EquipmentService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should pass search query to service', async () => {
+    const findAllSpy = jest
+      .spyOn(service, 'findAll')
+      .mockResolvedValue({ items: [], total: 0 });
+
+    const pagination: PaginationQueryDto = { page: 1, limit: 10 };
+    await controller.findAll(
+      pagination,
+      { user: { companyId: 1 } },
+      undefined,
+      undefined,
+      'tractor',
+    );
+
+    expect(findAllSpy).toHaveBeenCalledWith(
+      pagination,
+      1,
+      undefined,
+      undefined,
+      'tractor',
+    );
   });
 });

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -61,15 +61,28 @@ export class EquipmentController {
   @ApiQuery({ name: 'limit', required: false })
   @ApiQuery({ name: 'status', required: false, enum: EquipmentStatus })
   @ApiQuery({ name: 'type', required: false, enum: EquipmentType })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    description: 'Filter by name or description fragment',
+  })
   @ApiResponse({ status: 200, description: 'List of equipment' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('status', new ParseEnumPipe(EquipmentStatus, { optional: true }))
     status?: EquipmentStatus,
     @Query('type', new ParseEnumPipe(EquipmentType, { optional: true }))
     type?: EquipmentType,
+    @Query('search') search?: string,
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
-    return this.equipmentService.findAll(pagination, status, type);
+    return this.equipmentService.findAll(
+      pagination,
+      req.user.companyId,
+      status,
+      type,
+      search,
+    );
   }
 
   @Get(':id')
@@ -118,10 +131,12 @@ export class EquipmentController {
   async updateStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateEquipmentStatusDto: UpdateEquipmentStatusDto,
+    @Req() req: { user: { companyId: number } },
   ): Promise<EquipmentResponseDto> {
     return this.equipmentService.updateStatus(
       id,
       updateEquipmentStatusDto.status,
+      req.user.companyId,
     );
   }
 

--- a/backend/src/equipment/equipment.service.spec.ts
+++ b/backend/src/equipment/equipment.service.spec.ts
@@ -2,25 +2,52 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { EquipmentService } from './equipment.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Equipment } from './entities/equipment.entity';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 describe('EquipmentService', () => {
   let service: EquipmentService;
+  let equipmentRepository: {
+    createQueryBuilder: jest.Mock;
+  };
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        EquipmentService,
-        {
-          provide: getRepositoryToken(Equipment),
-          useValue: {},
-        },
-      ],
-    }).compile();
+    beforeEach(async () => {
+      equipmentRepository = {
+        createQueryBuilder: jest.fn(),
+      };
 
-    service = module.get<EquipmentService>(EquipmentService);
-  });
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          EquipmentService,
+          {
+            provide: getRepositoryToken(Equipment),
+            useValue: equipmentRepository,
+          },
+        ],
+      }).compile();
+
+      service = module.get<EquipmentService>(EquipmentService);
+    });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('applies search filter when provided', async () => {
+    const qb = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+    equipmentRepository.createQueryBuilder.mockReturnValue(qb);
+
+    const pagination: PaginationQueryDto = { page: 1, limit: 10 };
+    await service.findAll(pagination, 1, undefined, undefined, 'mower');
+
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      '(equipment.name ILIKE :search OR equipment.description ILIKE :search)',
+      { search: '%mower%' },
+    );
   });
 });

--- a/backend/src/equipment/equipment.service.ts
+++ b/backend/src/equipment/equipment.service.ts
@@ -35,6 +35,7 @@ export class EquipmentService {
     companyId: number,
     status?: EquipmentStatus,
     type?: string,
+    search?: string,
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
     const { page = 1, limit = 10 } = pagination;
     const cappedLimit = Math.min(limit, 100);
@@ -48,6 +49,13 @@ export class EquipmentService {
 
     if (type) {
       queryBuilder.andWhere('equipment.type = :type', { type });
+    }
+
+    if (search) {
+      queryBuilder.andWhere(
+        '(equipment.name ILIKE :search OR equipment.description ILIKE :search)',
+        { search: `%${search}%` },
+      );
     }
 
     const [equipments, total] = await queryBuilder

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -63,13 +63,18 @@ export class JobsController {
   @ApiResponse({ status: 200, description: 'List of jobs' })
   findAll(
     @Query() pagination: PaginationQueryDto,
+    @Req() req: { user: { companyId: number } },
     @Query('completed', new ParseBoolPipe({ optional: true }))
     completed?: boolean,
     @Query('customerId', new ParseIntPipe({ optional: true }))
     customerId?: number,
   ): Promise<{ items: JobResponseDto[]; total: number }> {
-    return this.jobsService.findAll(pagination, completed, customerId);
-
+    return this.jobsService.findAll(
+      pagination,
+      req.user.companyId,
+      completed,
+      customerId,
+    );
   }
 
   @Get(':id')


### PR DESCRIPTION
## Summary
- allow filtering equipment by name or description via `search` query
- document search filter in Swagger and unit tests
- align controllers with service signatures for company scoping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af9bb08ef88325a632e1581a564e23