### PR TITLE
feat(frontend): add equipment management components

### DIFF
--- a/frontend/src/app/equipment/equipment-detail.component.ts
+++ b/frontend/src/app/equipment/equipment-detail.component.ts
@@ -1,0 +1,61 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { EquipmentService, Equipment } from './equipment.service';
+
+@Component({
+  selector: 'app-equipment-detail',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  template: `
+    <div>
+      <h2>Equipment Detail</h2>
+      <form (ngSubmit)="save()">
+        <label>
+          Name:
+          <input [(ngModel)]="equipment.name" name="name" />
+        </label>
+        <label>
+          Status:
+          <input [(ngModel)]="equipment.status" name="status" />
+        </label>
+        <button type="submit">Save</button>
+        <button type="button" (click)="remove()" *ngIf="equipment.id">Delete</button>
+      </form>
+    </div>
+  `,
+})
+export class EquipmentDetailComponent {
+  equipment: Partial<Equipment> = { name: '', status: '' };
+  private equipmentService = inject(EquipmentService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id && id !== 'new') {
+      this.equipmentService.getEquipment(+id).subscribe((data) => (this.equipment = data));
+    }
+  }
+
+  save(): void {
+    if (this.equipment.id) {
+      this.equipmentService
+        .updateEquipment(this.equipment.id, this.equipment)
+        .subscribe(() => this.router.navigate(['/equipment']));
+    } else {
+      this.equipmentService
+        .createEquipment(this.equipment)
+        .subscribe(() => this.router.navigate(['/equipment']));
+    }
+  }
+
+  remove(): void {
+    if (this.equipment.id) {
+      this.equipmentService
+        .deleteEquipment(this.equipment.id)
+        .subscribe(() => this.router.navigate(['/equipment']));
+    }
+  }
+}

--- a/frontend/src/app/equipment/equipment-list.component.ts
+++ b/frontend/src/app/equipment/equipment-list.component.ts
@@ -1,0 +1,35 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { Equipment, EquipmentService } from './equipment.service';
+
+@Component({
+  selector: 'app-equipment-list',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  template: `
+    <h2>Equipment</h2>
+    <input type="text" [(ngModel)]="filter" placeholder="Search equipment" />
+    <ul>
+      <li *ngFor="let item of filteredEquipment()" [routerLink]="[item.id]">
+        {{ item.name }} - {{ item.status }}
+      </li>
+    </ul>
+    <a [routerLink]="['new']">Add Equipment</a>
+  `,
+})
+export class EquipmentListComponent {
+  filter = '';
+  equipments: Equipment[] = [];
+  private equipmentService = inject(EquipmentService);
+
+  ngOnInit(): void {
+    this.equipmentService.getEquipmentList().subscribe((data) => (this.equipments = data));
+  }
+
+  filteredEquipment(): Equipment[] {
+    const term = this.filter.toLowerCase();
+    return this.equipments.filter((e) => e.name.toLowerCase().includes(term));
+  }
+}

--- a/frontend/src/app/equipment/equipment.component.ts
+++ b/frontend/src/app/equipment/equipment.component.ts
@@ -1,8 +1,0 @@
-import { Component } from '@angular/core';
-
-@Component({
-  selector: 'app-equipment',
-  standalone: true,
-  template: `<p>equipment works!</p>`
-})
-export class EquipmentComponent {}

--- a/frontend/src/app/equipment/equipment.routes.ts
+++ b/frontend/src/app/equipment/equipment.routes.ts
@@ -3,6 +3,16 @@ import { Routes } from '@angular/router';
 export const equipmentRoutes: Routes = [
   {
     path: '',
-    loadComponent: () => import('./equipment.component').then(m => m.EquipmentComponent)
-  }
+    loadComponent: () => import('./equipment-list.component').then((m) => m.EquipmentListComponent),
+  },
+  {
+    path: 'new',
+    loadComponent: () =>
+      import('./equipment-detail.component').then((m) => m.EquipmentDetailComponent),
+  },
+  {
+    path: ':id',
+    loadComponent: () =>
+      import('./equipment-detail.component').then((m) => m.EquipmentDetailComponent),
+  },
 ];

--- a/frontend/src/app/equipment/equipment.service.ts
+++ b/frontend/src/app/equipment/equipment.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export interface Equipment {
+  id: number;
+  name: string;
+  status: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class EquipmentService {
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.apiUrl}/equipment`;
+
+  getEquipmentList(search?: string): Observable<Equipment[]> {
+    const options = search ? { params: { search } } : {};
+    return this.http
+      .get<{ items: Equipment[] }>(this.baseUrl, options)
+      .pipe(map((res) => res.items));
+  }
+
+  getEquipment(id: number): Observable<Equipment> {
+    return this.http.get<Equipment>(`${this.baseUrl}/${id}`);
+  }
+
+  createEquipment(equipment: Partial<Equipment>): Observable<Equipment> {
+    return this.http.post<Equipment>(this.baseUrl, equipment);
+  }
+
+  updateEquipment(id: number, equipment: Partial<Equipment>): Observable<Equipment> {
+    return this.http.patch<Equipment>(`${this.baseUrl}/${id}`, equipment);
+  }
+
+  deleteEquipment(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+
+  updateEquipmentStatus(id: number, status: string): Observable<Equipment> {
+    return this.http.patch<Equipment>(`${this.baseUrl}/${id}/status`, { status });
+  }
+}


### PR DESCRIPTION
## Summary
- add equipment list and detail components with search and CRUD operations
- add service for equipment CRUD and status update calls
- configure routes for equipment listing and editing

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b07969fb308325b8202ff4bcca724b