### PR TITLE
Add monthly and bi-monthly contract frequencies

### DIFF
--- a/backend/src/contracts/contracts.service.ts
+++ b/backend/src/contracts/contracts.service.ts
@@ -141,8 +141,20 @@ export class ContractsService {
 
   private addFrequency(date: Date, frequency: ContractFrequency): Date {
     const result = new Date(date);
-    const days = frequency === ContractFrequency.WEEKLY ? 7 : 14;
-    result.setDate(result.getDate() + days);
+    switch (frequency) {
+      case ContractFrequency.WEEKLY:
+        result.setDate(result.getDate() + 7);
+        break;
+      case ContractFrequency.BIWEEKLY:
+        result.setDate(result.getDate() + 14);
+        break;
+      case ContractFrequency.MONTHLY:
+        result.setMonth(result.getMonth() + 1);
+        break;
+      case ContractFrequency.BIMONTHLY:
+        result.setMonth(result.getMonth() + 2);
+        break;
+    }
     return result;
   }
 

--- a/backend/src/contracts/entities/contract.entity.ts
+++ b/backend/src/contracts/entities/contract.entity.ts
@@ -15,6 +15,8 @@ import { Job } from '../../jobs/entities/job.entity';
 export enum ContractFrequency {
   WEEKLY = 'weekly',
   BIWEEKLY = 'bi-weekly',
+  MONTHLY = 'monthly',
+  BIMONTHLY = 'bi-monthly',
 }
 
 @Entity()


### PR DESCRIPTION
## Summary
- allow monthly and bi-monthly contract schedules
- schedule generator handles month-based frequencies

## Testing
- `CI=true npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68afc3bb26508325a822bebc3d40bde3