### PR TITLE
feat: add admin module and guard

### DIFF
--- a/frontend/src/app/admin/admin.component.ts
+++ b/frontend/src/app/admin/admin.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-admin',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>Admin Area</h2>
+    <p>Only admins can see this page.</p>
+  `
+})
+export class AdminComponent {}

--- a/frontend/src/app/admin/admin.routes.ts
+++ b/frontend/src/app/admin/admin.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const adminRoutes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./admin.component').then(m => m.AdminComponent)
+  }
+];

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { AuthGuard } from './auth/auth.guard';
+import { AdminGuard } from './auth/admin.guard';
 
 export const routes: Routes = [
   {
@@ -29,6 +30,11 @@ export const routes: Routes = [
     path: 'users',
     canActivate: [AuthGuard],
     loadChildren: () => import('./users/users.routes').then(m => m.usersRoutes)
+  },
+  {
+    path: 'admin',
+    canActivate: [AdminGuard],
+    loadChildren: () => import('./admin/admin.routes').then(m => m.adminRoutes)
   },
   {
     path: 'dashboard',

--- a/frontend/src/app/auth/admin.guard.ts
+++ b/frontend/src/app/auth/admin.guard.ts
@@ -1,0 +1,8 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const AdminGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  return auth.hasRole('admin');
+};


### PR DESCRIPTION
## Summary
- decode roles from JWT and store them in a signal
- add admin area with guard-protected routing

## Testing
- `npm test` (fails: No binary for Chrome browser on your platform)

------
https://chatgpt.com/codex/tasks/task_e_68b0b7dde1c08325a1a2a5b6657d6475