### PR TITLE
feat: add email-based login and registration

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-import { User, UserRole } from '../users/user.entity';
+import { UserRole } from '../users/user.entity';
 import { RegisterDto } from './dto/register.dto';
 import { RequestPasswordResetDto } from './dto/request-password-reset.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
@@ -37,32 +37,28 @@ describe('AuthController', () => {
     controller = module.get<AuthController>(AuthController);
   });
 
-  it('registers a new user without returning password', async () => {
+  it('registers a new user and returns auth tokens', async () => {
     const dto: RegisterDto = {
       username: 'user',
       email: 'user@example.com',
       password: 'pass',
     };
-    const user: User = {
-      id: 1,
-      username: 'user',
-      email: 'user@example.com',
-      password: 'hashed',
-      role: UserRole.Customer,
-      passwordResetToken: null,
-      passwordResetExpires: null,
-    } as User;
-    authService.register.mockResolvedValue(user);
+    const response = {
+      access_token: 'access',
+      refresh_token: 'refresh',
+      user: {
+        id: 1,
+        username: 'user',
+        email: 'user@example.com',
+        role: UserRole.Customer,
+      },
+    };
+    authService.register.mockResolvedValue(response);
 
     const result = await controller.register(dto);
 
     expect(authService.register).toHaveBeenCalledWith(dto);
-    expect(result).toEqual({
-      id: 1,
-      username: 'user',
-      email: 'user@example.com',
-      role: UserRole.Customer,
-    });
+    expect(result).toEqual(response);
   });
 
   it('requests password reset', async () => {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -20,7 +20,7 @@ export class AuthController {
   @ApiResponse({ status: 200, description: 'JWT token payload' })
   async login(@Body() loginDto: LoginDto) {
     const user: User = await this.authService.validateUser(
-      loginDto.username,
+      loginDto.email,
       loginDto.password,
     );
     return this.authService.login(user);
@@ -31,13 +31,7 @@ export class AuthController {
   @ApiOperation({ summary: 'Register a new user' })
   @ApiResponse({ status: 201, description: 'Created user' })
   async register(@Body() registerDto: RegisterDto) {
-    const user = await this.authService.register(registerDto);
-    const { password, passwordResetToken, passwordResetExpires, ...result } =
-      user;
-    void passwordResetToken; // mark intentionally unused
-    void passwordResetExpires;
-    void password;
-    return result;
+    return this.authService.register(registerDto);
   }
 
   @Public()

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -18,8 +18,8 @@ export class AuthService {
     private readonly refreshTokenRepository: Repository<RefreshToken>,
   ) {}
 
-  async validateUser(username: string, pass: string): Promise<User> {
-    const user = await this.usersService.findByUsername(username);
+  async validateUser(email: string, pass: string): Promise<User> {
+    const user = await this.usersService.findByEmail(email);
     if (!user) {
       throw new UnauthorizedException('Invalid credentials');
     }
@@ -57,11 +57,12 @@ export class AuthService {
     };
   }
 
-  async register(registerDto: RegisterDto): Promise<User> {
+  async register(registerDto: RegisterDto) {
     // Validate password strength
     validatePasswordStrength(registerDto.password);
 
-    return this.usersService.create(registerDto);
+    const user = await this.usersService.create(registerDto);
+    return this.login(user);
   }
 
   async requestPasswordReset(email: string): Promise<void> {

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,10 +1,10 @@
-import { IsString } from 'class-validator';
+import { IsEmail, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
   @ApiProperty()
-  @IsString()
-  username: string;
+  @IsEmail()
+  email: string;
 
   @ApiProperty()
   @IsString()

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -27,7 +27,7 @@ export class AuthService {
   }
 
   register(data: {
-    name?: string;
+    username: string;
     email: string;
     password: string;
   }): Observable<{ access_token: string }> {

--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -10,7 +10,7 @@ import { AuthService } from '../auth.service';
   imports: [CommonModule, ReactiveFormsModule],
   template: `
     <form [formGroup]="form" (ngSubmit)="submit()">
-      <input type="text" formControlName="name" placeholder="Name" />
+      <input type="text" formControlName="username" placeholder="Username" />
       <input type="email" formControlName="email" placeholder="Email" />
       <input type="password" formControlName="password" placeholder="Password" />
       <button type="submit">Register</button>
@@ -23,7 +23,7 @@ export class RegisterComponent {
   private fb = inject(FormBuilder);
 
   form = this.fb.nonNullable.group({
-    name: ['', Validators.required],
+    username: ['', Validators.required],
     email: ['', [Validators.required, Validators.email]],
     password: ['', Validators.required]
   });

--- a/frontend/src/environments/environment.production.ts
+++ b/frontend/src/environments/environment.production.ts
@@ -1,4 +1,8 @@
+const apiUrl =
+  (typeof process !== 'undefined' && process.env['API_URL']) ||
+  'https://rflandscaperpro.com/api';
+
 export const environment = {
   production: true,
-  apiUrl: process.env['API_URL'] || 'https://rflandscaperpro.com/api'
+  apiUrl,
 };

--- a/frontend/src/environments/environment.staging.ts
+++ b/frontend/src/environments/environment.staging.ts
@@ -1,4 +1,8 @@
+const apiUrl =
+  (typeof process !== 'undefined' && process.env['API_URL']) ||
+  'https://staging.rflandscaperpro.com/api';
+
 export const environment = {
   production: false,
-  apiUrl: process.env['API_URL'] || 'https://staging.rflandscaperpro.com/api'
+  apiUrl,
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,4 +1,8 @@
+const apiUrl =
+  (typeof process !== 'undefined' && process.env['API_URL']) ||
+  'http://backend:3000/api';
+
 export const environment = {
   production: false,
-  apiUrl: process.env['API_URL'] || 'http://backend:3000/api',
+  apiUrl,
 };


### PR DESCRIPTION
## Summary
- support email-based login in backend
- return auth tokens from registration endpoint
- wire up frontend registration form and service

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c05b43b88325aa935bb6937bd2eb