### PR TITLE
Guard localStorage access for SSR safety

### DIFF
--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -6,6 +6,9 @@ import { environment } from '../../environments/environment';
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private http = inject(HttpClient);
+  private hasLocalStorage(): boolean {
+    return typeof localStorage !== 'undefined';
+  }
   private readonly roles = signal<string[]>(this.getRolesFromToken());
 
   hasRole(role: string): boolean {
@@ -13,33 +16,44 @@ export class AuthService {
   }
 
   login(data: { email: string; password: string }): Observable<{ access_token: string }> {
-    return this.http
-      .post<{ access_token: string }>(`${environment.apiUrl}/auth/login`, data)
-      .pipe(
-        tap(res => {
+    return this.http.post<{ access_token: string }>(`${environment.apiUrl}/auth/login`, data).pipe(
+      tap((res) => {
+        if (this.hasLocalStorage()) {
           localStorage.setItem('token', res.access_token);
           this.roles.set(this.getRolesFromToken());
-        })
-      );
+        }
+      }),
+    );
   }
 
-  register(data: { name?: string; email: string; password: string }): Observable<{ access_token: string }> {
+  register(data: {
+    name?: string;
+    email: string;
+    password: string;
+  }): Observable<{ access_token: string }> {
     return this.http
       .post<{ access_token: string }>(`${environment.apiUrl}/auth/register`, data)
       .pipe(
-        tap(res => {
-          localStorage.setItem('token', res.access_token);
-          this.roles.set(this.getRolesFromToken());
-        })
+        tap((res) => {
+          if (this.hasLocalStorage()) {
+            localStorage.setItem('token', res.access_token);
+            this.roles.set(this.getRolesFromToken());
+          }
+        }),
       );
   }
 
   logout(): void {
-    localStorage.removeItem('token');
+    if (this.hasLocalStorage()) {
+      localStorage.removeItem('token');
+    }
     this.roles.set([]);
   }
 
   getToken(): string | null {
+    if (!this.hasLocalStorage()) {
+      return null;
+    }
     return localStorage.getItem('token');
   }
 
@@ -66,4 +80,3 @@ export class AuthService {
     }
   }
 }
-


### PR DESCRIPTION
## Summary
- avoid ReferenceError during SSR by checking for localStorage before use
- update auth service to handle missing localStorage when setting, retrieving, or clearing tokens
- ensure hasLocalStorage is a method to prevent initialization ordering issues

## Testing
- `CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Can not find the binary chromium-browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bc73f14883259e3fef1d26be2339