### PR TITLE
feat: add recurring contracts scheduler

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^11.0.0",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.0.0",
         "@nestjs/swagger": "^11.2.0",
         "@nestjs/throttler": "^6.4.0",
         "@nestjs/typeorm": "^11.0.0",
@@ -1476,7 +1477,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -1489,7 +1490,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2695,7 +2696,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2716,7 +2717,7 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
       "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2729,13 +2730,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@keyv/serialize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
-      "integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -3490,6 +3484,19 @@
       "peerDependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/schematics": {
@@ -4833,28 +4840,28 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -5071,6 +5078,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -5981,27 +5994,13 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -6018,7 +6017,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -6257,7 +6256,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -6731,16 +6730,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cache-manager": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.1.1.tgz",
-      "integrity": "sha512-YZ5CXZ4cNOcVH5bokYE1Bo5NARvJhOkYAAwImGf7DozC0uyrT5Jqd5AWfPnSRavlHTPiHp2yZL3Q3ZEWBfkQvQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "keyv": "^5.5.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -7396,8 +7385,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/cross-env": {
       "version": "10.0.0",
@@ -7613,7 +7615,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -10566,16 +10568,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/keyv": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.0.tgz",
-      "integrity": "sha512-QG7qR2tijh1ftOvClut4YKKg1iW6cx3GZsKoGyJPxHkGWK9oJhG9P3j5deP0QQOGDowBMVQFaP+Vm4NpGYvmIQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@keyv/serialize": "^1.1.0"
-      }
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -10812,6 +10804,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -10842,7 +10843,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -13812,7 +13813,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -14196,7 +14197,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -14363,7 +14364,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -14452,56 +14453,6 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/webpack": {
-      "version": "5.100.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
-      "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.8",
-        "@types/json-schema": "^7.0.15",
-        "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.24.0",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.3.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/webpack-node-externals": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
@@ -14520,137 +14471,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/webpack/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/whatwg-url": {
@@ -14937,7 +14757,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^11.0.0",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { EquipmentModule } from './equipment/equipment.module';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { CompaniesModule } from './companies/companies.module';
+import { ContractsModule } from './contracts/contracts.module';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
@@ -23,12 +24,14 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { LoggerModule } from './logger/logger.module';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { MetricsModule } from './metrics/metrics.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
     PrometheusModule.register(),
     LoggerModule,
     MetricsModule,
+    ScheduleModule.forRoot(),
     ConfigModule.forRoot({
       envFilePath: `.env.${process.env.NODE_ENV || 'development'}`,
       isGlobal: true,
@@ -105,6 +108,7 @@ import { MetricsModule } from './metrics/metrics.module';
     UsersModule,
     AuthModule,
     CompaniesModule,
+    ContractsModule,
   ],
   controllers: [],
   providers: [

--- a/backend/src/companies/entities/company.entity.ts
+++ b/backend/src/companies/entities/company.entity.ts
@@ -10,6 +10,7 @@ import { User } from '../../users/user.entity';
 import { Customer } from '../../customers/entities/customer.entity';
 import { Equipment } from '../../equipment/entities/equipment.entity';
 import { Job } from '../../jobs/entities/job.entity';
+import { Contract } from '../../contracts/entities/contract.entity';
 
 @Entity()
 export class Company {
@@ -37,4 +38,7 @@ export class Company {
 
   @OneToMany(() => Job, (job) => job.company)
   jobs: Job[];
+
+  @OneToMany(() => Contract, (contract) => contract.company)
+  contracts: Contract[];
 }

--- a/backend/src/contracts/contract-scheduler.service.ts
+++ b/backend/src/contracts/contract-scheduler.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ContractsService } from './contracts.service';
+
+@Injectable()
+export class ContractScheduler {
+  constructor(private readonly contractsService: ContractsService) {}
+
+  @Cron('0 0 * * *')
+  async handleCron(): Promise<void> {
+    await this.contractsService.generateUpcomingJobs();
+  }
+}

--- a/backend/src/contracts/contracts.controller.ts
+++ b/backend/src/contracts/contracts.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Body,
+  Param,
+  Req,
+  ParseIntPipe,
+} from '@nestjs/common';
+import { ContractsService } from './contracts.service';
+import { CreateContractDto } from './dto/create-contract.dto';
+import { UpdateContractDto } from './dto/update-contract.dto';
+import { ContractResponseDto } from './dto/contract-response.dto';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '../users/user.entity';
+import {
+  ApiBearerAuth,
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
+
+@ApiTags('contracts')
+@ApiBearerAuth()
+@Controller('contracts')
+export class ContractsController {
+  constructor(private readonly contractsService: ContractsService) {}
+
+  @Post()
+  @Roles(UserRole.Admin)
+  @ApiOperation({ summary: 'Create contract' })
+  @ApiResponse({ status: 201, type: ContractResponseDto })
+  create(
+    @Body() dto: CreateContractDto,
+    @Req() req: { user: { companyId: number } },
+  ): Promise<ContractResponseDto> {
+    return this.contractsService.create(dto, req.user.companyId);
+  }
+
+  @Get()
+  @Roles(UserRole.Admin, UserRole.Worker)
+  @ApiOperation({ summary: 'List contracts' })
+  @ApiResponse({ status: 200, type: [ContractResponseDto] })
+  findAll(
+    @Req() req: { user: { companyId: number } },
+  ): Promise<ContractResponseDto[]> {
+    return this.contractsService.findAll(req.user.companyId);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.Admin)
+  @ApiOperation({ summary: 'Update contract' })
+  @ApiResponse({ status: 200, type: ContractResponseDto })
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateContractDto,
+    @Req() req: { user: { companyId: number } },
+  ): Promise<ContractResponseDto> {
+    return this.contractsService.update(id, dto, req.user.companyId);
+  }
+
+  @Post(':id/cancel')
+  @Roles(UserRole.Admin)
+  @ApiOperation({ summary: 'Cancel contract' })
+  @ApiResponse({ status: 200, description: 'Contract cancelled' })
+  cancel(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: { user: { companyId: number } },
+  ): Promise<void> {
+    return this.contractsService.cancel(id, req.user.companyId);
+  }
+}

--- a/backend/src/contracts/contracts.module.ts
+++ b/backend/src/contracts/contracts.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ContractsService } from './contracts.service';
+import { ContractsController } from './contracts.controller';
+import { Contract } from './entities/contract.entity';
+import { Customer } from '../customers/entities/customer.entity';
+import { Job } from '../jobs/entities/job.entity';
+import { ContractScheduler } from './contract-scheduler.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Contract, Customer, Job])],
+  controllers: [ContractsController],
+  providers: [ContractsService, ContractScheduler],
+  exports: [ContractsService],
+})
+export class ContractsModule {}

--- a/backend/src/contracts/contracts.service.ts
+++ b/backend/src/contracts/contracts.service.ts
@@ -1,0 +1,167 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Contract, ContractFrequency } from './entities/contract.entity';
+import { Customer } from '../customers/entities/customer.entity';
+import { Job } from '../jobs/entities/job.entity';
+import { CreateContractDto } from './dto/create-contract.dto';
+import { UpdateContractDto } from './dto/update-contract.dto';
+import { ContractResponseDto } from './dto/contract-response.dto';
+
+@Injectable()
+export class ContractsService {
+  constructor(
+    @InjectRepository(Contract)
+    private readonly contractRepository: Repository<Contract>,
+    @InjectRepository(Customer)
+    private readonly customerRepository: Repository<Customer>,
+    @InjectRepository(Job)
+    private readonly jobRepository: Repository<Job>,
+  ) {}
+
+  async create(
+    dto: CreateContractDto,
+    companyId: number,
+  ): Promise<ContractResponseDto> {
+    const customer = await this.customerRepository.findOne({
+      where: { id: dto.customerId, companyId },
+    });
+    if (!customer) {
+      throw new NotFoundException(
+        `Customer with ID ${dto.customerId} not found.`,
+      );
+    }
+    const contract = this.contractRepository.create({
+      customer,
+      companyId,
+      startDate: dto.startDate,
+      endDate: dto.endDate,
+      frequency: dto.frequency,
+      totalOccurrences: dto.totalOccurrences,
+      jobTemplate: dto.jobTemplate,
+    });
+    const saved = await this.contractRepository.save(contract);
+    await this.generateJobsForContract(saved);
+    return this.toResponseDto(saved);
+  }
+
+  async findAll(companyId: number): Promise<ContractResponseDto[]> {
+    const contracts = await this.contractRepository.find({
+      where: { companyId },
+      relations: ['customer'],
+    });
+    return contracts.map((c) => this.toResponseDto(c));
+  }
+
+  async update(
+    id: number,
+    dto: UpdateContractDto,
+    companyId: number,
+  ): Promise<ContractResponseDto> {
+    const contract = await this.contractRepository.findOne({
+      where: { id, companyId },
+      relations: ['customer'],
+    });
+    if (!contract) {
+      throw new NotFoundException(`Contract with ID ${id} not found.`);
+    }
+    if (dto.customerId !== undefined) {
+      const customer = await this.customerRepository.findOne({
+        where: { id: dto.customerId, companyId },
+      });
+      if (!customer) {
+        throw new NotFoundException(
+          `Customer with ID ${dto.customerId} not found.`,
+        );
+      }
+      contract.customer = customer;
+    }
+    Object.assign(contract, {
+      startDate: dto.startDate ?? contract.startDate,
+      endDate: dto.endDate ?? contract.endDate,
+      frequency: dto.frequency ?? contract.frequency,
+      totalOccurrences: dto.totalOccurrences ?? contract.totalOccurrences,
+      jobTemplate: dto.jobTemplate ?? contract.jobTemplate,
+    });
+    const saved = await this.contractRepository.save(contract);
+    await this.generateJobsForContract(saved);
+    return this.toResponseDto(saved);
+  }
+
+  async cancel(id: number, companyId: number): Promise<void> {
+    const contract = await this.contractRepository.findOne({
+      where: { id, companyId },
+    });
+    if (!contract) {
+      throw new NotFoundException(`Contract with ID ${id} not found.`);
+    }
+    contract.active = false;
+    await this.contractRepository.save(contract);
+  }
+
+  async generateJobsForContract(contract: Contract): Promise<void> {
+    if (!contract.active) return;
+    const now = new Date();
+    let nextDate = contract.lastGeneratedDate
+      ? this.addFrequency(contract.lastGeneratedDate, contract.frequency)
+      : new Date(contract.startDate);
+    while (
+      nextDate <= now &&
+      (!contract.endDate || nextDate <= contract.endDate) &&
+      (contract.totalOccurrences === undefined ||
+        contract.occurrencesGenerated < contract.totalOccurrences)
+    ) {
+      const job = this.jobRepository.create({
+        title: contract.jobTemplate.title,
+        description: contract.jobTemplate.description,
+        estimatedHours: contract.jobTemplate.estimatedHours,
+        notes: contract.jobTemplate.notes,
+        scheduledDate: nextDate,
+        customer: contract.customer,
+        companyId: contract.companyId,
+        contract: { id: contract.id } as Contract,
+      });
+      await this.jobRepository.save(job);
+      contract.lastGeneratedDate = nextDate;
+      contract.occurrencesGenerated += 1;
+      nextDate = this.addFrequency(nextDate, contract.frequency);
+    }
+    await this.contractRepository.save(contract);
+  }
+
+  async generateUpcomingJobs(): Promise<void> {
+    const contracts = await this.contractRepository.find({
+      where: { active: true },
+      relations: ['customer'],
+    });
+    for (const contract of contracts) {
+      await this.generateJobsForContract(contract);
+    }
+  }
+
+  private addFrequency(date: Date, frequency: ContractFrequency): Date {
+    const result = new Date(date);
+    const days = frequency === ContractFrequency.WEEKLY ? 7 : 14;
+    result.setDate(result.getDate() + days);
+    return result;
+  }
+
+  private toResponseDto(contract: Contract): ContractResponseDto {
+    return {
+      id: contract.id,
+      startDate: contract.startDate,
+      endDate: contract.endDate,
+      frequency: contract.frequency,
+      totalOccurrences: contract.totalOccurrences,
+      occurrencesGenerated: contract.occurrencesGenerated,
+      jobTemplate: contract.jobTemplate,
+      lastGeneratedDate: contract.lastGeneratedDate,
+      active: contract.active,
+      customer: {
+        id: contract.customer.id,
+        name: contract.customer.name,
+        email: contract.customer.email,
+      },
+    };
+  }
+}

--- a/backend/src/contracts/dto/contract-response.dto.ts
+++ b/backend/src/contracts/dto/contract-response.dto.ts
@@ -1,0 +1,23 @@
+import { ContractFrequency } from '../entities/contract.entity';
+
+export class ContractResponseDto {
+  id: number;
+  startDate: Date;
+  endDate?: Date;
+  frequency: ContractFrequency;
+  totalOccurrences?: number;
+  occurrencesGenerated: number;
+  jobTemplate: {
+    title: string;
+    description?: string;
+    estimatedHours?: number;
+    notes?: string;
+  };
+  lastGeneratedDate?: Date;
+  active: boolean;
+  customer: {
+    id: number;
+    name: string;
+    email: string;
+  };
+}

--- a/backend/src/contracts/dto/create-contract.dto.ts
+++ b/backend/src/contracts/dto/create-contract.dto.ts
@@ -1,0 +1,47 @@
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsDateString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ContractFrequency } from '../entities/contract.entity';
+
+class JobTemplateDto {
+  @IsNotEmpty()
+  title: string;
+
+  @IsOptional()
+  description?: string;
+
+  @IsOptional()
+  estimatedHours?: number;
+
+  @IsOptional()
+  notes?: string;
+}
+
+export class CreateContractDto {
+  @IsInt()
+  customerId: number;
+
+  @IsDateString()
+  startDate: Date;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: Date;
+
+  @IsEnum(ContractFrequency)
+  frequency: ContractFrequency;
+
+  @IsOptional()
+  @IsInt()
+  totalOccurrences?: number;
+
+  @ValidateNested()
+  @Type(() => JobTemplateDto)
+  jobTemplate: JobTemplateDto;
+}

--- a/backend/src/contracts/dto/update-contract.dto.ts
+++ b/backend/src/contracts/dto/update-contract.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateContractDto } from './create-contract.dto';
+
+export class UpdateContractDto extends PartialType(CreateContractDto) {}

--- a/backend/src/contracts/entities/contract.entity.ts
+++ b/backend/src/contracts/entities/contract.entity.ts
@@ -1,0 +1,77 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+  JoinColumn,
+} from 'typeorm';
+import { Customer } from '../../customers/entities/customer.entity';
+import { Company } from '../../companies/entities/company.entity';
+import { Job } from '../../jobs/entities/job.entity';
+
+export enum ContractFrequency {
+  WEEKLY = 'weekly',
+  BIWEEKLY = 'bi-weekly',
+}
+
+@Entity()
+export class Contract {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  companyId: number;
+
+  @ManyToOne(() => Company, (company) => company.contracts, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'companyId' })
+  company: Company;
+
+  @ManyToOne(() => Customer, (customer) => customer.contracts, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  customer: Customer;
+
+  @Column({ type: 'date' })
+  startDate: Date;
+
+  @Column({ type: 'date', nullable: true })
+  endDate?: Date;
+
+  @Column({ type: 'enum', enum: ContractFrequency })
+  frequency: ContractFrequency;
+
+  @Column({ type: 'int', nullable: true })
+  totalOccurrences?: number;
+
+  @Column({ type: 'int', default: 0 })
+  occurrencesGenerated: number;
+
+  @Column({ type: 'jsonb' })
+  jobTemplate: {
+    title: string;
+    description?: string;
+    estimatedHours?: number;
+    notes?: string;
+  };
+
+  @Column({ type: 'date', nullable: true })
+  lastGeneratedDate?: Date;
+
+  @Column({ default: true })
+  active: boolean;
+
+  @OneToMany(() => Job, (job) => job.contract)
+  jobs: Job[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/customers/entities/customer.entity.ts
+++ b/backend/src/customers/entities/customer.entity.ts
@@ -1,4 +1,5 @@
 import { Job } from '../../jobs/entities/job.entity';
+import { Contract } from '../../contracts/entities/contract.entity';
 import { Address } from './address.entity';
 import { User } from '../../users/user.entity';
 import { Company } from '../../companies/entities/company.entity';
@@ -65,6 +66,11 @@ export class Customer {
 
   @OneToMany(() => Job, (job) => job.customer, { onDelete: 'CASCADE' })
   jobs: Job[];
+
+  @OneToMany(() => Contract, (contract) => contract.customer, {
+    onDelete: 'CASCADE',
+  })
+  contracts: Contract[];
 
   @OneToMany(() => Address, (address) => address.customer, {
     cascade: true,

--- a/backend/src/equipment/equipment.controller.spec.ts
+++ b/backend/src/equipment/equipment.controller.spec.ts
@@ -16,7 +16,7 @@ describe('EquipmentController', () => {
           provide: EquipmentService,
           useValue: {
             updateStatus: jest.fn(),
-            findAll: jest.fn()
+            findAll: jest.fn(),
           },
         },
       ],
@@ -29,7 +29,6 @@ describe('EquipmentController', () => {
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
-
 
   describe('updateStatus', () => {
     it('should pass companyId to equipmentService.updateStatus', async () => {
@@ -47,23 +46,26 @@ describe('EquipmentController', () => {
       );
       expect(result).toBe(response);
     });
+  });
 
-  it('should call equipmentService.findAll with companyId', async () => {
-    const pagination = { page: 1, limit: 10 };
-    const req = { user: { companyId: 1 } };
-    const status = EquipmentStatus.AVAILABLE;
-    const type = EquipmentType.MOWER;
-    const expectedResult = { items: [], total: 0 };
-    (service.findAll as jest.Mock).mockResolvedValue(expectedResult);
+  describe('findAll', () => {
+    it('should call equipmentService.findAll with companyId', async () => {
+      const pagination = { page: 1, limit: 10 };
+      const req = { user: { companyId: 1 } };
+      const status = EquipmentStatus.AVAILABLE;
+      const type = EquipmentType.MOWER;
+      const expectedResult = { items: [], total: 0 };
+      (service.findAll as jest.Mock).mockResolvedValue(expectedResult);
 
-    const result = await controller.findAll(pagination, req, status, type);
-    expect(result).toEqual(expectedResult);
-    expect(service.findAll).toHaveBeenCalledWith(
-      pagination,
-      req.user.companyId,
-      status,
-      type,
-    );
-
+      const result = await controller.findAll(pagination, req, status, type);
+      expect(result).toEqual(expectedResult);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.findAll).toHaveBeenCalledWith(
+        pagination,
+        req.user.companyId,
+        status,
+        type,
+      );
+    });
   });
 });

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -60,7 +60,6 @@ export class EquipmentController {
   @ApiQuery({ name: 'type', required: false, enum: EquipmentType })
   @ApiResponse({ status: 200, description: 'List of equipment' })
   async findAll(
-    @Req() req: { user: { companyId: number } },
     @Query() pagination: PaginationQueryDto,
     @Req() req: { user: { companyId: number } },
     @Query('status', new ParseEnumPipe(EquipmentStatus, { optional: true }))

--- a/backend/src/jobs/entities/job.entity.ts
+++ b/backend/src/jobs/entities/job.entity.ts
@@ -12,6 +12,7 @@ import {
 import { Customer } from '../../customers/entities/customer.entity';
 import { Assignment } from './assignment.entity';
 import { Company } from '../../companies/entities/company.entity';
+import { Contract } from '../../contracts/entities/contract.entity';
 
 @Entity()
 @Index(['scheduledDate', 'completed']) // Add index for common queries
@@ -61,6 +62,15 @@ export class Job {
     onDelete: 'CASCADE',
   })
   assignments: Assignment[];
+
+  @Column({ nullable: true })
+  contractId?: number;
+
+  @ManyToOne(() => Contract, (contract) => contract.jobs, {
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'contractId' })
+  contract?: Contract;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/jobs/jobs.controller.spec.ts
+++ b/backend/src/jobs/jobs.controller.spec.ts
@@ -2,12 +2,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
 
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
+
 describe('JobsController', () => {
   let controller: JobsController;
   let jobsService: { findAll: jest.Mock };
 
   beforeEach(async () => {
-    
     jobsService = {
       findAll: jest.fn(),
     };
@@ -28,7 +29,6 @@ describe('JobsController', () => {
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
-
 
   it('should forward filters to service.findAll', async () => {
     jobsService.findAll.mockResolvedValue({ items: [], total: 0 });
@@ -54,6 +54,7 @@ describe('JobsController', () => {
       4,
     );
     expect(result).toEqual({ items: [], total: 0 });
+  });
 
   describe('findAll', () => {
     it('should call jobsService.findAll with companyId', async () => {
@@ -76,9 +77,12 @@ describe('JobsController', () => {
         req.user.companyId,
         completed,
         customerId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
       );
       expect(response).toBe(result);
     });
-
   });
 });

--- a/backend/src/jobs/jobs.service.spec.ts
+++ b/backend/src/jobs/jobs.service.spec.ts
@@ -11,6 +11,7 @@ import { CreateJobDto } from './dto/create-job.dto';
 import { ScheduleJobDto } from './dto/schedule-job.dto';
 import { AssignJobDto } from './dto/assign-job.dto';
 
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
 describe('JobsService', () => {
   let service: JobsService;
   let jobRepository: {
@@ -92,16 +93,7 @@ describe('JobsService', () => {
     const pagination = { page: 1, limit: 10 } as any;
     const startDate = new Date('2023-01-01');
     const endDate = new Date('2023-01-31');
-    await service.findAll(
-      pagination,
-      1,
-      true,
-      2,
-      startDate,
-      endDate,
-      3,
-      4,
-    );
+    await service.findAll(pagination, 1, true, 2, startDate, endDate, 3, 4);
 
     expect(qb.andWhere).toHaveBeenCalledWith('job.completed = :completed', {
       completed: true,
@@ -113,10 +105,9 @@ describe('JobsService', () => {
       'job.scheduledDate >= :startDate',
       { startDate },
     );
-    expect(qb.andWhere).toHaveBeenCalledWith(
-      'job.scheduledDate <= :endDate',
-      { endDate },
-    );
+    expect(qb.andWhere).toHaveBeenCalledWith('job.scheduledDate <= :endDate', {
+      endDate,
+    });
     expect(qb.andWhere).toHaveBeenCalledWith('user.id = :workerId', {
       workerId: 3,
     });
@@ -166,9 +157,9 @@ describe('JobsService', () => {
     assignmentRepository.createQueryBuilder.mockReturnValue(qb);
 
     const scheduleJobDto: ScheduleJobDto = { scheduledDate: date };
-    await expect(
-      service.schedule(1, scheduleJobDto, 1),
-    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(service.schedule(1, scheduleJobDto, 1)).rejects.toBeInstanceOf(
+      ConflictException,
+    );
   });
 
   it('should throw ConflictException when assigning user or equipment already booked', async () => {
@@ -190,8 +181,8 @@ describe('JobsService', () => {
     assignmentRepository.createQueryBuilder.mockReturnValue(qb);
 
     const assignJobDto: AssignJobDto = { userId: 1, equipmentId: 2 };
-    await expect(
-      service.assign(1, assignJobDto, 1),
-    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(service.assign(1, assignJobDto, 1)).rejects.toBeInstanceOf(
+      ConflictException,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- introduce Contract entity referencing customers and companies
- expose create/list/update/cancel contract endpoints and link generated jobs
- schedule cron job to materialize jobs from active contracts

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68afa00173bc83259392d96a2954786e