### PR TITLE
feat: add optional drop to seed script

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -64,6 +64,9 @@ npx cross-env NODE_ENV=development npm run migration:run
 # automatically skip execution when `NODE_ENV=production`.
 npx cross-env NODE_ENV=development npm run seed
 
+# Drop and re-seed the database from scratch
+npx cross-env NODE_ENV=development npm run seed:drop
+
 ```
 
 ### **4. Start Development Server**
@@ -204,6 +207,9 @@ npx cross-env NODE_ENV=development npm run migration:revert
 
 # Seed database with sample data
 npx cross-env NODE_ENV=development npm run seed
+
+# Drop and re-seed the database from scratch
+npx cross-env NODE_ENV=development npm run seed:drop
 ```
 
 ## 🗄️ **Database Schema**

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,8 @@
     "migration:generate": "node scripts/generate-migration.mjs",
     "migration:run": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:run -d data-source.ts",
     "migration:revert": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:revert -d data-source.ts",
-    "seed": "ts-node src/seed.ts"
+    "seed": "ts-node src/seed.ts",
+    "seed:drop": "ts-node src/seed.ts --drop"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^3.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "serve:ssr:frontend": "node dist/frontend/server/server.mjs"
+    "serve:ssr:frontend": "node dist/frontend/server/server.mjs",
+    "seed": "npm --prefix ../backend run seed",
+    "seed:drop": "npm --prefix ../backend run seed:drop"
   },
   "prettier": {
     "printWidth": 100,


### PR DESCRIPTION
## Summary
- add `seed:drop` script for backend to reset database
- expose backend seed commands from frontend package for convenience
- document reseed instructions in backend README

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b0627638fc8325aad01f60295f93c0