### PR TITLE
feat(frontend): add Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ RFLandscaperPro/
 │   ├── Dockerfile          # Production container
 │   ├── docker-compose.yml  # Development environment
 │   └── fly.toml            # Fly.io deployment configuration
+├── frontend/                # Angular web client
+│   ├── Dockerfile          # Production container
+│   ├── docker-compose.yml  # Development environment
+│   └── README.md           # Frontend documentation
 ├── LICENSE                 # MIT License
 └── README.md               # Project documentation
 ```
-

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+# ---------- Build Stage ----------
+ARG NODE_VERSION=24.3.0
+FROM node:${NODE_VERSION}-slim AS build
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the Angular app
+RUN npm run build
+
+# ---------- Production Stage ----------
+FROM nginx:alpine AS prod
+
+# Copy compiled app to Nginx html directory
+COPY --from=build /app/dist/frontend/browser /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx server
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+# ---- Base image ----
+ARG NODE_VERSION=24.3.0
+FROM node:${NODE_VERSION}-slim AS base
+
+# ---- Set working directory ----
+WORKDIR /app
+
+# ---- Set default environment ----
+ENV NODE_ENV=development
+
+# ---- Install dependencies ----
+COPY package*.json ./
+RUN npm install
+
+# ---- Copy application code ----
+COPY . .
+
+# ---- Expose application port ----
+EXPOSE 4200
+
+# ---- Start development server ----
+CMD ["npm", "start"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -73,3 +73,25 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## Docker
+
+### Development
+
+To start the frontend in a container with hot reload, run:
+
+```bash
+docker compose up
+```
+
+This uses `Dockerfile.dev` and serves the app at <http://localhost:4200>.
+
+### Production build
+
+To build and run the production image:
+
+```bash
+docker compose -f docker-compose.yml up --build -d
+```
+
+The compiled application is served by Nginx on port 80.

--- a/frontend/docker-compose.override.yml
+++ b/frontend/docker-compose.override.yml
@@ -1,0 +1,11 @@
+services:
+  frontend:
+    build:
+      dockerfile: Dockerfile.dev
+    volumes:
+      - .:/app
+      - /app/node_modules
+    ports:
+      - "4200:4200"
+    environment:
+      - NODE_ENV=development

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  frontend:
+    image: rflandscaperpro/frontend
+    container_name: rflandscaperpro_frontend
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "80:80"


### PR DESCRIPTION
## Summary
- add production and development Dockerfiles for Angular app
- configure docker-compose for local dev and update docs

## Testing
- `npm ci`
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b05e4700448325bc72198d736c59da