### PR TITLE
Add registration links to layout and login

### DIFF
--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -1,19 +1,20 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { AuthService } from '../auth.service';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
   template: `
     <form [formGroup]="form" (ngSubmit)="submit()">
       <input type="email" formControlName="email" placeholder="Email" />
       <input type="password" formControlName="password" placeholder="Password" />
       <button type="submit">Login</button>
     </form>
+    <p><small><a routerLink="/register">Create account</a></small></p>
   `
 })
 export class LoginComponent {

--- a/frontend/src/app/layout/layout.component.html
+++ b/frontend/src/app/layout/layout.component.html
@@ -4,6 +4,7 @@
 <div class="container">
   <nav class="sidebar">
     <a *ngIf="!auth.isAuthenticated()" routerLink="/login" routerLinkActive="active">Login</a>
+    <a *ngIf="!auth.isAuthenticated()" routerLink="/register" routerLinkActive="active">Register</a>
     <button *ngIf="auth.isAuthenticated()" (click)="logout()">Logout</button>
     <a *ngIf="auth.hasRole('admin')" routerLink="/users" routerLinkActive="active">Admin Panel</a>
     <a routerLink="/customers" routerLinkActive="active">Customers</a>


### PR DESCRIPTION
## Summary
- Add Register link in the sidebar layout when not authenticated
- Import RouterLink and show Create account link under login form

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: routes with parameters missing getPrerenderParams)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d949ce9483258ce9d1085d711738