### PR TITLE
feat: expose company contact fields

### DIFF
--- a/backend/src/companies/companies.controller.ts
+++ b/backend/src/companies/companies.controller.ts
@@ -34,7 +34,9 @@ export class CompaniesController {
     @Req() req: { user: { userId: number } },
   ): Promise<CompanyResponseDto> {
     const company = await this.companiesService.findByUserId(req.user.userId);
-    if (!company) throw new NotFoundException('Company not found');
+    if (!company) {
+      throw new NotFoundException('Company not found');
+    }
     return company;
   }
 

--- a/backend/src/companies/companies.service.ts
+++ b/backend/src/companies/companies.service.ts
@@ -54,6 +54,7 @@ export class CompaniesService {
       address: company.address ?? null,
       phone: company.phone ?? null,
       email: company.email ?? null,
+      ownerId: company.ownerId ?? null,
     };
   }
 }

--- a/backend/src/companies/dto/company-response.dto.ts
+++ b/backend/src/companies/dto/company-response.dto.ts
@@ -1,7 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CompanyResponseDto {
-  id: number;
-  name: string;
-  address?: string | null;
-  phone?: string | null;
-  email?: string | null;
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ nullable: true })
+  address!: string | null;
+
+  @ApiProperty({ nullable: true })
+  phone!: string | null;
+
+  @ApiProperty({ nullable: true })
+  email!: string | null;
+
+  @ApiProperty({ nullable: true })
+  ownerId!: number | null;
 }

--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -71,6 +71,8 @@ export interface Company {
   name: string;
   address?: string;
   phone?: string;
+  email?: string;
+  ownerId?: number;
 }
 
 export type CreateCompany = Partial<Omit<Company, 'id'>>;

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -31,7 +31,7 @@ export class AuthService {
     email: string;
     password: string;
     role?: string;
-    company?: { name: string; address?: string; phone?: string };
+    company?: { name: string; address?: string; phone?: string; email?: string };
   }): Observable<{ access_token: string }> {
     return this.http
       .post<{ access_token: string }>(`${environment.apiUrl}/auth/register`, data)

--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -25,6 +25,7 @@ import { AuthService } from '../auth.service';
         <input type="text" formControlName="name" placeholder="Company Name" />
         <input type="text" formControlName="address" placeholder="Address" />
         <input type="text" formControlName="phone" placeholder="Phone" />
+        <input type="email" formControlName="email" placeholder="Email" />
       </div>
       <button type="submit">Register</button>
     </form>
@@ -44,6 +45,7 @@ export class RegisterComponent {
       name: [''],
       address: [''],
       phone: [''],
+      email: [''],
     }),
   });
 

--- a/frontend/src/app/companies/company.model.ts
+++ b/frontend/src/app/companies/company.model.ts
@@ -1,0 +1,9 @@
+export interface Company {
+  id?: number;
+  name: string;
+  address?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  ownerId?: number | null;
+}
+

--- a/frontend/src/app/companies/company.service.ts
+++ b/frontend/src/app/companies/company.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable } from 'rxjs';
+import { Company } from './company.model';
+import { User } from '../users/user.service';
+
+@Injectable({ providedIn: 'root' })
+export class CompanyService {
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.apiUrl}/companies`;
+
+  getProfile(): Observable<Company> {
+    return this.http.get<Company>(`${this.baseUrl}/profile`);
+  }
+
+  getWorkers(): Observable<User[]> {
+    return this.http.get<User[]>(`${this.baseUrl}/workers`);
+  }
+
+  createCompany(company: Partial<Company>): Observable<Company> {
+    return this.http.post<Company>(this.baseUrl, company);
+  }
+
+  updateCompany(id: number, company: Partial<Company>): Observable<Company> {
+    return this.http.patch<Company>(`${this.baseUrl}/${id}`, company);
+  }
+}
+

--- a/frontend/src/app/users/user-form.component.ts
+++ b/frontend/src/app/users/user-form.component.ts
@@ -56,6 +56,10 @@ import { UserService } from './user.service';
           Phone:
           <input formControlName="phone" />
         </label>
+        <label>
+          Email:
+          <input formControlName="email" />
+        </label>
       </div>
       <button type="submit" [disabled]="form.invalid">Save</button>
     </form>
@@ -78,6 +82,7 @@ export class UserFormComponent {
       name: [''],
       address: [''],
       phone: [''],
+      email: [''],
     }),
   });
 

--- a/frontend/src/app/users/user.service.ts
+++ b/frontend/src/app/users/user.service.ts
@@ -2,12 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
-
-export interface Company {
-  name: string;
-  address?: string;
-  phone?: string;
-}
+import { Company } from '../companies/company.model';
 
 export interface User {
   id: number;


### PR DESCRIPTION
## Summary
- return address, phone, email, and ownerId from company endpoints
- add Company model/service and surface email fields in registration and user forms

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e63b82e88325acd2cad86b35d0be