### PR TITLE
feat: support company header for cross-tenant requests

### DIFF
--- a/backend/src/common/decorators/company.decorator.ts
+++ b/backend/src/common/decorators/company.decorator.ts
@@ -4,7 +4,17 @@ export const Company = createParamDecorator(
   (_data: unknown, ctx: ExecutionContext): number | undefined => {
     const request = ctx
       .switchToHttp()
-      .getRequest<{ user?: { companyId?: number } }>();
+      .getRequest<{
+        user?: { companyId?: number };
+        headers?: Record<string, string>;
+      }>();
+    const header = request.headers?.['x-company-id'];
+    if (header) {
+      const parsed = parseInt(header, 10);
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    }
     return request.user?.companyId;
   },
 );

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -15,6 +15,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Company } from '../common/decorators/company.decorator';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -83,10 +84,8 @@ export class UsersController {
     description: 'List of workers',
     type: [UserResponseDto],
   })
-  async findWorkers(
-    @Req() req: { user: { companyId: number } },
-  ): Promise<UserResponseDto[]> {
-    const users = await this.usersService.findAll(req.user.companyId);
+  async findWorkers(@Company() companyId: number): Promise<UserResponseDto[]> {
+    const users = await this.usersService.findAll(companyId);
     return users
       .filter((u) => u.role === UserRole.Worker)
       .map(toUserResponseDto);
@@ -133,19 +132,15 @@ export class UsersController {
     type: UserResponseDto,
   })
   async updateWorker(
-    @Req() req: { user: { companyId: number } },
+    @Company() companyId: number,
     @Param('id', ParseIntPipe) id: number,
     @Body() updateUserDto: UpdateUserDto,
   ): Promise<UserResponseDto> {
-    const worker = await this.usersService.findById(id, req.user.companyId);
+    const worker = await this.usersService.findById(id, companyId);
     if (!worker || worker.role !== UserRole.Worker) {
       throw new NotFoundException('Worker not found');
     }
-    const updated = await this.usersService.update(
-      id,
-      updateUserDto,
-      req.user.companyId,
-    );
+    const updated = await this.usersService.update(id, updateUserDto, companyId);
     return toUserResponseDto(updated);
   }
 

--- a/frontend/src/app/api.service.spec.ts
+++ b/frontend/src/app/api.service.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ApiService } from './api.service';
+import { ErrorService } from './error.service';
+import { environment } from '../environments/environment';
+
+describe('ApiService company header', () => {
+  let service: ApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ApiService, ErrorService],
+    });
+    service = TestBed.inject(ApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should attach X-Company-ID header from storage', () => {
+    localStorage.setItem('companyId', '1');
+    service.getHealth().subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/health`);
+    expect(req.request.headers.get('X-Company-ID')).toBe('1');
+    req.flush({ status: 'ok' });
+  });
+
+  it('should update header when company changes', () => {
+    localStorage.setItem('companyId', '1');
+    service.getHealth().subscribe();
+    const first = httpMock.expectOne(`${environment.apiUrl}/health`);
+    expect(first.request.headers.get('X-Company-ID')).toBe('1');
+    first.flush({ status: 'ok' });
+
+    localStorage.setItem('companyId', '2');
+    service.getHealth().subscribe();
+    const second = httpMock.expectOne(`${environment.apiUrl}/health`);
+    expect(second.request.headers.get('X-Company-ID')).toBe('2');
+    second.flush({ status: 'ok' });
+  });
+});

--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -3,6 +3,7 @@ import {
   HttpClient,
   HttpErrorResponse,
   HttpParams,
+  HttpHeaders,
 } from '@angular/common/http';
 import { environment } from '../environments/environment';
 import { Observable, throwError } from 'rxjs';
@@ -102,80 +103,88 @@ export class ApiService {
     return httpParams;
   }
 
-  getHealth(): Observable<{ status: string }> {
+  private getCompanyId(): string | null {
+    if (typeof localStorage === 'undefined') {
+      return null;
+    }
+    return localStorage.getItem('companyId');
+  }
+
+  private request<T>(
+    method: string,
+    url: string,
+    options: { params?: Record<string, unknown>; body?: unknown } = {},
+  ): Observable<T> {
+    let headers = new HttpHeaders();
+    const companyId = this.getCompanyId();
+    if (companyId) {
+      headers = headers.set('X-Company-ID', companyId);
+    }
     return this.http
-      .get<{ status: string }>(`${environment.apiUrl}/health`)
+      .request<T>(method, url, {
+        body: options.body,
+        params: this.toHttpParams(options.params),
+        headers,
+      })
       .pipe(catchError(this.handleError));
+  }
+
+  getHealth(): Observable<{ status: string }> {
+    return this.request<{ status: string }>('GET', `${environment.apiUrl}/health`);
   }
 
   // Customers
   getCustomers(query: PaginationQuery & { active?: boolean; search?: string } = {}): Observable<
     Paginated<Customer>
   > {
-    return this.http
-      .get<Paginated<Customer>>(`${environment.apiUrl}/customers`, {
-        params: this.toHttpParams(query),
-      })
-      .pipe(catchError(this.handleError));
+    return this.request<Paginated<Customer>>('GET', `${environment.apiUrl}/customers`, {
+      params: query,
+    });
   }
 
   getCustomer(id: number): Observable<Customer> {
-    return this.http
-      .get<Customer>(`${environment.apiUrl}/customers/${id}`)
-      .pipe(catchError(this.handleError));
+    return this.request<Customer>('GET', `${environment.apiUrl}/customers/${id}`);
   }
 
   createCustomer(payload: CreateCustomer): Observable<Customer> {
-    return this.http
-      .post<Customer>(`${environment.apiUrl}/customers`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<Customer>('POST', `${environment.apiUrl}/customers`, { body: payload });
   }
 
   updateCustomer(id: number, payload: UpdateCustomer): Observable<Customer> {
-    return this.http
-      .patch<Customer>(`${environment.apiUrl}/customers/${id}`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<Customer>('PATCH', `${environment.apiUrl}/customers/${id}`, {
+      body: payload,
+    });
   }
 
   deleteCustomer(id: number): Observable<void> {
-    return this.http
-      .delete<void>(`${environment.apiUrl}/customers/${id}`)
-      .pipe(catchError(this.handleError));
+    return this.request<void>('DELETE', `${environment.apiUrl}/customers/${id}`);
   }
 
   // Equipment
-  getEquipment(query: PaginationQuery & { status?: string; type?: string; search?: string } = {}): Observable<
-    Paginated<Equipment>
-  > {
-    return this.http
-      .get<Paginated<Equipment>>(`${environment.apiUrl}/equipment`, {
-        params: this.toHttpParams(query),
-      })
-      .pipe(catchError(this.handleError));
+  getEquipment(
+    query: PaginationQuery & { status?: string; type?: string; search?: string } = {},
+  ): Observable<Paginated<Equipment>> {
+    return this.request<Paginated<Equipment>>('GET', `${environment.apiUrl}/equipment`, {
+      params: query,
+    });
   }
 
   getEquipmentById(id: number): Observable<Equipment> {
-    return this.http
-      .get<Equipment>(`${environment.apiUrl}/equipment/${id}`)
-      .pipe(catchError(this.handleError));
+    return this.request<Equipment>('GET', `${environment.apiUrl}/equipment/${id}`);
   }
 
   createEquipment(payload: CreateEquipment): Observable<Equipment> {
-    return this.http
-      .post<Equipment>(`${environment.apiUrl}/equipment`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<Equipment>('POST', `${environment.apiUrl}/equipment`, { body: payload });
   }
 
   updateEquipment(id: number, payload: UpdateEquipment): Observable<Equipment> {
-    return this.http
-      .patch<Equipment>(`${environment.apiUrl}/equipment/${id}`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<Equipment>('PATCH', `${environment.apiUrl}/equipment/${id}`, {
+      body: payload,
+    });
   }
 
   deleteEquipment(id: number): Observable<void> {
-    return this.http
-      .delete<void>(`${environment.apiUrl}/equipment/${id}`)
-      .pipe(catchError(this.handleError));
+    return this.request<void>('DELETE', `${environment.apiUrl}/equipment/${id}`);
   }
 
   // Jobs
@@ -189,115 +198,83 @@ export class ApiService {
       equipmentId?: number;
     } = {},
   ): Observable<Paginated<Job>> {
-    return this.http
-      .get<Paginated<Job>>(`${environment.apiUrl}/jobs`, {
-        params: this.toHttpParams(query),
-      })
-      .pipe(catchError(this.handleError));
+    return this.request<Paginated<Job>>('GET', `${environment.apiUrl}/jobs`, {
+      params: query,
+    });
   }
 
   getJob(id: number): Observable<Job> {
-    return this.http
-      .get<Job>(`${environment.apiUrl}/jobs/${id}`)
-      .pipe(catchError(this.handleError));
+    return this.request<Job>('GET', `${environment.apiUrl}/jobs/${id}`);
   }
 
   createJob(payload: CreateJob): Observable<Job> {
-    return this.http
-      .post<Job>(`${environment.apiUrl}/jobs`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<Job>('POST', `${environment.apiUrl}/jobs`, { body: payload });
   }
 
   updateJob(id: number, payload: UpdateJob): Observable<Job> {
-    return this.http
-      .patch<Job>(`${environment.apiUrl}/jobs/${id}`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<Job>('PATCH', `${environment.apiUrl}/jobs/${id}`, { body: payload });
   }
 
   deleteJob(id: number): Observable<void> {
-    return this.http
-      .delete<void>(`${environment.apiUrl}/jobs/${id}`)
-      .pipe(catchError(this.handleError));
+    return this.request<void>('DELETE', `${environment.apiUrl}/jobs/${id}`);
   }
 
   // Users
   getUsers(): Observable<User[]> {
-    return this.http
-      .get<User[]>(`${environment.apiUrl}/users`)
-      .pipe(catchError(this.handleError));
+    return this.request<User[]>('GET', `${environment.apiUrl}/users`);
   }
 
   getUser(id: number): Observable<User> {
-    return this.http
-      .get<User>(`${environment.apiUrl}/users/${id}`)
-      .pipe(catchError(this.handleError));
+    return this.request<User>('GET', `${environment.apiUrl}/users/${id}`);
   }
 
   createUser(payload: CreateUser): Observable<User> {
-    return this.http
-      .post<User>(`${environment.apiUrl}/users`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<User>('POST', `${environment.apiUrl}/users`, { body: payload });
   }
 
   updateUser(id: number, payload: UpdateUser): Observable<User> {
-    return this.http
-      .patch<User>(`${environment.apiUrl}/users/${id}`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<User>('PATCH', `${environment.apiUrl}/users/${id}`, { body: payload });
   }
 
   deleteUser(id: number): Observable<void> {
-    return this.http
-      .delete<void>(`${environment.apiUrl}/users/${id}`)
-      .pipe(catchError(this.handleError));
+    return this.request<void>('DELETE', `${environment.apiUrl}/users/${id}`);
   }
 
   getMe(): Observable<User> {
-    return this.http
-      .get<User>(`${environment.apiUrl}/users/me`)
-      .pipe(catchError(this.handleError));
+    return this.request<User>('GET', `${environment.apiUrl}/users/me`);
   }
 
   updateMe(payload: UpdateUser): Observable<User> {
-    return this.http
-      .put<User>(`${environment.apiUrl}/users/me`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<User>('PUT', `${environment.apiUrl}/users/me`, { body: payload });
   }
 
   // Companies
   getCompanyProfile(): Observable<Company> {
-    return this.http
-      .get<Company>(`${environment.apiUrl}/companies/profile`)
-      .pipe(catchError(this.handleError));
+    return this.request<Company>('GET', `${environment.apiUrl}/companies/profile`);
   }
 
   getCompanyWorkers(): Observable<User[]> {
-    return this.http
-      .get<User[]>(`${environment.apiUrl}/companies/workers`)
-      .pipe(catchError(this.handleError));
+    return this.request<User[]>('GET', `${environment.apiUrl}/companies/workers`);
   }
 
   createCompany(payload: CreateCompany): Observable<Company> {
-    return this.http
-      .post<Company>(`${environment.apiUrl}/companies`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<Company>('POST', `${environment.apiUrl}/companies`, { body: payload });
   }
 
   updateCompany(id: number, payload: UpdateCompany): Observable<Company> {
-    return this.http
-      .patch<Company>(`${environment.apiUrl}/companies/${id}`, payload)
-      .pipe(catchError(this.handleError));
+    return this.request<Company>('PATCH', `${environment.apiUrl}/companies/${id}`, { body: payload });
   }
 
   getUpcomingJobs(): Observable<{ items: unknown[]; total: number }> {
-    return this.http.get<{ items: unknown[]; total: number }>(
-      `${environment.apiUrl}/jobs?completed=false&limit=5`
-    );
+    return this.request<{ items: unknown[]; total: number }>('GET', `${environment.apiUrl}/jobs`, {
+      params: { completed: false, limit: 5 },
+    });
   }
 
   getEquipmentCount(status: string): Observable<{ items: unknown[]; total: number }> {
-    return this.http.get<{ items: unknown[]; total: number }>(
-      `${environment.apiUrl}/equipment?status=${status}&limit=1`
-    );
+    return this.request<{ items: unknown[]; total: number }>('GET', `${environment.apiUrl}/equipment`, {
+      params: { status, limit: 1 },
+    });
   }
 
 }


### PR DESCRIPTION
## Summary
- attach stored company ID to every frontend API request via `X-Company-ID`
- prefer header-based company identification in backend controllers
- add unit tests ensuring the company header is sent and updated

## Testing
- `npm test` (backend)
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b11435f9b88325859558353995d6b8