### PR TITLE
Configure frontend API URL and dev proxy

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -76,21 +76,24 @@
             },
             "defaultConfiguration": "production"
           },
-          "serve": {
-            "builder": "@angular/build:dev-server",
-            "configurations": {
-              "production": {
-                "buildTarget": "frontend:build:production"
-              },
-              "development": {
-                "buildTarget": "frontend:build:development"
-              },
-              "staging": {
-                "buildTarget": "frontend:build:staging"
-              }
-            },
-            "defaultConfiguration": "development"
+        "serve": {
+          "builder": "@angular/build:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
           },
+          "configurations": {
+            "production": {
+              "buildTarget": "frontend:build:production"
+            },
+            "development": {
+              "buildTarget": "frontend:build:development"
+            },
+            "staging": {
+              "buildTarget": "frontend:build:staging"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
         "extract-i18n": {
           "builder": "@angular/build:extract-i18n"
         },
@@ -116,5 +119,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:3000",
+    "target": "http://backend:3000",
     "secure": false
   }
 }

--- a/frontend/src/environments/environment.production.ts
+++ b/frontend/src/environments/environment.production.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://rflandscaperpro.com/api'
+  apiUrl: process.env['API_URL'] || 'https://rflandscaperpro.com/api'
 };

--- a/frontend/src/environments/environment.staging.ts
+++ b/frontend/src/environments/environment.staging.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: 'https://staging.rflandscaperpro.com/api'
+  apiUrl: process.env['API_URL'] || 'https://staging.rflandscaperpro.com/api'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:3000/api'
+  apiUrl: process.env['API_URL'] || 'http://backend:3000/api',
 };


### PR DESCRIPTION
## Summary
- allow overriding API base URL via `API_URL` and default to backend container
- proxy `/api` to backend container and wire proxy into Angular dev server

## Testing
- `npm --prefix frontend run build` *(fails: getPrerenderParams missing)*
- `npm --prefix backend start` *(fails: Config validation error: "DB_HOST" is required. "DB_USERNAME" is required. "DB_PASSWORD" is required. "DB_NAME" is required. "JWT_SECRET" is required)*
- `curl -x '' -i http://backend:3000/api/health`

------
https://chatgpt.com/codex/tasks/task_e_68b0b7aabdc08325b902b123b3d0e212