### PR TITLE
chore: run CI for backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,25 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [backend, frontend]
     defaults:
       run:
-        working-directory: backend
+        working-directory: ${{ matrix.project }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: backend/package-lock.json
+          cache-dependency-path: ${{ matrix.project }}/package-lock.json
       - run: npm ci
-      - run: npm run lint
-      - run: npm test
+      - run: npm run lint --if-present
+      - run: npm test --if-present
+        env:
+          CI: true
       - run: npm run build
       - name: Build production image
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: matrix.project == 'backend' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         run: docker build .


### PR DESCRIPTION
## Summary
- build and test both backend and frontend in CI
- cache Node dependencies per project
- build backend Docker image only when on main or tag

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend) *(fails: no Chrome in container)*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b062450958832594feee5da831b9fc