### PR TITLE
fix: use localhost API URL for development

### DIFF
--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://backend:3000",
+    "target": "http://localhost:3000",
     "secure": false
   }
 }

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,6 +1,6 @@
 const apiUrl =
   (typeof process !== 'undefined' && process.env['API_URL']) ||
-  'http://backend:3000/api';
+  'http://localhost:3000/api';
 
 export const environment = {
   production: false,


### PR DESCRIPTION
## Summary
- default dev API URL to `http://localhost:3000/api`
- update proxy config to point to localhost

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless requires snap)*
- `npm run build` *(fails: equipment/:id route uses prerendering without getPrerenderParams)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d783577c8325974bdd27a4536ac0