### PR TITLE
feat: add lazy-loaded feature modules

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,3 +1,29 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: 'auth',
+    loadChildren: () => import('./auth/auth.routes').then(m => m.authRoutes)
+  },
+  {
+    path: 'customers',
+    loadChildren: () => import('./customers/customers.routes').then(m => m.customersRoutes)
+  },
+  {
+    path: 'equipment',
+    loadChildren: () => import('./equipment/equipment.routes').then(m => m.equipmentRoutes)
+  },
+  {
+    path: 'jobs',
+    loadChildren: () => import('./jobs/jobs.routes').then(m => m.jobsRoutes)
+  },
+  {
+    path: 'users',
+    loadChildren: () => import('./users/users.routes').then(m => m.usersRoutes)
+  },
+  {
+    path: '',
+    redirectTo: 'auth',
+    pathMatch: 'full'
+  }
+];

--- a/frontend/src/app/auth/auth.component.ts
+++ b/frontend/src/app/auth/auth.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-auth',
+  standalone: true,
+  template: `<p>auth works!</p>`
+})
+export class AuthComponent {}

--- a/frontend/src/app/auth/auth.routes.ts
+++ b/frontend/src/app/auth/auth.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const authRoutes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./auth.component').then(m => m.AuthComponent)
+  }
+];

--- a/frontend/src/app/customers/customers.component.ts
+++ b/frontend/src/app/customers/customers.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-customers',
+  standalone: true,
+  template: `<p>customers works!</p>`
+})
+export class CustomersComponent {}

--- a/frontend/src/app/customers/customers.routes.ts
+++ b/frontend/src/app/customers/customers.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const customersRoutes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./customers.component').then(m => m.CustomersComponent)
+  }
+];

--- a/frontend/src/app/equipment/equipment.component.ts
+++ b/frontend/src/app/equipment/equipment.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-equipment',
+  standalone: true,
+  template: `<p>equipment works!</p>`
+})
+export class EquipmentComponent {}

--- a/frontend/src/app/equipment/equipment.routes.ts
+++ b/frontend/src/app/equipment/equipment.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const equipmentRoutes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./equipment.component').then(m => m.EquipmentComponent)
+  }
+];

--- a/frontend/src/app/jobs/jobs.component.ts
+++ b/frontend/src/app/jobs/jobs.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-jobs',
+  standalone: true,
+  template: `<p>jobs works!</p>`
+})
+export class JobsComponent {}

--- a/frontend/src/app/jobs/jobs.routes.ts
+++ b/frontend/src/app/jobs/jobs.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const jobsRoutes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./jobs.component').then(m => m.JobsComponent)
+  }
+];

--- a/frontend/src/app/users/users.component.ts
+++ b/frontend/src/app/users/users.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-users',
+  standalone: true,
+  template: `<p>users works!</p>`
+})
+export class UsersComponent {}

--- a/frontend/src/app/users/users.routes.ts
+++ b/frontend/src/app/users/users.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const usersRoutes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./users.component').then(m => m.UsersComponent)
+  }
+];


### PR DESCRIPTION
## Summary
- add placeholder feature modules with route configurations
- lazily load feature routes and redirect default path to login

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b0727a994c8325a5e0a79a0ef0e5a6