### PR TITLE
feat: integrate Angular frontend with backend environments

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,22 @@
 
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.2.1.
 
+## Backend integration
+
+API endpoints are configured through environment files located in `src/environments`.
+
+- `environment.ts` – local development (default)
+- `environment.staging.ts` – staging deployment
+- `environment.production.ts` – production deployment
+
+Each file defines an `apiUrl` pointing to the backend. The Angular build configuration
+replaces `environment.ts` with the appropriate file when building for `staging` or `production`.
+
+### Development proxy
+
+When running `ng serve`, requests to `/api` are proxied to `http://localhost:3000` using
+`proxy.conf.json`. Update this file if your backend runs on a different host or port.
+
 ## Development server
 
 To start a local development server, run:

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -38,42 +38,59 @@
               "entry": "src/server.ts"
             }
           },
-          "configurations": {
-            "production": {
-              "budgets": [
-                {
-                  "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
-                },
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
-                }
-              ],
-              "outputHashing": "all"
+            "configurations": {
+              "production": {
+                "budgets": [
+                  {
+                    "type": "initial",
+                    "maximumWarning": "500kB",
+                    "maximumError": "1MB"
+                  },
+                  {
+                    "type": "anyComponentStyle",
+                    "maximumWarning": "4kB",
+                    "maximumError": "8kB"
+                  }
+                ],
+                "outputHashing": "all",
+                "fileReplacements": [
+                  {
+                    "replace": "src/environments/environment.ts",
+                    "with": "src/environments/environment.production.ts"
+                  }
+                ]
+              },
+              "development": {
+                "optimization": false,
+                "extractLicenses": false,
+                "sourceMap": true
+              },
+              "staging": {
+                "fileReplacements": [
+                  {
+                    "replace": "src/environments/environment.ts",
+                    "with": "src/environments/environment.staging.ts"
+                  }
+                ]
+              }
             },
-            "development": {
-              "optimization": false,
-              "extractLicenses": false,
-              "sourceMap": true
-            }
+            "defaultConfiguration": "production"
           },
-          "defaultConfiguration": "production"
-        },
-        "serve": {
-          "builder": "@angular/build:dev-server",
-          "configurations": {
-            "production": {
-              "buildTarget": "frontend:build:production"
+          "serve": {
+            "builder": "@angular/build:dev-server",
+            "configurations": {
+              "production": {
+                "buildTarget": "frontend:build:production"
+              },
+              "development": {
+                "buildTarget": "frontend:build:development"
+              },
+              "staging": {
+                "buildTarget": "frontend:build:staging"
+              }
             },
-            "development": {
-              "buildTarget": "frontend:build:development"
-            }
+            "defaultConfiguration": "development"
           },
-          "defaultConfiguration": "development"
-        },
         "extract-i18n": {
           "builder": "@angular/build:extract-i18n"
         },

--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -1,0 +1,13 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../environments/environment';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  private http = inject(HttpClient);
+
+  getHealth(): Observable<unknown> {
+    return this.http.get(`${environment.apiUrl}/health`);
+  }
+}

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,13 +1,16 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
-import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes), provideClientHydration(withEventReplay())
+    provideRouter(routes),
+    provideClientHydration(withEventReplay()),
+    provideHttpClient()
   ]
 };

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -183,6 +183,7 @@
 </style>
 
 <main class="main">
+  <p>Backend status: {{ backendStatus() }}</p>
   <div class="content">
     <div class="left-side">
       <svg

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -1,15 +1,25 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { App } from './app';
+import { ApiService } from './api.service';
+
+class MockApiService {
+  getHealth() {
+    return of({ status: 'ok' });
+  }
+}
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [{ provide: ApiService, useClass: MockApiService }]
     }).compileComponents();
   });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,5 +1,6 @@
-import { Component, signal } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { ApiService } from './api.service';
 
 @Component({
   selector: 'app-root',
@@ -7,6 +8,15 @@ import { RouterOutlet } from '@angular/router';
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })
-export class App {
+export class App implements OnInit {
   protected readonly title = signal('frontend');
+  protected readonly backendStatus = signal('checking');
+  private readonly api = inject(ApiService);
+
+  ngOnInit(): void {
+    this.api.getHealth().subscribe({
+      next: () => this.backendStatus.set('online'),
+      error: () => this.backendStatus.set('offline')
+    });
+  }
 }

--- a/frontend/src/environments/environment.production.ts
+++ b/frontend/src/environments/environment.production.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiUrl: 'https://rflandscaperpro.com/api'
+};

--- a/frontend/src/environments/environment.staging.ts
+++ b/frontend/src/environments/environment.staging.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: 'https://staging.rflandscaperpro.com/api'
+};

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:3000/api'
+};


### PR DESCRIPTION
## Summary
- configure Angular builds for dev, staging, and production API endpoints
- add ApiService and HttpClient setup to query backend health
- display backend status and document environment configuration

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless requires chromium snap)*

------
https://chatgpt.com/codex/tasks/task_e_68b05bcfd34083259065e385c052c161