### PR TITLE
feat: add api prefix for production

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -93,10 +93,11 @@ npm run start:prod
 ```
 
 ### **5. Access the API**
-- **API Base URL**: http://localhost:3000
-- **Swagger Docs**: http://localhost:3000/docs (admin/admin)
-- **Health Check**: http://localhost:3000/health
-- **Metrics**: http://localhost:3000/metrics
+- **API Base URL**: http://localhost:3000/api
+- **Swagger Docs**: http://localhost:3000/api/docs (admin/admin)
+- **Health Check**: http://localhost:3000/api/health
+- **Metrics**: http://localhost:3000/api/metrics
+- **Production Base URL**: https://rflandscaperpro.com/api
 
 ## 🏗️ **Project Structure**
 

--- a/backend/env.example
+++ b/backend/env.example
@@ -11,7 +11,7 @@ HOST=0.0.0.0
 
 # CORS Configuration
 # Comma-separated list of allowed origins
-ALLOWED_ORIGINS=https://example.com,https://admin.example.com
+ALLOWED_ORIGINS=https://rflandscaperpro.com
 
 # Database Configuration
 DB_HOST=localhost

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -21,6 +21,9 @@ async function bootstrap() {
   try {
     app = await NestFactory.create(AppModule, { bufferLogs: true });
 
+    // Prefix all routes with /api
+    app.setGlobalPrefix('api');
+
     // Apply middleware
     app.use(requestIdMiddleware);
 

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -13,12 +13,13 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
     await app.init();
   });
 
-  it('/ (GET)', () => {
+  it('/api (GET)', () => {
     return request(app.getHttpServer())
-      .get('/')
+      .get('/api')
       .expect(200)
       .expect('Hello World!');
   });

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -15,6 +15,7 @@ describe('UsersController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
     app.use(
       (
         req: Request & { user?: unknown },
@@ -30,7 +31,7 @@ describe('UsersController (e2e)', () => {
 
   it('POST /users returns 403 for non-admin', () => {
     return request(app.getHttpServer())
-      .post('/users')
+      .post('/api/users')
       .send({
         username: 'user',
         email: 'user@example.com',


### PR DESCRIPTION
## Summary
- prefix all backend routes with `/api`
- document production API domain and allowed origins
- adjust e2e tests for new API path

## Testing
- `npm run lint` *(fails: Unsafe call of a(n) `error` type typed value)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afc60e922883259f906f845bc5141d