### PR TITLE
feat: support company data in user registration and forms

### DIFF
--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -56,7 +56,11 @@ export interface User {
   firstName?: string;
   lastName?: string;
   phone?: string;
-  companyName?: string;
+  company?: {
+    name: string;
+    address?: string;
+    phone?: string;
+  };
 }
 
 export type CreateUser = Partial<Omit<User, 'id'>>;
@@ -65,6 +69,8 @@ export type UpdateUser = Partial<CreateUser>;
 export interface Company {
   id: number;
   name: string;
+  address?: string;
+  phone?: string;
 }
 
 export type CreateCompany = Partial<Omit<Company, 'id'>>;

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -30,6 +30,8 @@ export class AuthService {
     username: string;
     email: string;
     password: string;
+    role?: string;
+    company?: { name: string; address?: string; phone?: string };
   }): Observable<{ access_token: string }> {
     return this.http
       .post<{ access_token: string }>(`${environment.apiUrl}/auth/register`, data)

--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -13,6 +13,19 @@ import { AuthService } from '../auth.service';
       <input type="text" formControlName="username" placeholder="Username" />
       <input type="email" formControlName="email" placeholder="Email" />
       <input type="password" formControlName="password" placeholder="Password" />
+      <label>
+        Role:
+        <select formControlName="role">
+          <option value="customer">Customer</option>
+          <option value="owner">Owner</option>
+          <option value="worker">Worker</option>
+        </select>
+      </label>
+      <div formGroupName="company" *ngIf="isOwner">
+        <input type="text" formControlName="name" placeholder="Company Name" />
+        <input type="text" formControlName="address" placeholder="Address" />
+        <input type="text" formControlName="phone" placeholder="Phone" />
+      </div>
       <button type="submit">Register</button>
     </form>
   `
@@ -25,12 +38,27 @@ export class RegisterComponent {
   form = this.fb.nonNullable.group({
     username: ['', Validators.required],
     email: ['', [Validators.required, Validators.email]],
-    password: ['', Validators.required]
+    password: ['', Validators.required],
+    role: ['customer', Validators.required],
+    company: this.fb.nonNullable.group({
+      name: [''],
+      address: [''],
+      phone: [''],
+    }),
   });
+
+  get isOwner(): boolean {
+    return this.form.controls.role.value === 'owner';
+  }
 
   submit(): void {
     if (this.form.valid) {
-      this.auth.register(this.form.getRawValue()).subscribe(() => {
+      const { username, email, password, role, company } = this.form.getRawValue();
+      const payload: any = { username, email, password, role };
+      if (this.isOwner) {
+        payload.company = company;
+      }
+      this.auth.register(payload).subscribe(() => {
         this.router.navigate(['/dashboard']);
       });
     }

--- a/frontend/src/app/users/user-form.component.ts
+++ b/frontend/src/app/users/user-form.component.ts
@@ -37,12 +37,26 @@ import { UserService } from './user.service';
       </label>
       <label>
         Role:
-        <input formControlName="role" />
+        <select formControlName="role">
+          <option value="customer">Customer</option>
+          <option value="owner">Owner</option>
+          <option value="worker">Worker</option>
+        </select>
       </label>
-      <label *ngIf="isOwner">
-        Company Name:
-        <input formControlName="companyName" />
-      </label>
+      <div formGroupName="company" *ngIf="isOwner">
+        <label>
+          Company Name:
+          <input formControlName="name" />
+        </label>
+        <label>
+          Address:
+          <input formControlName="address" />
+        </label>
+        <label>
+          Phone:
+          <input formControlName="phone" />
+        </label>
+      </div>
       <button type="submit" [disabled]="form.invalid">Save</button>
     </form>
   `
@@ -59,8 +73,12 @@ export class UserFormComponent {
     firstName: [''],
     lastName: [''],
     phone: [''],
-    role: [''],
-    companyName: ['']
+    role: ['customer'],
+    company: this.fb.nonNullable.group({
+      name: [''],
+      address: [''],
+      phone: [''],
+    }),
   });
 
   onSubmit(): void {
@@ -73,14 +91,14 @@ export class UserFormComponent {
         lastName,
         phone,
         role,
-        companyName
+        company,
       } = this.form.getRawValue();
       const payload: any = { username, email, password };
       if (firstName) payload.firstName = firstName;
       if (lastName) payload.lastName = lastName;
       if (phone) payload.phone = phone;
       if (role) payload.role = role;
-      if (companyName) payload.companyName = companyName;
+      if (this.isOwner) payload.company = company;
       this.userService
         .createUser(payload)
         .subscribe(() => {

--- a/frontend/src/app/users/user.service.ts
+++ b/frontend/src/app/users/user.service.ts
@@ -3,12 +3,18 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 
+export interface Company {
+  name: string;
+  address?: string;
+  phone?: string;
+}
+
 export interface User {
   id: number;
   username: string;
   email: string;
   role: string;
-  companyName?: string;
+  company?: Company;
   firstName?: string;
   lastName?: string;
   phone?: string;


### PR DESCRIPTION
## Summary
- add role selection and company fields to registration form
- handle company payloads in auth and user services
- update user form to conditionally collect company details

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e2ee5d748325be186a6ade6814e6