### PR TITLE
fix: specify varchar types for user name fields

### DIFF
--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -37,13 +37,13 @@ export class User {
   @Column({ type: 'enum', enum: UserRole, default: UserRole.Customer })
   role: UserRole;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   firstName: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   lastName: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   phone: string | null;
 
   @Index('IDX_user_password_reset_token')


### PR DESCRIPTION
## Summary
- fix DataTypeNotSupported error by explicitly defining varchar column types for optional user fields

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe call errors in app.module.ts and contract-scheduler.service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68afa6a2eeec8325b195c7d8f6661d3a