### PR TITLE
feat(frontend): add job management views

### DIFF
--- a/frontend/src/app/jobs/job-calendar.component.html
+++ b/frontend/src/app/jobs/job-calendar.component.html
@@ -1,0 +1,5 @@
+<h2>Job Calendar</h2>
+<input type="date" [(ngModel)]="selectedDate" (change)="loadJobs()">
+<ul>
+  <li *ngFor="let job of jobs">{{ job.title }} - {{ job.scheduledDate }}</li>
+</ul>

--- a/frontend/src/app/jobs/job-calendar.component.ts
+++ b/frontend/src/app/jobs/job-calendar.component.ts
@@ -1,0 +1,24 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { JobsService, Job } from './jobs.service';
+
+@Component({
+  selector: 'app-job-calendar',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './job-calendar.component.html'
+})
+export class JobCalendarComponent {
+  private jobsService = inject(JobsService);
+  selectedDate?: string;
+  jobs: Job[] = [];
+
+  loadJobs(): void {
+    if (this.selectedDate) {
+      this.jobsService.list().subscribe(jobs => {
+        this.jobs = jobs.filter(j => j.scheduledDate?.startsWith(this.selectedDate!));
+      });
+    }
+  }
+}

--- a/frontend/src/app/jobs/job-editor.component.html
+++ b/frontend/src/app/jobs/job-editor.component.html
@@ -1,0 +1,28 @@
+<h2>Job Editor</h2>
+<form (ngSubmit)="save()" #jobForm="ngForm">
+  <label>
+    Title
+    <input type="text" name="title" [(ngModel)]="job.title" required />
+  </label>
+  <label>
+    Description
+    <textarea name="description" [(ngModel)]="job.description"></textarea>
+  </label>
+  <label>
+    Schedule Date
+    <input type="date" name="scheduledDate" [(ngModel)]="job.scheduledDate" (change)="schedule()" />
+  </label>
+  <fieldset>
+    <legend>Assign</legend>
+    <label>
+      Worker ID
+      <input type="number" #worker />
+    </label>
+    <label>
+      Equipment ID
+      <input type="number" #equipment />
+    </label>
+    <button type="button" (click)="assign(worker.valueAsNumber, equipment.valueAsNumber)">Assign</button>
+  </fieldset>
+  <button type="submit" [disabled]="jobForm.invalid">Save</button>
+</form>

--- a/frontend/src/app/jobs/job-editor.component.ts
+++ b/frontend/src/app/jobs/job-editor.component.ts
@@ -1,0 +1,49 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, RouterModule, Router } from '@angular/router';
+import { JobsService, Job } from './jobs.service';
+
+@Component({
+  selector: 'app-job-editor',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  templateUrl: './job-editor.component.html'
+})
+export class JobEditorComponent implements OnInit {
+  private jobsService = inject(JobsService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+
+  job: Job = { title: '', customerId: 1 };
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      const jobId = Number(id);
+      if (!isNaN(jobId)) {
+        this.jobsService.get(jobId).subscribe(job => (this.job = job));
+      }
+    }
+  }
+
+  save(): void {
+    if (this.job.id) {
+      this.jobsService.update(this.job.id, this.job).subscribe(() => this.router.navigate(['/jobs']));
+    } else {
+      this.jobsService.create(this.job).subscribe(() => this.router.navigate(['/jobs']));
+    }
+  }
+
+  schedule(): void {
+    if (this.job.id && this.job.scheduledDate) {
+      this.jobsService.schedule(this.job.id, this.job.scheduledDate).subscribe(job => (this.job = job));
+    }
+  }
+
+  assign(userId: number, equipmentId: number): void {
+    if (this.job.id) {
+      this.jobsService.assign(this.job.id, { userId, equipmentId }).subscribe(job => (this.job = job));
+    }
+  }
+}

--- a/frontend/src/app/jobs/job-list.component.html
+++ b/frontend/src/app/jobs/job-list.component.html
@@ -1,0 +1,7 @@
+<h2>Jobs</h2>
+<ul>
+  <li *ngFor="let job of jobs">
+    <a [routerLink]="['/jobs', job.id]">{{ job.title }}</a>
+  </li>
+</ul>
+<a routerLink="/jobs/calendar">View Calendar</a>

--- a/frontend/src/app/jobs/job-list.component.ts
+++ b/frontend/src/app/jobs/job-list.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { JobsService, Job } from './jobs.service';
+
+@Component({
+  selector: 'app-job-list',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './job-list.component.html'
+})
+export class JobListComponent implements OnInit {
+  private jobsService = inject(JobsService);
+  jobs: Job[] = [];
+
+  ngOnInit(): void {
+    this.jobsService.list().subscribe(jobs => (this.jobs = jobs));
+  }
+}

--- a/frontend/src/app/jobs/jobs.component.ts
+++ b/frontend/src/app/jobs/jobs.component.ts
@@ -1,8 +1,0 @@
-import { Component } from '@angular/core';
-
-@Component({
-  selector: 'app-jobs',
-  standalone: true,
-  template: `<p>jobs works!</p>`
-})
-export class JobsComponent {}

--- a/frontend/src/app/jobs/jobs.routes.ts
+++ b/frontend/src/app/jobs/jobs.routes.ts
@@ -3,6 +3,14 @@ import { Routes } from '@angular/router';
 export const jobsRoutes: Routes = [
   {
     path: '',
-    loadComponent: () => import('./jobs.component').then(m => m.JobsComponent)
+    loadComponent: () => import('./job-list.component').then(m => m.JobListComponent)
+  },
+  {
+    path: 'calendar',
+    loadComponent: () => import('./job-calendar.component').then(m => m.JobCalendarComponent)
+  },
+  {
+    path: ':id',
+    loadComponent: () => import('./job-editor.component').then(m => m.JobEditorComponent)
   }
 ];

--- a/frontend/src/app/jobs/jobs.service.ts
+++ b/frontend/src/app/jobs/jobs.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface Job {
+  id?: number;
+  title: string;
+  description?: string;
+  scheduledDate?: string;
+  customerId: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class JobsService {
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.apiUrl}/jobs`;
+
+  list(): Observable<Job[]> {
+    return this.http.get<Job[]>(this.baseUrl);
+  }
+
+  get(id: number): Observable<Job> {
+    return this.http.get<Job>(`${this.baseUrl}/${id}`);
+  }
+
+  create(job: Job): Observable<Job> {
+    return this.http.post<Job>(this.baseUrl, job);
+  }
+
+  update(id: number, job: Job): Observable<Job> {
+    return this.http.patch<Job>(`${this.baseUrl}/${id}`, job);
+  }
+
+  assign(id: number, payload: { userId: number; equipmentId: number }): Observable<Job> {
+    return this.http.post<Job>(`${this.baseUrl}/${id}/assign`, payload);
+  }
+
+  schedule(id: number, date: string): Observable<Job> {
+    return this.http.post<Job>(`${this.baseUrl}/${id}/schedule`, { scheduledDate: date });
+  }
+}


### PR DESCRIPTION
## Summary
- add job list, calendar and editor components
- wire up job service for create, update, assign and schedule
- route /jobs, /jobs/:id and /jobs/calendar

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68b0796b62a8832582da8cbbcf98e917