### PR TITLE
feat: allow smtp creds in development

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -37,7 +37,11 @@ cp env.example .env.development
 ```
 
 ### 2. Environment Configuration
-Edit `.env.development` with your database credentials:
+Edit `.env.development` with your database credentials. You may also add SMTP settings
+(`SMTP_USER`, `SMTP_PASS`, and optional `SMTP_HOST`/`SMTP_PORT`) to send real emails
+during development.
+
+> **Note:** `.env.development` is git-ignored to keep secrets out of version control.
 
 ```env
 NODE_ENV=development
@@ -57,7 +61,8 @@ LOG_LEVEL=debug
 # REMOTE_LOG_PATH=/
 ```
 
-SMTP settings are only required in production. During development and testing the application uses an Ethereal account automatically and logs preview URLs for any emails sent.
+If no SMTP credentials are defined, the application falls back to an Ethereal test
+account and logs preview URLs for emails.
 
 Remote logging is only enabled when `REMOTE_LOG_HOST` is defined. When omitted, logs are written to the console and `app.log` file only.
 

--- a/backend/env.example
+++ b/backend/env.example
@@ -49,7 +49,9 @@ THROTTLE_LIMIT=20
 
 # Email Configuration
 # The backend uses an Ethereal test account automatically in development and test
-# environments. Configure the following settings only for production deployments.
+# environments unless SMTP_USER and SMTP_PASS are provided.
+# Optionally set the following variables to use a real SMTP server locally.
+# In production these settings are required.
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USER=your_email@example.com

--- a/backend/src/common/email.service.ts
+++ b/backend/src/common/email.service.ts
@@ -32,7 +32,8 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
   );
 
   private get driver(): MailDriver {
-    return process.env.NODE_ENV === 'production' ? 'smtp' : 'ethereal';
+    if (process.env.NODE_ENV === 'production') return 'smtp';
+    return process.env.SMTP_USER && process.env.SMTP_PASS ? 'smtp' : 'ethereal';
   }
 
   async onModuleInit(): Promise<void> {
@@ -40,6 +41,7 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
     this.logger.log(`Initializing EmailService with driver: ${driver}`);
 
     if (driver === 'ethereal') {
+      // Fall back to an Ethereal test account when no SMTP credentials are provided
       this.testAccount = await nodemailer.createTestAccount();
       this.transporter = nodemailer.createTransport({
         host: 'smtp.ethereal.email',


### PR DESCRIPTION
## Summary
- allow EmailService to use SMTP credentials when NODE_ENV is not production
- document optional SMTP_* env vars and .env.development handling

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment / member access warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f818701083258ddba1c1e1fda785