### PR TITLE
feat(frontend): add auth components and route guard

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,29 +1,38 @@
 import { Routes } from '@angular/router';
+import { AuthGuard } from './auth/auth.guard';
 
 export const routes: Routes = [
   {
-    path: 'auth',
-    loadChildren: () => import('./auth/auth.routes').then(m => m.authRoutes)
+    path: 'login',
+    loadComponent: () => import('./auth/login/login.component').then(m => m.LoginComponent)
+  },
+  {
+    path: 'register',
+    loadComponent: () => import('./auth/register/register.component').then(m => m.RegisterComponent)
   },
   {
     path: 'customers',
+    canActivate: [AuthGuard],
     loadChildren: () => import('./customers/customers.routes').then(m => m.customersRoutes)
   },
   {
     path: 'equipment',
+    canActivate: [AuthGuard],
     loadChildren: () => import('./equipment/equipment.routes').then(m => m.equipmentRoutes)
   },
   {
     path: 'jobs',
+    canActivate: [AuthGuard],
     loadChildren: () => import('./jobs/jobs.routes').then(m => m.jobsRoutes)
   },
   {
     path: 'users',
+    canActivate: [AuthGuard],
     loadChildren: () => import('./users/users.routes').then(m => m.usersRoutes)
   },
   {
     path: '',
-    redirectTo: 'auth',
+    redirectTo: 'login',
     pathMatch: 'full'
   }
 ];

--- a/frontend/src/app/auth/auth.component.ts
+++ b/frontend/src/app/auth/auth.component.ts
@@ -1,8 +1,0 @@
-import { Component } from '@angular/core';
-
-@Component({
-  selector: 'app-auth',
-  standalone: true,
-  template: `<p>auth works!</p>`
-})
-export class AuthComponent {}

--- a/frontend/src/app/auth/auth.guard.ts
+++ b/frontend/src/app/auth/auth.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from './auth.service';
+
+export const AuthGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  if (auth.isAuthenticated()) {
+    return true;
+  }
+
+  return router.parseUrl('/login');
+};

--- a/frontend/src/app/auth/auth.routes.ts
+++ b/frontend/src/app/auth/auth.routes.ts
@@ -1,8 +1,0 @@
-import { Routes } from '@angular/router';
-
-export const authRoutes: Routes = [
-  {
-    path: '',
-    loadComponent: () => import('./auth.component').then(m => m.AuthComponent)
-  }
-];

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, tap } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private http = inject(HttpClient);
+
+  login(data: { email: string; password: string }): Observable<{ access_token: string }> {
+    return this.http
+      .post<{ access_token: string }>(`${environment.apiUrl}/auth/login`, data)
+      .pipe(tap(res => localStorage.setItem('token', res.access_token)));
+  }
+
+  register(data: { name?: string; email: string; password: string }): Observable<{ access_token: string }> {
+    return this.http
+      .post<{ access_token: string }>(`${environment.apiUrl}/auth/register`, data)
+      .pipe(tap(res => localStorage.setItem('token', res.access_token)));
+  }
+
+  logout(): void {
+    localStorage.removeItem('token');
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem('token');
+  }
+
+  isAuthenticated(): boolean {
+    return !!this.getToken();
+  }
+}

--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -1,0 +1,36 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { AuthService } from '../auth.service';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="submit()">
+      <input type="email" formControlName="email" placeholder="Email" />
+      <input type="password" formControlName="password" placeholder="Password" />
+      <button type="submit">Login</button>
+    </form>
+  `
+})
+export class LoginComponent {
+  private auth = inject(AuthService);
+  private router = inject(Router);
+  private fb = inject(FormBuilder);
+
+  form = this.fb.nonNullable.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', Validators.required]
+  });
+
+  submit(): void {
+    if (this.form.valid) {
+      this.auth.login(this.form.getRawValue()).subscribe(() => {
+        this.router.navigate(['/']);
+      });
+    }
+  }
+}

--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -1,0 +1,38 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { AuthService } from '../auth.service';
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="submit()">
+      <input type="text" formControlName="name" placeholder="Name" />
+      <input type="email" formControlName="email" placeholder="Email" />
+      <input type="password" formControlName="password" placeholder="Password" />
+      <button type="submit">Register</button>
+    </form>
+  `
+})
+export class RegisterComponent {
+  private auth = inject(AuthService);
+  private router = inject(Router);
+  private fb = inject(FormBuilder);
+
+  form = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', Validators.required]
+  });
+
+  submit(): void {
+    if (this.form.valid) {
+      this.auth.register(this.form.getRawValue()).subscribe(() => {
+        this.router.navigate(['/']);
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone login and register components
- implement AuthService with JWT storage
- protect routes using AuthGuard and expose login/register paths

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b0796667488325ad98768fa4a7ee22