### PR TITLE
Redirect post-auth flows to dashboard

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { AuthGuard } from './auth/auth.guard';
 import { AdminGuard } from './auth/admin.guard';
+import { RootRedirectGuard } from './auth/root-redirect.guard';
 
 export const routes: Routes = [
   {
@@ -43,7 +44,7 @@ export const routes: Routes = [
   },
   {
     path: '',
-    redirectTo: 'dashboard',
+    canActivate: [RootRedirectGuard],
     pathMatch: 'full'
   }
 ];

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -43,7 +43,7 @@ export const routes: Routes = [
   },
   {
     path: '',
-    redirectTo: 'login',
+    redirectTo: 'dashboard',
     pathMatch: 'full'
   }
 ];

--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -29,7 +29,7 @@ export class LoginComponent {
   submit(): void {
     if (this.form.valid) {
       this.auth.login(this.form.getRawValue()).subscribe(() => {
-        this.router.navigate(['/']);
+        this.router.navigate(['/dashboard']);
       });
     }
   }

--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -31,7 +31,7 @@ export class RegisterComponent {
   submit(): void {
     if (this.form.valid) {
       this.auth.register(this.form.getRawValue()).subscribe(() => {
-        this.router.navigate(['/']);
+        this.router.navigate(['/dashboard']);
       });
     }
   }

--- a/frontend/src/app/auth/root-redirect.guard.ts
+++ b/frontend/src/app/auth/root-redirect.guard.ts
@@ -1,0 +1,13 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const RootRedirectGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  return auth.isAuthenticated()
+    ? router.parseUrl('/dashboard')
+    : router.parseUrl('/login');
+};
+


### PR DESCRIPTION
## Summary
- Send users to `/dashboard` after logging in or registering
- Redirect root route to the dashboard rather than the login screen

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless failed to start; chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d95fac3c8325aceaf490f0cb5a77