### PR TITLE
feat(frontend): enable angular universal ssr

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,13 +18,20 @@ COPY . .
 RUN npm run build
 
 # ---------- Production Stage ----------
-FROM nginx:alpine AS prod
+FROM node:${NODE_VERSION}-slim AS prod
 
-# Copy compiled app to Nginx html directory
-COPY --from=build /app/dist/frontend/browser /usr/share/nginx/html
+# Set working directory for the runtime image
+WORKDIR /app
 
-# Expose port 80
-EXPOSE 80
+# Install only production dependencies
+COPY --from=build /app/package*.json ./
+RUN npm ci --omit=dev
 
-# Start Nginx server
-CMD ["nginx", "-g", "daemon off;"]
+# Copy the built application
+COPY --from=build /app/dist ./dist
+
+# Expose the port used by the Node server
+EXPOSE 4000
+
+# Start the server
+CMD ["node", "dist/frontend/server/server.mjs"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -21,4 +21,4 @@ COPY . .
 EXPOSE 4200
 
 # ---- Start development server ----
-CMD ["npm", "start"]
+CMD ["npm", "run", "dev:ssr"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,7 @@
 # Frontend
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.2.1.
+This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.2.1 and
+includes Angular Universal for server‑side rendering (SSR).
 
 ## Backend integration
 
@@ -20,7 +21,7 @@ When running `ng serve`, requests to `/api` are proxied to `http://localhost:300
 
 ## Development server
 
-To start a local development server, run:
+To start a local development server with SSR enabled, run:
 
 ```bash
 ng serve
@@ -44,13 +45,19 @@ ng generate --help
 
 ## Building
 
-To build the project run:
+To build the project for SSR, run:
 
 ```bash
-ng build
+npm run build:ssr
 ```
 
-This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
+After building, you can serve the application using:
+
+```bash
+npm run serve:ssr
+```
+
+This compiles the project and stores the build artifacts in the `dist/` directory. The server bundle is then executed with Node to render pages on the server.
 
 ## Running unit tests
 
@@ -94,4 +101,4 @@ To build and run the production image:
 docker compose -f docker-compose.yml up --build -d
 ```
 
-The compiled application is served by Nginx on port 80.
+The application is built and served by a Node Express server on port 4000.

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -6,4 +6,4 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "80:80"
+      - "4000:4000"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,11 +4,13 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "dev:ssr": "ng serve",
     "dev:compose": "docker compose -f docker-compose.yml -f docker-compose.override.yml up --build",
     "build": "ng build",
+    "build:ssr": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "serve:ssr:frontend": "node dist/frontend/server/server.mjs",
+    "serve:ssr": "node dist/frontend/server/server.mjs",
     "seed": "npm --prefix ../backend run seed",
     "seed:drop": "npm --prefix ../backend run seed:drop"
   },


### PR DESCRIPTION
## Summary
- expose SSR build and serve scripts for Angular Universal
- run the production image with a Node server instead of nginx
- update docs and compose config for SSR on port 4000

## Testing
- `npm test -- --watch=false` *(fails: Cannot start Chrome, snap install required)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0841709f08325a5f029bb84dcd9bd