### PR TITLE
fix: expose dev server to host

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "dev:ssr": "ng serve",
+    "dev:ssr": "ng serve --host 0.0.0.0",
     "dev:compose": "docker compose -f docker-compose.yml -f docker-compose.override.yml up --build",
     "build": "ng build",
     "build:ssr": "ng build",


### PR DESCRIPTION
## Summary
- ensure Angular dev server listens on all interfaces

## Testing
- `npm test` (backend)
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b4688014832588ee5f76a74c7dd5