### PR TITLE
Add tenant row level security policies

### DIFF
--- a/backend/data-source.ts
+++ b/backend/data-source.ts
@@ -2,6 +2,7 @@ import { config } from 'dotenv';
 config({ path: `.env.${process.env.NODE_ENV || 'development'}` });
 import { DataSource } from 'typeorm';
 import { join } from 'path';
+import { CompanyIdSubscriber } from './src/common/tenant/company-id.subscriber';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -17,4 +18,5 @@ export default new DataSource({
   migrationsRun: true,
   synchronize: false,
   ssl: isProduction ? { rejectUnauthorized: false } : false,
+  subscribers: [CompanyIdSubscriber],
 });

--- a/backend/src/common/tenant/company-id.subscriber.ts
+++ b/backend/src/common/tenant/company-id.subscriber.ts
@@ -1,0 +1,12 @@
+import { EntitySubscriberInterface, EventSubscriber, BeforeQueryEvent } from 'typeorm';
+import { getCurrentCompanyId } from './tenant-context';
+
+@EventSubscriber()
+export class CompanyIdSubscriber implements EntitySubscriberInterface {
+  async beforeQuery(event: BeforeQueryEvent<any>): Promise<void> {
+    const companyId = getCurrentCompanyId();
+    if (companyId === undefined) return;
+    if (event.query.startsWith('SET app.current_company_id')) return;
+    await event.queryRunner.query(`SET app.current_company_id = ${companyId}`);
+  }
+}

--- a/backend/src/common/tenant/tenant-context.ts
+++ b/backend/src/common/tenant/tenant-context.ts
@@ -1,0 +1,15 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface TenantStore {
+  companyId?: number;
+}
+
+export const tenantStorage = new AsyncLocalStorage<TenantStore>();
+
+export function getCurrentCompanyId(): number | undefined {
+  return tenantStorage.getStore()?.companyId;
+}
+
+export function runWithCompanyId<T>(companyId: number, fn: () => T): T {
+  return tenantStorage.run({ companyId }, fn);
+}

--- a/backend/src/migrations/1756435084873-enable-tenant-rls.ts
+++ b/backend/src/migrations/1756435084873-enable-tenant-rls.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EnableTenantRls1756435084873 implements MigrationInterface {
+  name = 'EnableTenantRls1756435084873';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const tables = ['customer', 'job', 'equipment', 'contract', 'user'];
+    for (const table of tables) {
+      await queryRunner.query(`ALTER TABLE "${table}" ENABLE ROW LEVEL SECURITY`);
+      await queryRunner.query(
+        `CREATE POLICY "${table}_tenant_policy" ON "${table}" USING ("companyId" = current_setting('app.current_company_id')::int) WITH CHECK ("companyId" = current_setting('app.current_company_id')::int)`,
+      );
+      await queryRunner.query(`ALTER TABLE "${table}" FORCE ROW LEVEL SECURITY`);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const tables = ['customer', 'job', 'equipment', 'contract', 'user'];
+    for (const table of tables) {
+      await queryRunner.query(`DROP POLICY IF EXISTS "${table}_tenant_policy" ON "${table}"`);
+      await queryRunner.query(`ALTER TABLE "${table}" DISABLE ROW LEVEL SECURITY`);
+    }
+  }
+}

--- a/backend/src/rls.policy.spec.ts
+++ b/backend/src/rls.policy.spec.ts
@@ -1,0 +1,83 @@
+process.env.DB_HOST = 'localhost';
+process.env.DB_PORT = '5432';
+process.env.DB_USERNAME = 'appuser';
+process.env.DB_PASSWORD = 'test';
+process.env.DB_NAME = 'rflandscaperpro_test';
+
+import dataSource from '../data-source';
+import { Company } from './companies/entities/company.entity';
+import { Customer } from './customers/entities/customer.entity';
+import { runWithCompanyId } from './common/tenant/tenant-context';
+import { EnableTenantRls1756435084873 } from './migrations/1756435084873-enable-tenant-rls';
+
+describe('RLS enforcement', () => {
+  let company1: Company;
+  let company2: Company;
+  let customer1: Customer;
+  let customer2: Customer;
+
+  beforeAll(async () => {
+    dataSource.setOptions({ synchronize: true, dropSchema: true, migrationsRun: false });
+    await dataSource.initialize();
+    const migration = new EnableTenantRls1756435084873();
+    await migration.up(dataSource.createQueryRunner());
+    const companyRepo = dataSource.getRepository(Company);
+    const customerRepo = dataSource.getRepository(Customer);
+    company1 = await companyRepo.save({ name: 'Company One' });
+    company2 = await companyRepo.save({ name: 'Company Two' });
+    customer1 = await runWithCompanyId(company1.id, () =>
+      customerRepo.save({ name: 'Alice', email: 'alice@example.com', companyId: company1.id }),
+    );
+    customer2 = await runWithCompanyId(company2.id, () =>
+      customerRepo.save({ name: 'Bob', email: 'bob@example.com', companyId: company2.id }),
+    );
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  it('allows reading only own records', async () => {
+    const customerRepo = dataSource.getRepository(Customer);
+    const list = await runWithCompanyId(company1.id, () => customerRepo.find());
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(customer1.id);
+
+    const other = await runWithCompanyId(company1.id, () =>
+      customerRepo.findOne({ where: { id: customer2.id } }),
+    );
+    expect(other).toBeNull();
+  });
+
+  it('prevents creating records for another company', async () => {
+    const qr = dataSource.createQueryRunner();
+    await qr.startTransaction();
+    await expect(
+      runWithCompanyId(company1.id, () =>
+        qr.manager.getRepository(Customer).save({
+          name: 'Eve',
+          email: 'eve@example.com',
+          companyId: company2.id,
+        }),
+      ),
+    ).rejects.toThrow();
+    await qr.rollbackTransaction();
+    await qr.release();
+  });
+
+  it('prevents updating records from another company', async () => {
+    const customerRepo = dataSource.getRepository(Customer);
+    const result = await runWithCompanyId(company1.id, () =>
+      customerRepo.update({ id: customer2.id }, { name: 'Updated' }),
+    );
+    expect(result.affected).toBe(0);
+  });
+
+  it('prevents deleting records from another company', async () => {
+    const customerRepo = dataSource.getRepository(Customer);
+    const result = await runWithCompanyId(company1.id, () =>
+      customerRepo.delete(customer2.id),
+    );
+    expect(result.affected).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- enable row level security and tenant policies for key tables
- set `app.current_company_id` for each query via a TypeORM subscriber
- add tests confirming tenant isolation enforcement

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b111a289f08325964c8e112c6e3e6f