### PR TITLE
Add unique constraint for company name to fix seeding

### DIFF
--- a/backend/src/companies/entities/company.entity.ts
+++ b/backend/src/companies/entities/company.entity.ts
@@ -17,7 +17,7 @@ export class Company {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
+  @Column({ unique: true })
   name: string;
 
   @Column({ nullable: true })

--- a/backend/src/migrations/1724787000000-AddCompanyNameUnique.ts
+++ b/backend/src/migrations/1724787000000-AddCompanyNameUnique.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner, TableUnique } from 'typeorm';
+
+export class AddCompanyNameUnique1724787000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('company');
+    const hasUnique = table?.uniques.some((uq) => uq.columnNames.length === 1 && uq.columnNames[0] === 'name');
+    if (!hasUnique) {
+      await queryRunner.createUniqueConstraint(
+        'company',
+        new TableUnique({ name: 'UQ_company_name', columnNames: ['name'] }),
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('company');
+    const unique = table?.uniques.find((uq) => uq.name === 'UQ_company_name');
+    if (unique) {
+      await queryRunner.dropUniqueConstraint('company', unique);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enforce unique company names to allow idempotent upserts
- add migration creating unique constraint on `company.name`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b9da239c8325b863d2db4732613a