### PR TITLE
Fix owner worker creation

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -52,11 +52,11 @@ export class UsersController {
         throw new BadRequestException('Owners can only create workers');
       }
       const owner = await this.usersService.findById(req.user.userId);
-      if (!owner?.companyId) {
+      if (!owner?.company) {
         throw new NotFoundException('Owner company not found');
       }
       createUserDto.role = UserRole.Worker;
-      createUserDto.companyId = owner.companyId;
+      createUserDto.company = { name: owner.company.name };
     }
     const user = await this.usersService.create(createUserDto);
     return toUserResponseDto(user);

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -40,7 +40,10 @@ export class UsersService {
   }
 
   findById(id: number): Promise<User | null> {
-    return this.usersRepository.findOne({ where: { id } });
+    return this.usersRepository.findOne({
+      where: { id },
+      relations: ['company'],
+    });
   }
 
   findAll(): Promise<User[]> {


### PR DESCRIPTION
## Summary
- Assign worker company details when owner creates users
- Load company relation in UsersService.findById

## Testing
- `cd backend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b0f8b1e6588325a4ab1100920830d7