### PR TITLE
feat: enable optional remote logging

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -49,9 +49,15 @@ DB_PASSWORD=your_password
 DB_NAME=rflandscaperpro
 JWT_SECRET=your_secure_jwt_secret
 LOG_LEVEL=debug
+# Remote log forwarding (optional)
+# REMOTE_LOG_HOST=logs.example.com
+# REMOTE_LOG_PORT=1234
+# REMOTE_LOG_PATH=/
 ```
 
 SMTP settings are only required in production. During development and testing the application uses an Ethereal account automatically and logs preview URLs for any emails sent.
+
+Remote logging is only enabled when `REMOTE_LOG_HOST` is defined. When omitted, logs are written to the console and `app.log` file only.
 
 ### 3. Database Setup
 ```bash

--- a/backend/src/logger/logger.module.ts
+++ b/backend/src/logger/logger.module.ts
@@ -1,17 +1,24 @@
 import { WinstonModule } from 'nest-winston';
 import * as winston from 'winston';
 
-export const LoggerModule = WinstonModule.forRoot({
-  level: process.env.LOG_LEVEL || 'info',
-  transports: [
-    new winston.transports.Console(),
-    new winston.transports.File({ filename: 'app.log' }),
+const transports: winston.transport[] = [
+  new winston.transports.Console(),
+  new winston.transports.File({ filename: 'app.log' }),
+];
+
+if (process.env.REMOTE_LOG_HOST) {
+  transports.push(
     new winston.transports.Http({
-      host: process.env.REMOTE_LOG_HOST || 'localhost',
+      host: process.env.REMOTE_LOG_HOST,
       port: process.env.REMOTE_LOG_PORT
         ? Number(process.env.REMOTE_LOG_PORT)
         : 1234,
       path: process.env.REMOTE_LOG_PATH || '/',
     }),
-  ],
+  );
+}
+
+export const LoggerModule = WinstonModule.forRoot({
+  level: process.env.LOG_LEVEL || 'info',
+  transports,
 });


### PR DESCRIPTION
## Summary
- add conditional HTTP transport for remote logging
- document optional remote logging configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0eadd0db883258bc715e5d972846c