### PR TITLE
chore: add dev scripts for migrations and seeds

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -57,15 +57,15 @@ LOG_LEVEL=debug
 createdb rflandscaperpro
 
 # Run database migrations (when available)
-npx cross-env NODE_ENV=development npm run migration:run
+npm run migration:run:dev
 
 # Seed initial data (creates admin user and sample customer)
 # This script is intended for local development only and will
 # automatically skip execution when `NODE_ENV=production`.
-npx cross-env NODE_ENV=development npm run seed
+npm run seed:dev
 
 # Drop and re-seed the database from scratch
-npx cross-env NODE_ENV=development npm run seed:drop
+npm run seed:drop:dev
 
 ```
 
@@ -194,22 +194,22 @@ npm run format
 ### **Database**
 ```bash
 # Create new migration
-npx cross-env NODE_ENV=development npm run migration:create
+npm run migration:create:dev
 
 # Generate migration from entity changes
-npx cross-env NODE_ENV=development npm run migration:generate
+npm run migration:generate:dev
 
 # Run pending migrations
-npx cross-env NODE_ENV=development npm run migration:run
+npm run migration:run:dev
 
 # Revert last migration
-npx cross-env NODE_ENV=development npm run migration:revert
+npm run migration:revert:dev
 
 # Seed database with sample data
-npx cross-env NODE_ENV=development npm run seed
+npm run seed:dev
 
 # Drop and re-seed the database from scratch
-npx cross-env NODE_ENV=development npm run seed:drop
+npm run seed:drop:dev
 ```
 
 ## 🗄️ **Database Schema**

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,8 +23,14 @@
     "migration:generate": "node scripts/generate-migration.mjs",
     "migration:run": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:run -d data-source.ts",
     "migration:revert": "ts-node --transpile-only ./node_modules/typeorm/cli.js migration:revert -d data-source.ts",
+    "migration:create:dev": "cross-env NODE_ENV=development npm run migration:create --",
+    "migration:generate:dev": "cross-env NODE_ENV=development npm run migration:generate --",
+    "migration:run:dev": "cross-env NODE_ENV=development npm run migration:run --",
+    "migration:revert:dev": "cross-env NODE_ENV=development npm run migration:revert --",
     "seed": "ts-node src/seed.ts",
-    "seed:drop": "ts-node src/seed.ts --drop"
+    "seed:dev": "cross-env NODE_ENV=development npm run seed",
+    "seed:drop": "ts-node src/seed.ts --drop",
+    "seed:drop:dev": "cross-env NODE_ENV=development npm run seed:drop"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^3.0.1",


### PR DESCRIPTION
## Summary
- add cross-env dev wrappers for TypeORM migrations and seed scripts
- document migration and seed commands using npm scripts

## Testing
- `NODE_ENV=production npm run seed`
- `NODE_ENV=production npm run seed:dev`
- `pwsh -Command '$env:NODE_ENV="production"; npm run seed'`
- `pwsh -Command '$env:NODE_ENV="production"; npm run seed:dev'`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0dfe9766c832597ec85fd623e2cc8