### PR TITLE
feat(auth): add email verification

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -12,6 +12,7 @@ describe('AuthController', () => {
     validateUser: jest.Mock;
     login: jest.Mock;
     register: jest.Mock;
+    verifyEmail: jest.Mock;
     requestPasswordReset: jest.Mock;
     resetPassword: jest.Mock;
     refresh: jest.Mock;
@@ -23,6 +24,7 @@ describe('AuthController', () => {
       validateUser: jest.fn(),
       login: jest.fn(),
       register: jest.fn(),
+      verifyEmail: jest.fn(),
       requestPasswordReset: jest.fn(),
       resetPassword: jest.fn(),
       refresh: jest.fn(),
@@ -37,28 +39,24 @@ describe('AuthController', () => {
     controller = module.get<AuthController>(AuthController);
   });
 
-  it('registers a new user and returns auth tokens', async () => {
+  it('registers a new user and sends verification email', async () => {
     const dto: RegisterDto = {
       username: 'user',
       email: 'user@example.com',
       password: 'pass',
     };
-    const response = {
-      access_token: 'access',
-      refresh_token: 'refresh',
-      user: {
-        id: 1,
-        username: 'user',
-        email: 'user@example.com',
-        role: UserRole.Customer,
-      },
-    };
+    const response = { message: 'Verification email sent' };
     authService.register.mockResolvedValue(response);
 
     const result = await controller.register(dto);
 
     expect(authService.register).toHaveBeenCalledWith(dto);
     expect(result).toEqual(response);
+  });
+
+  it('verifies email', async () => {
+    await controller.verifyEmail({ token: 'abc' });
+    expect(authService.verifyEmail).toHaveBeenCalledWith('abc');
   });
 
   it('requests password reset', async () => {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { Public } from '../common/decorators/public.decorator';
 import { User } from '../users/user.entity';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { VerifyEmailDto } from './dto/verify-email.dto';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -32,6 +33,15 @@ export class AuthController {
   @ApiResponse({ status: 201, description: 'Created user' })
   async register(@Body() registerDto: RegisterDto) {
     return this.authService.register(registerDto);
+  }
+
+  @Public()
+  @Post('verify-email')
+  @ApiOperation({ summary: 'Verify user email' })
+  @ApiResponse({ status: 200, description: 'Email verified' })
+  async verifyEmail(@Body() dto: VerifyEmailDto): Promise<{ message: string }> {
+    await this.authService.verifyEmail(dto.token);
+    return { message: 'Email verified' };
   }
 
   @Public()

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -7,12 +7,15 @@ import { AuthController } from './auth.controller';
 import { UsersModule } from '../users/users.module';
 import { JwtStrategy } from './jwt.strategy';
 import { RefreshToken } from './refresh-token.entity';
+import { VerificationToken } from './verification-token.entity';
+import { User } from '../users/user.entity';
+import { EmailService } from '../common/email.service';
 
 @Module({
   imports: [
     UsersModule,
     ConfigModule,
-    TypeOrmModule.forFeature([RefreshToken]),
+    TypeOrmModule.forFeature([RefreshToken, VerificationToken, User]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -29,7 +32,7 @@ import { RefreshToken } from './refresh-token.entity';
       },
     }),
   ],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, EmailService],
   controllers: [AuthController],
   exports: [AuthService],
 })

--- a/backend/src/auth/dto/verify-email.dto.ts
+++ b/backend/src/auth/dto/verify-email.dto.ts
@@ -1,0 +1,8 @@
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VerifyEmailDto {
+  @ApiProperty()
+  @IsString()
+  token: string;
+}

--- a/backend/src/auth/verification-token.entity.ts
+++ b/backend/src/auth/verification-token.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+
+@Entity()
+export class VerificationToken {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  token: string;
+
+  @Column({ type: 'timestamptz' })
+  expiresAt: Date;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column()
+  userId: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/common/email.service.ts
+++ b/backend/src/common/email.service.ts
@@ -138,6 +138,18 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
     });
   }
 
+  async sendVerificationEmail(
+    to: string,
+    token: string,
+  ): Promise<{ messageId: string; previewUrl?: string }> {
+    return this.sendMail({
+      to,
+      subject: 'Verify your email',
+      text: `Your verification token is: ${token}`,
+      html: `<p>Your verification token is: <strong>${token}</strong></p>`,
+    });
+  }
+
   async sendWelcomeEmail(
     to: string,
     username: string,

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -37,6 +37,9 @@ export class User {
   @Column({ type: 'enum', enum: UserRole, default: UserRole.Customer })
   role: UserRole;
 
+  @Column({ default: false })
+  isVerified: boolean;
+
   @Column({ type: 'varchar', nullable: true })
   firstName: string | null;
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -13,6 +13,10 @@ export const routes: Routes = [
     loadComponent: () => import('./auth/register/register.component').then(m => m.RegisterComponent)
   },
   {
+    path: 'verify',
+    loadComponent: () => import('./auth/verify/verify.component').then(m => m.VerifyComponent)
+  },
+  {
     path: 'customers',
     canActivate: [AuthGuard],
     loadChildren: () => import('./customers/customers.routes').then(m => m.customersRoutes)

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -32,17 +32,18 @@ export class AuthService {
     password: string;
     role?: string;
     company?: { name: string; address?: string; phone?: string; email?: string };
-  }): Observable<{ access_token: string }> {
-    return this.http
-      .post<{ access_token: string }>(`${environment.apiUrl}/auth/register`, data)
-      .pipe(
-        tap((res) => {
-          if (this.hasLocalStorage()) {
-            localStorage.setItem('token', res.access_token);
-            this.roles.set(this.getRolesFromToken());
-          }
-        }),
-      );
+  }): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(
+      `${environment.apiUrl}/auth/register`,
+      data,
+    );
+  }
+
+  verifyEmail(token: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(
+      `${environment.apiUrl}/auth/verify-email`,
+      { token },
+    );
   }
 
   logout(): void {

--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -61,7 +61,7 @@ export class RegisterComponent {
         payload.company = company;
       }
       this.auth.register(payload).subscribe(() => {
-        this.router.navigate(['/dashboard']);
+        this.router.navigate(['/login']);
       });
     }
   }

--- a/frontend/src/app/auth/verify/verify.component.ts
+++ b/frontend/src/app/auth/verify/verify.component.ts
@@ -1,0 +1,30 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { AuthService } from '../auth.service';
+
+@Component({
+  selector: 'app-verify',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <p>{{ message }}</p>
+  `,
+})
+export class VerifyComponent {
+  private route = inject(ActivatedRoute);
+  private auth = inject(AuthService);
+  message = 'Verifying...';
+
+  constructor() {
+    const token = this.route.snapshot.queryParamMap.get('token');
+    if (token) {
+      this.auth.verifyEmail(token).subscribe({
+        next: () => (this.message = 'Email verified. You can now login.'),
+        error: () => (this.message = 'Verification failed.'),
+      });
+    } else {
+      this.message = 'No token provided.';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add verification token entity and email service for verification mail
- require verified users before login and expose verification endpoint
- add Angular verification component and route; adjust registration flow

## Testing
- `npm test` (backend)
- `CHROME_BIN=chromium-browser npm test` (frontend, fails: Chrome requires snap)

------
https://chatgpt.com/codex/tasks/task_e_68b0eb52eaa88325877f8449c40829e2