### PR TITLE
Add companyId relations for assignments and addresses

### DIFF
--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -60,10 +60,29 @@ describe('CustomersService', () => {
       'message',
       'Email already exists',
     );
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(repo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'John Doe',
+        email: 'john@example.com',
+        companyId: 1,
+        addresses: [
+          expect.objectContaining({
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'CA',
+            zip: '12345',
+            companyId: 1,
+          }),
+        ],
+      }),
+    );
   });
 
   it('allows duplicate emails across different companies', async () => {
-    repo.create.mockImplementation((dto) => dto as any);
+    repo.create.mockImplementation(
+      (dto: Partial<Customer>) => dto as Customer,
+    );
     repo.save
       .mockResolvedValueOnce({ id: 1 } as Customer)
       .mockResolvedValueOnce({ id: 2 } as Customer);

--- a/backend/src/customers/customers.service.ts
+++ b/backend/src/customers/customers.service.ts
@@ -27,6 +27,10 @@ export class CustomersService {
       const customer = this.customerRepository.create({
         ...createCustomerDto,
         companyId,
+        addresses: createCustomerDto.addresses?.map((addr) => ({
+          ...addr,
+          companyId,
+        })),
       });
       const savedCustomer = await this.customerRepository.save(customer);
       return this.toCustomerResponseDto(savedCustomer);

--- a/backend/src/customers/entities/address.entity.ts
+++ b/backend/src/customers/entities/address.entity.ts
@@ -4,11 +4,14 @@ import {
   Column,
   ManyToOne,
   Index,
+  JoinColumn,
 } from 'typeorm';
 import { Customer } from './customer.entity';
+import { Company } from '../../companies/entities/company.entity';
 
 @Entity()
 @Index(['street', 'city', 'state', 'zip']) // Add composite index for address lookups
+@Index(['companyId']) // Add index for company-based queries
 export class Address {
   @PrimaryGeneratedColumn()
   id: number;
@@ -33,6 +36,13 @@ export class Address {
 
   @Column({ type: 'boolean', default: true })
   primary: boolean;
+
+  @Column()
+  companyId: number;
+
+  @ManyToOne(() => Company, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'companyId' })
+  company: Company;
 
   @ManyToOne(() => Customer, (customer) => customer.addresses, {
     onDelete: 'CASCADE',

--- a/backend/src/jobs/entities/assignment.entity.ts
+++ b/backend/src/jobs/entities/assignment.entity.ts
@@ -5,14 +5,17 @@ import {
   Column,
   CreateDateColumn,
   Index,
+  JoinColumn,
 } from 'typeorm';
 import { Job } from './job.entity';
 import { User } from '../../users/user.entity';
 import { Equipment } from '../../equipment/entities/equipment.entity';
+import { Company } from '../../companies/entities/company.entity';
 
 @Entity()
 @Index(['user', 'job']) // Add index for user-job queries
 @Index(['equipment', 'job']) // Add index for equipment-job queries
+@Index(['companyId']) // Add index for company-based queries
 export class Assignment {
   @PrimaryGeneratedColumn()
   id: number;
@@ -25,6 +28,13 @@ export class Assignment {
 
   @ManyToOne(() => Equipment, { onDelete: 'CASCADE' })
   equipment: Equipment;
+
+  @Column()
+  companyId: number;
+
+  @ManyToOne(() => Company, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'companyId' })
+  company: Company;
 
   @Column({ type: 'timestamp', nullable: true })
   startTime?: Date;

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -207,7 +207,7 @@ export class JobsService {
       .createQueryBuilder('assignment')
       .leftJoin('assignment.job', 'job')
       .where('job.scheduledDate = :date', { date })
-      .andWhere('job.companyId = :companyId', { companyId })
+      .andWhere('assignment.companyId = :companyId', { companyId })
       .andWhere(
         '(assignment.userId = :userId OR assignment.equipmentId = :equipmentId)',
         { userId, equipmentId },
@@ -301,6 +301,7 @@ export class JobsService {
       job,
       user,
       equipment,
+      companyId,
     });
     await this.assignmentRepository.save(assignment);
 
@@ -366,6 +367,7 @@ export class JobsService {
           job,
           user: { id: assignmentData.userId } as User,
           equipment: { id: assignmentData.equipmentId } as Equipment,
+          companyId,
         }),
       );
       await manager.save(assignments);
@@ -381,7 +383,7 @@ export class JobsService {
     companyId: number,
   ): Promise<JobResponseDto> {
     const assignment = await this.assignmentRepository.findOne({
-      where: { id: assignmentId, job: { id: jobId, companyId } },
+      where: { id: assignmentId, companyId, job: { id: jobId } },
       relations: ['job'],
     });
 

--- a/backend/src/migrations/1756447465689-add-companyid-to-address-and-assignment.ts
+++ b/backend/src/migrations/1756447465689-add-companyid-to-address-and-assignment.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCompanyIdToAddressAndAssignment1756447465689
+  implements MigrationInterface
+{
+  name = 'AddCompanyIdToAddressAndAssignment1756447465689';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "address" ADD "companyId" integer`);
+    await queryRunner.query(
+      `UPDATE "address" a SET "companyId" = c."companyId" FROM "customer" c WHERE a."customerId" = c."id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "address" ALTER COLUMN "companyId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_address_companyId" ON "address" ("companyId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "address" ADD CONSTRAINT "FK_address_company" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+
+    await queryRunner.query(`ALTER TABLE "assignment" ADD "companyId" integer`);
+    await queryRunner.query(
+      `UPDATE "assignment" a SET "companyId" = j."companyId" FROM "job" j WHERE a."jobId" = j."id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "assignment" ALTER COLUMN "companyId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_assignment_companyId" ON "assignment" ("companyId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "assignment" ADD CONSTRAINT "FK_assignment_company" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "assignment" DROP CONSTRAINT "FK_assignment_company"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_assignment_companyId"`);
+    await queryRunner.query(`ALTER TABLE "assignment" DROP COLUMN "companyId"`);
+
+    await queryRunner.query(
+      `ALTER TABLE "address" DROP CONSTRAINT "FK_address_company"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_address_companyId"`);
+    await queryRunner.query(`ALTER TABLE "address" DROP COLUMN "companyId"`);
+  }
+}

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -100,6 +100,7 @@ async function main() {
               city: 'Townsville',
               state: 'CA',
               zip: '12345',
+              companyId: company.id,
             },
           ],
         },


### PR DESCRIPTION
## Summary
- add `companyId` and Company relation to Assignment and Address entities with indexes
- ensure customer and job services set and query by `companyId`
- backfill existing records and index `companyId` via migration

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment/member access warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b11454d14c83259e4c4cf5602b5315