### PR TITLE
feat: add auth http interceptor

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,7 +1,8 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { authInterceptor } from './core/http.interceptor';
 
 import { routes } from './app.routes';
 
@@ -11,6 +12,6 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
-    provideHttpClient()
+    provideHttpClient(withInterceptors([authInterceptor]))
   ]
 };

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private http = inject(HttpClient);
+  private readonly tokenKey = 'access_token';
+  private readonly refreshKey = 'refresh_token';
+
+  getToken(): string | null {
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  refreshToken(): Observable<string | null> {
+    const refreshToken = localStorage.getItem(this.refreshKey);
+    if (!refreshToken) {
+      return of(null);
+    }
+    return this.http
+      .post<{ accessToken: string }>(`${environment.apiUrl}/auth/refresh`, { refreshToken })
+      .pipe(
+        tap(res => localStorage.setItem(this.tokenKey, res.accessToken)),
+        map(res => res.accessToken),
+        catchError(() => of(null))
+      );
+  }
+
+  logout(): void {
+    localStorage.removeItem(this.tokenKey);
+    localStorage.removeItem(this.refreshKey);
+  }
+}

--- a/frontend/src/app/core/error.service.ts
+++ b/frontend/src/app/core/error.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ErrorService {
+  notify(message: string): void {
+    alert(message);
+  }
+}

--- a/frontend/src/app/core/http.interceptor.ts
+++ b/frontend/src/app/core/http.interceptor.ts
@@ -1,0 +1,47 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, switchMap, throwError } from 'rxjs';
+import { AuthService } from '../auth/auth.service';
+import { ErrorService } from './error.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+  const errorService = inject(ErrorService);
+
+  const token = authService.getToken();
+  const authReq = token ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } }) : req;
+
+  return next(authReq).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status === 401) {
+        return authService.refreshToken().pipe(
+          switchMap(newToken => {
+            if (newToken) {
+              const retryReq = req.clone({ setHeaders: { Authorization: `Bearer ${newToken}` } });
+              return next(retryReq);
+            }
+            authService.logout();
+            router.navigate(['/auth']);
+            errorService.notify('Session expired. Please log in again.');
+            return throwError(() => error);
+          }),
+          catchError(err => {
+            authService.logout();
+            router.navigate(['/auth']);
+            errorService.notify('Session expired. Please log in again.');
+            return throwError(() => err);
+          })
+        );
+      }
+
+      if (error.status === 403) {
+        router.navigate(['/auth']);
+      }
+
+      errorService.notify(error.message);
+      return throwError(() => error);
+    })
+  );
+};


### PR DESCRIPTION
## Summary
- add AuthService to manage JWT tokens
- add ErrorService for global notifications
- add authInterceptor to attach Authorization headers and handle 401/403
- register interceptor in app config

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b0797b71a08325b44d89578cee6c30