### PR TITLE
feat(frontend): add user management and role guard

### DIFF
--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,0 +1,11 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  // In a real app roles would come from the authenticated user
+  private readonly roles = signal<string[]>(['admin']);
+
+  hasRole(role: string): boolean {
+    return this.roles().includes(role);
+  }
+}

--- a/frontend/src/app/auth/role.guard.ts
+++ b/frontend/src/app/auth/role.guard.ts
@@ -1,0 +1,12 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const roleGuard: CanActivateFn = (route) => {
+  const auth = inject(AuthService);
+  const roles = route.data?.['roles'] as string[] | undefined;
+  if (!roles || roles.length === 0) {
+    return true;
+  }
+  return roles.some(r => auth.hasRole(r));
+};

--- a/frontend/src/app/users/user-detail.component.ts
+++ b/frontend/src/app/users/user-detail.component.ts
@@ -1,0 +1,59 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { UserService, User } from './user.service';
+import { AuthService } from '../auth/auth.service';
+
+@Component({
+  selector: 'app-user-detail',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div *ngIf="user">
+      <h3>{{ user.name }}</h3>
+      <form (ngSubmit)="save()">
+        <label>Name:
+          <input name="name" [(ngModel)]="user.name" />
+        </label>
+        <label>Email:
+          <input name="email" [(ngModel)]="user.email" />
+        </label>
+        <div *ngIf="auth.hasRole('admin')">
+          <label>Roles:
+            <input name="roles" [(ngModel)]="rolesText" />
+          </label>
+        </div>
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  `
+})
+export class UserDetailComponent implements OnInit {
+  private readonly userService = inject(UserService);
+  private readonly route = inject(ActivatedRoute);
+  protected readonly auth = inject(AuthService);
+  user?: User;
+  rolesText = '';
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    this.userService.getUser(id).subscribe(u => {
+      this.user = u;
+      this.rolesText = u.roles.join(', ');
+    });
+  }
+
+  save(): void {
+    if (!this.user) {
+      return;
+    }
+    if (this.auth.hasRole('admin')) {
+      this.user.roles = this.rolesText
+        .split(',')
+        .map(r => r.trim())
+        .filter(r => r.length);
+    }
+    this.userService.updateUser(this.user).subscribe();
+  }
+}

--- a/frontend/src/app/users/user-list.component.ts
+++ b/frontend/src/app/users/user-list.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { UserService, User } from './user.service';
+import { AuthService } from '../auth/auth.service';
+
+@Component({
+  selector: 'app-user-list',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  template: `
+    <h2>Users</h2>
+    <ul>
+      <li *ngFor="let u of users">
+        <a [routerLink]="[u.id]">{{ u.name }}</a>
+        <button *ngIf="auth.hasRole('admin')" (click)="delete(u.id)">Delete</button>
+      </li>
+    </ul>
+    <button *ngIf="auth.hasRole('admin')" (click)="addUser()">Add User</button>
+  `
+})
+export class UserListComponent implements OnInit {
+  private readonly userService = inject(UserService);
+  protected readonly auth = inject(AuthService);
+  users: User[] = [];
+
+  ngOnInit(): void {
+    this.userService.getUsers().subscribe(users => (this.users = users));
+  }
+
+  delete(id: number): void {
+    this.userService.deleteUser(id).subscribe(() => {
+      this.users = this.users.filter(u => u.id !== id);
+    });
+  }
+
+  addUser(): void {
+    // Placeholder for creating a new user
+  }
+}

--- a/frontend/src/app/users/user.service.ts
+++ b/frontend/src/app/users/user.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  roles: string[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  private readonly http = inject(HttpClient);
+  private readonly base = `${environment.apiUrl}/users`;
+
+  getUsers(): Observable<User[]> {
+    return this.http.get<User[]>(this.base);
+  }
+
+  getUser(id: number): Observable<User> {
+    return this.http.get<User>(`${this.base}/${id}`);
+  }
+
+  createUser(user: Partial<User>): Observable<User> {
+    return this.http.post<User>(this.base, user);
+  }
+
+  updateUser(user: User): Observable<User> {
+    return this.http.put<User>(`${this.base}/${user.id}`, user);
+  }
+
+  deleteUser(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.base}/${id}`);
+  }
+}

--- a/frontend/src/app/users/users.component.ts
+++ b/frontend/src/app/users/users.component.ts
@@ -1,8 +1,0 @@
-import { Component } from '@angular/core';
-
-@Component({
-  selector: 'app-users',
-  standalone: true,
-  template: `<p>users works!</p>`
-})
-export class UsersComponent {}

--- a/frontend/src/app/users/users.routes.ts
+++ b/frontend/src/app/users/users.routes.ts
@@ -1,8 +1,17 @@
 import { Routes } from '@angular/router';
+import { roleGuard } from '../auth/role.guard';
 
 export const usersRoutes: Routes = [
   {
     path: '',
-    loadComponent: () => import('./users.component').then(m => m.UsersComponent)
+    canActivate: [roleGuard],
+    data: { roles: ['admin'] },
+    loadComponent: () => import('./user-list.component').then(m => m.UserListComponent)
+  },
+  {
+    path: ':id',
+    canActivate: [roleGuard],
+    data: { roles: ['admin'] },
+    loadComponent: () => import('./user-detail.component').then(m => m.UserDetailComponent)
   }
 ];


### PR DESCRIPTION
## Summary
- scaffold user list and detail components with role-based templates
- add UserService for CRUD operations
- enforce role guard on user routes

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b0796ec92883259d59edd0ec036731