### PR TITLE
feat: add customer pages

### DIFF
--- a/frontend/src/app/customers/customer-detail.component.ts
+++ b/frontend/src/app/customers/customer-detail.component.ts
@@ -1,0 +1,27 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { CustomerService } from './customer.service';
+import { Customer } from './customer.model';
+import { switchMap } from 'rxjs';
+
+@Component({
+  selector: 'app-customer-detail',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <ng-container *ngIf="customer$ | async as customer">
+      <h2>{{ customer.name }}</h2>
+      <p>Email: {{ customer.email }}</p>
+      <p *ngIf="customer.phone">Phone: {{ customer.phone }}</p>
+    </ng-container>
+  `
+})
+export class CustomerDetailComponent {
+  private route = inject(ActivatedRoute);
+  private customerService = inject(CustomerService);
+
+  customer$ = this.route.paramMap.pipe(
+    switchMap(params => this.customerService.getCustomer(Number(params.get('id'))))
+  );
+}

--- a/frontend/src/app/customers/customer-form.component.ts
+++ b/frontend/src/app/customers/customer-form.component.ts
@@ -1,0 +1,51 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { CustomerService } from './customer.service';
+import { Customer } from './customer.model';
+
+@Component({
+  selector: 'app-customer-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <h2>New Customer</h2>
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <label>
+        Name:
+        <input formControlName="name" />
+      </label>
+      <label>
+        Email:
+        <input formControlName="email" />
+      </label>
+      <label>
+        Phone:
+        <input formControlName="phone" />
+      </label>
+      <button type="submit" [disabled]="form.invalid">Save</button>
+    </form>
+  `
+})
+export class CustomerFormComponent {
+  private fb = inject(FormBuilder);
+  private customerService = inject(CustomerService);
+  private router = inject(Router);
+
+  form = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    phone: ['']
+  });
+
+  onSubmit(): void {
+    if (this.form.valid) {
+      this.customerService
+        .createCustomer(this.form.value as Customer)
+        .subscribe(() => {
+          this.router.navigate(['/customers']);
+        });
+    }
+  }
+}

--- a/frontend/src/app/customers/customer-list.component.ts
+++ b/frontend/src/app/customers/customer-list.component.ts
@@ -1,0 +1,35 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { CustomerService } from './customer.service';
+import { Customer } from './customer.model';
+
+@Component({
+  selector: 'app-customer-list',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  template: `
+    <h2>Customers</h2>
+    <table *ngIf="customers$ | async as customers">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Phone</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let c of customers">
+          <td><a [routerLink]="['/customers', c.id]">{{ c.name }}</a></td>
+          <td>{{ c.email }}</td>
+          <td>{{ c.phone }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <a [routerLink]="['/customers', 'new']">Add Customer</a>
+  `
+})
+export class CustomerListComponent {
+  private customerService = inject(CustomerService);
+  customers$ = this.customerService.getCustomers();
+}

--- a/frontend/src/app/customers/customer.model.ts
+++ b/frontend/src/app/customers/customer.model.ts
@@ -1,0 +1,6 @@
+export interface Customer {
+  id?: number;
+  name: string;
+  email: string;
+  phone?: string;
+}

--- a/frontend/src/app/customers/customer.service.ts
+++ b/frontend/src/app/customers/customer.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { Customer } from './customer.model';
+
+@Injectable({ providedIn: 'root' })
+export class CustomerService {
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.apiUrl}/customers`;
+
+  getCustomers(): Observable<Customer[]> {
+    return this.http.get<Customer[]>(this.baseUrl);
+  }
+
+  getCustomer(id: number): Observable<Customer> {
+    return this.http.get<Customer>(`${this.baseUrl}/${id}`);
+  }
+
+  createCustomer(customer: Partial<Customer>): Observable<Customer> {
+    return this.http.post<Customer>(this.baseUrl, customer);
+  }
+
+  updateCustomer(id: number, customer: Partial<Customer>): Observable<Customer> {
+    return this.http.patch<Customer>(`${this.baseUrl}/${id}`, customer);
+  }
+
+  deleteCustomer(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/frontend/src/app/customers/customers.component.ts
+++ b/frontend/src/app/customers/customers.component.ts
@@ -1,8 +1,0 @@
-import { Component } from '@angular/core';
-
-@Component({
-  selector: 'app-customers',
-  standalone: true,
-  template: `<p>customers works!</p>`
-})
-export class CustomersComponent {}

--- a/frontend/src/app/customers/customers.routes.ts
+++ b/frontend/src/app/customers/customers.routes.ts
@@ -3,6 +3,17 @@ import { Routes } from '@angular/router';
 export const customersRoutes: Routes = [
   {
     path: '',
-    loadComponent: () => import('./customers.component').then(m => m.CustomersComponent)
+    loadComponent: () =>
+      import('./customer-list.component').then(m => m.CustomerListComponent)
+  },
+  {
+    path: 'new',
+    loadComponent: () =>
+      import('./customer-form.component').then(m => m.CustomerFormComponent)
+  },
+  {
+    path: ':id',
+    loadComponent: () =>
+      import('./customer-detail.component').then(m => m.CustomerDetailComponent)
   }
 ];


### PR DESCRIPTION
## Summary
- scaffold customer list, form, and detail components
- add CustomerService with CRUD methods
- wire up customer routes for list, new, and detail views

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*
- `npm run build` *(fails: The 'customers/:id' route uses prerendering and includes parameters, but 'getPrerenderParams' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b079682c288325be56a24d43fff046