### PR TITLE
chore: fix lint errors

### DIFF
--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -2,9 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { CustomersService } from './customers.service';
 import { Customer } from './entities/customer.entity';
-import { Repository, QueryFailedError } from 'typeorm';
+import { Repository, QueryFailedError, SelectQueryBuilder } from 'typeorm';
 import { ConflictException } from '@nestjs/common';
 import { CreateCustomerDto } from './dto/create-customer.dto';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 describe('CustomersService', () => {
   let service: CustomersService;
@@ -63,7 +64,7 @@ describe('CustomersService', () => {
   });
 
   it('should apply search filter when finding all customers', async () => {
-    const qb = {
+    const qb: Record<string, jest.Mock> = {
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
@@ -71,11 +72,13 @@ describe('CustomersService', () => {
       take: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
       getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
-    } as any;
+    };
 
-    (repo.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+    (repo.createQueryBuilder as jest.Mock).mockReturnValue(
+      qb as unknown as SelectQueryBuilder<Customer>,
+    );
 
-    const pagination = { page: 1, limit: 10 } as any;
+    const pagination: PaginationQueryDto = { page: 1, limit: 10 };
     await service.findAll(pagination, 1, undefined, 'Jane');
 
     expect(qb.andWhere).toHaveBeenCalledWith(

--- a/backend/src/equipment/equipment.service.spec.ts
+++ b/backend/src/equipment/equipment.service.spec.ts
@@ -3,6 +3,8 @@ import { EquipmentService } from './equipment.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Equipment, EquipmentStatus } from './entities/equipment.entity';
 import { EquipmentResponseDto } from './dto/equipment-response.dto';
+import { SelectQueryBuilder } from 'typeorm';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 describe('EquipmentService', () => {
   let service: EquipmentService;
@@ -48,17 +50,19 @@ describe('EquipmentService', () => {
   });
 
   it('should apply search filter when finding all equipment', async () => {
-    const qb = {
+    const qb: Record<string, jest.Mock> = {
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
       skip: jest.fn().mockReturnThis(),
       take: jest.fn().mockReturnThis(),
       getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
-    } as any;
+    };
 
-    repo.createQueryBuilder.mockReturnValue(qb);
+    repo.createQueryBuilder.mockReturnValue(
+      qb as unknown as SelectQueryBuilder<Equipment>,
+    );
 
-    const pagination = { page: 1, limit: 10 } as any;
+    const pagination: PaginationQueryDto = { page: 1, limit: 10 };
     await service.findAll(pagination, 1, undefined, undefined, 'truck');
 
     expect(qb.andWhere).toHaveBeenCalledWith(

--- a/backend/src/migrations/1724786000000-AddCustomerCompanyUser.ts
+++ b/backend/src/migrations/1724786000000-AddCustomerCompanyUser.ts
@@ -66,13 +66,17 @@ export class AddCustomerCompanyUser1724786000000 implements MigrationInterface {
         'customer',
         'FK_customer_companyId_company_id',
       );
-    } catch {}
+    } catch {
+      // ignore if foreign key does not exist
+    }
     try {
       await queryRunner.dropForeignKey(
         'customer',
         'FK_customer_userId_user_id',
       );
-    } catch {}
+    } catch {
+      // ignore if foreign key does not exist
+    }
 
     // drop columns
     if (await queryRunner.hasColumn('customer', 'companyId')) {


### PR DESCRIPTION
## Summary
- type-safe query builder mocks in customer and equipment service tests
- document ignored foreign key drops in migration down path

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afc06ef4a08325a486c0fcbf0dabee