### PR TITLE
feat: add company contact fields

### DIFF
--- a/backend/src/companies/companies.controller.ts
+++ b/backend/src/companies/companies.controller.ts
@@ -35,7 +35,7 @@ export class CompaniesController {
   ): Promise<CompanyResponseDto> {
     const company = await this.companiesService.findByUserId(req.user.userId);
     if (!company) throw new NotFoundException('Company not found');
-    return { id: company.id, name: company.name };
+    return company;
   }
 
   @Roles(UserRole.Owner)
@@ -56,8 +56,7 @@ export class CompaniesController {
     @Body() dto: CreateCompanyDto,
     @Req() req: { user: { userId: number } },
   ): Promise<CompanyResponseDto> {
-    const company = await this.companiesService.create(dto, req.user.userId);
-    return { id: company.id, name: company.name };
+    return this.companiesService.create(dto, req.user.userId);
   }
 
   @Roles(UserRole.Owner, UserRole.Admin)
@@ -69,7 +68,6 @@ export class CompaniesController {
   ): Promise<CompanyResponseDto> {
     if (req.user.companyId !== id)
       throw new NotFoundException('Company not found');
-    const company = await this.companiesService.update(id, dto);
-    return { id: company.id, name: company.name };
+    return this.companiesService.update(id, dto);
   }
 }

--- a/backend/src/companies/dto/company-response.dto.ts
+++ b/backend/src/companies/dto/company-response.dto.ts
@@ -1,4 +1,7 @@
 export class CompanyResponseDto {
   id: number;
   name: string;
+  address?: string | null;
+  phone?: string | null;
+  email?: string | null;
 }

--- a/backend/src/companies/dto/create-company.dto.ts
+++ b/backend/src/companies/dto/create-company.dto.ts
@@ -1,6 +1,18 @@
-import { IsString } from 'class-validator';
+import { IsEmail, IsOptional, IsString } from 'class-validator';
 
 export class CreateCompanyDto {
   @IsString()
   name: string;
+
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
 }

--- a/backend/src/companies/dto/update-company.dto.ts
+++ b/backend/src/companies/dto/update-company.dto.ts
@@ -1,7 +1,19 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsEmail, IsOptional, IsString } from 'class-validator';
 
 export class UpdateCompanyDto {
   @IsOptional()
   @IsString()
   name?: string;
+
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
 }

--- a/backend/src/companies/entities/company.entity.ts
+++ b/backend/src/companies/entities/company.entity.ts
@@ -21,6 +21,15 @@ export class Company {
   name: string;
 
   @Column({ nullable: true })
+  address?: string;
+
+  @Column({ nullable: true })
+  phone?: string;
+
+  @Column({ nullable: true })
+  email?: string;
+
+  @Column({ nullable: true })
   ownerId?: number;
 
   @ManyToOne(() => User, { nullable: true })

--- a/backend/src/migrations/1756422198641-add-company-contact-fields.ts
+++ b/backend/src/migrations/1756422198641-add-company-contact-fields.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCompanyContactFields1756422198641
+  implements MigrationInterface
+{
+  name = 'AddCompanyContactFields1756422198641';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "company" ADD "address" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "company" ADD "phone" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "company" ADD "email" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "company" DROP COLUMN "email"`);
+    await queryRunner.query(`ALTER TABLE "company" DROP COLUMN "phone"`);
+    await queryRunner.query(`ALTER TABLE "company" DROP COLUMN "address"`);
+  }
+}


### PR DESCRIPTION
## Summary
- add address, phone, and email fields to companies
- expose and validate new company contact fields in DTOs, service, and controller
- create migration to add contact columns to company table

## Testing
- `npm run lint`
- `npm test`
- `npm run migration:run`


------
https://chatgpt.com/codex/tasks/task_e_68b0df538084832595331f84a7e14ba6