### PR TITLE
Protect dashboard route with auth guard

### DIFF
--- a/frontend/src/app/app.routes.spec.ts
+++ b/frontend/src/app/app.routes.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { routes } from './app.routes';
+import { AuthService } from './auth/auth.service';
+
+describe('App Routes', () => {
+  it('redirects unauthenticated dashboard access to login', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        { provide: AuthService, useValue: { isAuthenticated: () => false } }
+      ]
+    });
+
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/dashboard');
+
+    expect(router.url).toBe('/login');
+  });
+});

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -32,11 +32,12 @@ export const routes: Routes = [
   },
   {
     path: 'dashboard',
+    canActivate: [AuthGuard],
     loadChildren: () => import('./dashboard/dashboard.routes').then(m => m.dashboardRoutes)
   },
   {
     path: '',
-    redirectTo: 'dashboard',
+    redirectTo: 'login',
     pathMatch: 'full'
   }
 ];


### PR DESCRIPTION
## Summary
- require authentication for dashboard route and redirect default route to login
- test unauthenticated dashboard navigation to ensure redirect to login

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*


------
https://chatgpt.com/codex/tasks/task_e_68b0b7b96da08325a0b8f41155efd0d0