### PR TITLE
feat: enforce tenant context

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 import { MetricsThrottlerGuard } from './common/guards/metrics-throttler.guard';
+import { TenantGuard } from './common/tenant.guard';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { LoggerModule } from './logger/logger.module';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
@@ -129,6 +130,10 @@ import { ScheduleModule } from '@nestjs/schedule';
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: TenantGuard,
     },
     {
       provide: APP_GUARD,

--- a/backend/src/common/decorators/company.decorator.ts
+++ b/backend/src/common/decorators/company.decorator.ts
@@ -1,0 +1,10 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const Company = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): number | undefined => {
+    const request = ctx
+      .switchToHttp()
+      .getRequest<{ user?: { companyId?: number } }>();
+    return request.user?.companyId;
+  },
+);

--- a/backend/src/common/tenant.guard.ts
+++ b/backend/src/common/tenant.guard.ts
@@ -1,0 +1,22 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from './decorators/public.decorator';
+
+@Injectable()
+export class TenantGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+    const request = context
+      .switchToHttp()
+      .getRequest<{ user?: { companyId?: number } }>();
+    return Boolean(request.user?.companyId);
+  }
+}

--- a/backend/src/contracts/contracts.controller.ts
+++ b/backend/src/contracts/contracts.controller.ts
@@ -5,7 +5,6 @@ import {
   Patch,
   Body,
   Param,
-  Req,
   ParseIntPipe,
 } from '@nestjs/common';
 import { ContractsService } from './contracts.service';
@@ -14,6 +13,7 @@ import { UpdateContractDto } from './dto/update-contract.dto';
 import { ContractResponseDto } from './dto/contract-response.dto';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../users/user.entity';
+import { Company } from '../common/decorators/company.decorator';
 import {
   ApiBearerAuth,
   ApiTags,
@@ -33,19 +33,17 @@ export class ContractsController {
   @ApiResponse({ status: 201, type: ContractResponseDto })
   create(
     @Body() dto: CreateContractDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<ContractResponseDto> {
-    return this.contractsService.create(dto, req.user.companyId);
+    return this.contractsService.create(dto, companyId);
   }
 
   @Get()
   @Roles(UserRole.Admin, UserRole.Worker)
   @ApiOperation({ summary: 'List contracts' })
   @ApiResponse({ status: 200, type: [ContractResponseDto] })
-  findAll(
-    @Req() req: { user: { companyId: number } },
-  ): Promise<ContractResponseDto[]> {
-    return this.contractsService.findAll(req.user.companyId);
+  findAll(@Company() companyId: number): Promise<ContractResponseDto[]> {
+    return this.contractsService.findAll(companyId);
   }
 
   @Patch(':id')
@@ -55,9 +53,9 @@ export class ContractsController {
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() dto: UpdateContractDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<ContractResponseDto> {
-    return this.contractsService.update(id, dto, req.user.companyId);
+    return this.contractsService.update(id, dto, companyId);
   }
 
   @Post(':id/cancel')
@@ -66,8 +64,8 @@ export class ContractsController {
   @ApiResponse({ status: 200, description: 'Contract cancelled' })
   cancel(
     @Param('id', ParseIntPipe) id: number,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<void> {
-    return this.contractsService.cancel(id, req.user.companyId);
+    return this.contractsService.cancel(id, companyId);
   }
 }

--- a/backend/src/customers/customers.controller.spec.ts
+++ b/backend/src/customers/customers.controller.spec.ts
@@ -33,15 +33,25 @@ describe('CustomersController', () => {
       const pagination = new PaginationQueryDto();
       pagination.page = 1;
       pagination.limit = 10;
-      const req = { user: { companyId: 1 } };
+      const companyId = 1;
       const result = { items: [], total: 0 };
       const findAllSpy = jest
         .spyOn(service, 'findAll')
         .mockResolvedValue(result);
 
-      const response = await controller.findAll(pagination, req, true, 'john');
+      const response = await controller.findAll(
+        pagination,
+        companyId,
+        true,
+        'john',
+      );
 
-      expect(findAllSpy).toHaveBeenCalledWith(pagination, 1, true, 'john');
+      expect(findAllSpy).toHaveBeenCalledWith(
+        pagination,
+        companyId,
+        true,
+        'john',
+      );
       expect(response).toBe(result);
     });
   });

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -11,7 +11,6 @@ import {
   Query,
   HttpCode,
   HttpStatus,
-  Req,
 } from '@nestjs/common';
 
 import { CustomersService } from './customers.service';
@@ -21,6 +20,9 @@ import { CustomerResponseDto } from './dto/customer-response.dto';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../users/user.entity';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { Company } from '../common/decorators/company.decorator';
+import { AuthUser } from '../common/decorators/auth-user.decorator';
+import { User } from '../users/user.entity';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -45,9 +47,9 @@ export class CustomersController {
   })
   async create(
     @Body() createCustomerDto: CreateCustomerDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<CustomerResponseDto> {
-    return this.customersService.create(createCustomerDto, req.user.companyId);
+    return this.customersService.create(createCustomerDto, companyId);
   }
 
   @Get()
@@ -60,16 +62,11 @@ export class CustomersController {
   @ApiResponse({ status: 200, description: 'List of customers' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
     @Query('active', new ParseBoolPipe({ optional: true })) active?: boolean,
     @Query('search') search?: string,
   ): Promise<{ items: CustomerResponseDto[]; total: number }> {
-    return this.customersService.findAll(
-      pagination,
-      req.user.companyId,
-      active,
-      search,
-    );
+    return this.customersService.findAll(pagination, companyId, active, search);
   }
 
   @Get('profile')
@@ -80,13 +77,8 @@ export class CustomersController {
     description: 'Customer profile',
     type: CustomerResponseDto,
   })
-  async getProfile(
-    @Req() req: { user: { userId: number; companyId: number } },
-  ): Promise<CustomerResponseDto> {
-    return this.customersService.findByUserId(
-      req.user.userId,
-      req.user.companyId,
-    );
+  async getProfile(@AuthUser() user: User): Promise<CustomerResponseDto> {
+    return this.customersService.findByUserId(user.id, user.companyId!);
   }
 
   @Get(':id')
@@ -99,9 +91,9 @@ export class CustomersController {
   })
   async findOne(
     @Param('id', ParseIntPipe) id: number,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<CustomerResponseDto> {
-    return this.customersService.findOne(id, req.user.companyId);
+    return this.customersService.findOne(id, companyId);
   }
 
   @Patch(':id')
@@ -115,13 +107,9 @@ export class CustomersController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateCustomerDto: UpdateCustomerDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<CustomerResponseDto> {
-    return this.customersService.update(
-      id,
-      updateCustomerDto,
-      req.user.companyId,
-    );
+    return this.customersService.update(id, updateCustomerDto, companyId);
   }
 
   @Patch(':id/activate')
@@ -134,9 +122,9 @@ export class CustomersController {
   })
   async activate(
     @Param('id', ParseIntPipe) id: number,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<CustomerResponseDto> {
-    return this.customersService.activate(id, req.user.companyId);
+    return this.customersService.activate(id, companyId);
   }
 
   @Patch(':id/deactivate')
@@ -149,9 +137,9 @@ export class CustomersController {
   })
   async deactivate(
     @Param('id', ParseIntPipe) id: number,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<CustomerResponseDto> {
-    return this.customersService.deactivate(id, req.user.companyId);
+    return this.customersService.deactivate(id, companyId);
   }
 
   @Delete(':id')
@@ -161,8 +149,8 @@ export class CustomersController {
   @ApiResponse({ status: 204, description: 'Customer deleted' })
   async remove(
     @Param('id', ParseIntPipe) id: number,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<void> {
-    await this.customersService.remove(id, req.user.companyId);
+    await this.customersService.remove(id, companyId);
   }
 }

--- a/backend/src/equipment/equipment.controller.spec.ts
+++ b/backend/src/equipment/equipment.controller.spec.ts
@@ -32,17 +32,17 @@ describe('EquipmentController', () => {
 
   describe('updateStatus', () => {
     it('should pass companyId to equipmentService.updateStatus', async () => {
-      const req = { user: { companyId: 2 } };
+      const companyId = 2;
       const dto = { status: EquipmentStatus.AVAILABLE };
       const response = {} as EquipmentResponseDto;
       (service.updateStatus as jest.Mock).mockResolvedValue(response);
 
-      const result = await controller.updateStatus(1, dto, req);
+      const result = await controller.updateStatus(1, dto, companyId);
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(service.updateStatus).toHaveBeenCalledWith(
         1,
         dto.status,
-        req.user.companyId,
+        companyId,
       );
       expect(result).toBe(response);
     });
@@ -51,7 +51,7 @@ describe('EquipmentController', () => {
   describe('findAll', () => {
     it('should call equipmentService.findAll with companyId and search term', async () => {
       const pagination = { page: 1, limit: 10 };
-      const req = { user: { companyId: 1 } };
+      const companyId = 1;
       const status = EquipmentStatus.AVAILABLE;
       const type = EquipmentType.MOWER;
       const search = 'mower';
@@ -60,7 +60,7 @@ describe('EquipmentController', () => {
 
       const result = await controller.findAll(
         pagination,
-        req,
+        companyId,
         status,
         type,
         search,
@@ -69,7 +69,7 @@ describe('EquipmentController', () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(service.findAll).toHaveBeenCalledWith(
         pagination,
-        req.user.companyId,
+        companyId,
         status,
         type,
         search,

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -11,7 +11,6 @@ import {
   Query,
   HttpCode,
   HttpStatus,
-  Req,
 } from '@nestjs/common';
 import { EquipmentService } from './equipment.service';
 import { CreateEquipmentDto } from './dto/create-equipment.dto';
@@ -22,6 +21,7 @@ import { EquipmentStatus, EquipmentType } from './entities/equipment.entity';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../users/user.entity';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { Company } from '../common/decorators/company.decorator';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -46,9 +46,9 @@ export class EquipmentController {
   })
   async create(
     @Body() createEquipmentDto: CreateEquipmentDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<EquipmentResponseDto> {
-    return this.equipmentService.create(createEquipmentDto, req.user.companyId);
+    return this.equipmentService.create(createEquipmentDto, companyId);
   }
 
   @Get()
@@ -62,7 +62,7 @@ export class EquipmentController {
   @ApiResponse({ status: 200, description: 'List of equipment' })
   async findAll(
     @Query() pagination: PaginationQueryDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
     @Query('status', new ParseEnumPipe(EquipmentStatus, { optional: true }))
     status?: EquipmentStatus,
     @Query('type', new ParseEnumPipe(EquipmentType, { optional: true }))
@@ -71,7 +71,7 @@ export class EquipmentController {
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
     return this.equipmentService.findAll(
       pagination,
-      req.user.companyId,
+      companyId,
       status,
       type,
       search,
@@ -88,9 +88,9 @@ export class EquipmentController {
   })
   async findOne(
     @Param('id', ParseIntPipe) id: number,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<EquipmentResponseDto> {
-    return this.equipmentService.findOne(id, req.user.companyId);
+    return this.equipmentService.findOne(id, companyId);
   }
 
   @Patch(':id')
@@ -104,13 +104,9 @@ export class EquipmentController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateEquipmentDto: UpdateEquipmentDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<EquipmentResponseDto> {
-    return this.equipmentService.update(
-      id,
-      updateEquipmentDto,
-      req.user.companyId,
-    );
+    return this.equipmentService.update(id, updateEquipmentDto, companyId);
   }
 
   @Patch(':id/status')
@@ -124,12 +120,12 @@ export class EquipmentController {
   async updateStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateEquipmentStatusDto: UpdateEquipmentStatusDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<EquipmentResponseDto> {
     return this.equipmentService.updateStatus(
       id,
       updateEquipmentStatusDto.status,
-      req.user.companyId,
+      companyId,
     );
   }
 
@@ -140,8 +136,8 @@ export class EquipmentController {
   @ApiResponse({ status: 204, description: 'Equipment deleted' })
   async remove(
     @Param('id', ParseIntPipe) id: number,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<void> {
-    await this.equipmentService.remove(id, req.user.companyId);
+    await this.equipmentService.remove(id, companyId);
   }
 }

--- a/backend/src/jobs/jobs.controller.spec.ts
+++ b/backend/src/jobs/jobs.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
 
 describe('JobsController', () => {
   let controller: JobsController;
@@ -35,7 +35,7 @@ describe('JobsController', () => {
     const pagination = { page: 1, limit: 10 } as any;
     const result = await controller.findAll(
       pagination,
-      { user: { companyId: 1 } },
+      1,
       true,
       2,
       '2023-01-01',
@@ -61,20 +61,20 @@ describe('JobsController', () => {
       const pagination = { page: 1, limit: 10 } as any;
       const completed = true;
       const customerId = 2;
-      const req = { user: { companyId: 1 } } as any;
+      const companyId = 1;
       const result = { items: [], total: 0 };
       jobsService.findAll.mockResolvedValue(result);
 
       const response = await controller.findAll(
         pagination,
-        req,
+        companyId,
         completed,
         customerId,
       );
 
       expect(jobsService.findAll).toHaveBeenCalledWith(
         pagination,
-        req.user.companyId,
+        companyId,
         completed,
         customerId,
         undefined,

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -11,7 +11,6 @@ import {
   Query,
   HttpCode,
   HttpStatus,
-  Req,
 } from '@nestjs/common';
 
 import { JobsService } from './jobs.service';
@@ -24,6 +23,7 @@ import { ScheduleJobDto } from './dto/schedule-job.dto';
 import { AssignJobDto } from './dto/assign-job.dto';
 import { BulkAssignJobDto } from './dto/bulk-assign-job.dto';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { Company } from '../common/decorators/company.decorator';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -48,9 +48,9 @@ export class JobsController {
   })
   create(
     @Body() createJobDto: CreateJobDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<JobResponseDto> {
-    return this.jobsService.create(createJobDto, req.user.companyId);
+    return this.jobsService.create(createJobDto, companyId);
   }
 
   @Get()
@@ -67,7 +67,7 @@ export class JobsController {
   @ApiResponse({ status: 200, description: 'List of jobs' })
   findAll(
     @Query() pagination: PaginationQueryDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
     @Query('completed', new ParseBoolPipe({ optional: true }))
     completed?: boolean,
     @Query('customerId', new ParseIntPipe({ optional: true }))
@@ -80,7 +80,7 @@ export class JobsController {
   ): Promise<{ items: JobResponseDto[]; total: number }> {
     return this.jobsService.findAll(
       pagination,
-      req.user.companyId,
+      companyId,
       completed,
       customerId,
       startDate ? new Date(startDate) : undefined,
@@ -100,9 +100,9 @@ export class JobsController {
   })
   findOne(
     @Param('id', ParseIntPipe) id: number,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<JobResponseDto> {
-    return this.jobsService.findOne(id, req.user.companyId);
+    return this.jobsService.findOne(id, companyId);
   }
 
   @Patch(':id')
@@ -116,9 +116,9 @@ export class JobsController {
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateJobDto: UpdateJobDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<JobResponseDto> {
-    return this.jobsService.update(id, updateJobDto, req.user.companyId);
+    return this.jobsService.update(id, updateJobDto, companyId);
   }
 
   @Post(':id/schedule')
@@ -132,9 +132,9 @@ export class JobsController {
   schedule(
     @Param('id', ParseIntPipe) id: number,
     @Body() scheduleJobDto: ScheduleJobDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<JobResponseDto> {
-    return this.jobsService.schedule(id, scheduleJobDto, req.user.companyId);
+    return this.jobsService.schedule(id, scheduleJobDto, companyId);
   }
 
   @Post(':id/assign')
@@ -148,9 +148,9 @@ export class JobsController {
   assign(
     @Param('id', ParseIntPipe) id: number,
     @Body() assignJobDto: AssignJobDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<JobResponseDto> {
-    return this.jobsService.assign(id, assignJobDto, req.user.companyId);
+    return this.jobsService.assign(id, assignJobDto, companyId);
   }
 
   @Post(':id/bulk-assign')
@@ -164,13 +164,9 @@ export class JobsController {
   bulkAssign(
     @Param('id', ParseIntPipe) id: number,
     @Body() bulkAssignJobDto: BulkAssignJobDto,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<JobResponseDto> {
-    return this.jobsService.bulkAssign(
-      id,
-      bulkAssignJobDto,
-      req.user.companyId,
-    );
+    return this.jobsService.bulkAssign(id, bulkAssignJobDto, companyId);
   }
 
   @Delete(':id/assignments/:assignmentId')
@@ -184,13 +180,9 @@ export class JobsController {
   removeAssignment(
     @Param('id', ParseIntPipe) jobId: number,
     @Param('assignmentId', ParseIntPipe) assignmentId: number,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<JobResponseDto> {
-    return this.jobsService.removeAssignment(
-      jobId,
-      assignmentId,
-      req.user.companyId,
-    );
+    return this.jobsService.removeAssignment(jobId, assignmentId, companyId);
   }
 
   @Delete(':id')
@@ -200,8 +192,8 @@ export class JobsController {
   @ApiResponse({ status: 204, description: 'Job deleted' })
   async remove(
     @Param('id', ParseIntPipe) id: number,
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
   ): Promise<void> {
-    await this.jobsService.remove(id, req.user.companyId);
+    await this.jobsService.remove(id, companyId);
   }
 }


### PR DESCRIPTION
## Summary
- add TenantGuard to ensure requests include a companyId
- introduce @Company decorator to inject companyId into controllers
- replace manual req.user.companyId access with decorator and apply guard globally

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment of an `any` value etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1113cb2a08325ad62a945b66cde95