### PR TITLE
feat: add auth-aware sidebar links

### DIFF
--- a/frontend/src/app/layout/layout.component.html
+++ b/frontend/src/app/layout/layout.component.html
@@ -3,11 +3,12 @@
 </header>
 <div class="container">
   <nav class="sidebar">
-    <a routerLink="/auth" routerLinkActive="active">Auth</a>
+    <a *ngIf="!auth.isAuthenticated()" routerLink="/login" routerLinkActive="active">Login</a>
+    <button *ngIf="auth.isAuthenticated()" (click)="logout()">Logout</button>
+    <a *ngIf="auth.hasRole('admin')" routerLink="/users" routerLinkActive="active">Admin Panel</a>
     <a routerLink="/customers" routerLinkActive="active">Customers</a>
     <a routerLink="/equipment" routerLinkActive="active">Equipment</a>
     <a routerLink="/jobs" routerLinkActive="active">Jobs</a>
-    <a routerLink="/users" routerLinkActive="active">Users</a>
   </nav>
   <main class="content">
     <router-outlet></router-outlet>

--- a/frontend/src/app/layout/layout.component.ts
+++ b/frontend/src/app/layout/layout.component.ts
@@ -1,12 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { NgIf } from '@angular/common';
 import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+import { AuthService } from '../auth/auth.service';
 
 @Component({
   selector: 'app-layout',
   standalone: true,
-  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, NgIf],
   templateUrl: './layout.component.html',
   styleUrl: './layout.component.scss'
 })
-export class LayoutComponent {}
+export class LayoutComponent {
+  protected readonly auth = inject(AuthService);
+
+  logout(): void {
+    this.auth.logout();
+  }
+}
 


### PR DESCRIPTION
## Summary
- Replace static auth link with conditional Login/Logout controls
- Only show Admin Panel link in sidebar for admin users

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b7cd1d508325a774d1e29fa109d1