### PR TITLE
Allow Prometheus metrics without auth

### DIFF
--- a/backend/src/common/guards/jwt-auth.guard.spec.ts
+++ b/backend/src/common/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,18 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+describe('JwtAuthGuard', () => {
+  it('allows access to metrics endpoint with global prefix', () => {
+    const guard = new JwtAuthGuard(new Reflector());
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ path: '/api/metrics' }),
+      }),
+      getHandler: () => undefined,
+      getClass: () => undefined,
+    } as unknown as ExecutionContext;
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+});

--- a/backend/src/common/guards/jwt-auth.guard.ts
+++ b/backend/src/common/guards/jwt-auth.guard.ts
@@ -12,7 +12,8 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
 
   canActivate(context: ExecutionContext) {
     const req = context.switchToHttp().getRequest<Request>();
-    if (req.path?.startsWith('/metrics')) {
+    const path = req.path || req.originalUrl || '';
+    if (path.startsWith('/api/metrics') || path.startsWith('/metrics')) {
       return true;
     }
 

--- a/backend/src/common/guards/metrics-throttler.guard.ts
+++ b/backend/src/common/guards/metrics-throttler.guard.ts
@@ -6,7 +6,8 @@ import { Request } from 'express';
 export class MetricsThrottlerGuard extends ThrottlerGuard {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest<Request>();
-    if (req.path?.startsWith('/metrics')) {
+    const path = req.path || req.originalUrl || '';
+    if (path.startsWith('/api/metrics') || path.startsWith('/metrics')) {
       return true;
     }
     return super.canActivate(context);


### PR DESCRIPTION
## Summary
- ensure JWT and throttler guards bypass metrics endpoint even when prefixed with /api
- add unit test for metrics access

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Cannot find module '@nestjs/schedule')*

------
https://chatgpt.com/codex/tasks/task_e_68afc89dd97c83258abe734ce1aba0bf