### PR TITLE
feat: add company-aware authentication

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,7 +1,8 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { companyInterceptor } from './company.interceptor';
 
 import { routes } from './app.routes';
 
@@ -11,6 +12,6 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
-    provideHttpClient()
+    provideHttpClient(withInterceptors([companyInterceptor]))
   ]
 };

--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -10,6 +10,7 @@ import { AuthService } from '../auth.service';
   imports: [CommonModule, ReactiveFormsModule, RouterLink],
   template: `
     <form [formGroup]="form" (ngSubmit)="submit()">
+      <input type="text" formControlName="company" placeholder="Company" />
       <input type="email" formControlName="email" placeholder="Email" />
       <input type="password" formControlName="password" placeholder="Password" />
       <button type="submit">Login</button>
@@ -23,6 +24,7 @@ export class LoginComponent {
   private fb = inject(FormBuilder);
 
   form = this.fb.nonNullable.group({
+    company: ['', Validators.required],
     email: ['', [Validators.required, Validators.email]],
     password: ['', Validators.required]
   });

--- a/frontend/src/app/company-switcher/company-switcher.component.ts
+++ b/frontend/src/app/company-switcher/company-switcher.component.ts
@@ -1,0 +1,25 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { AuthService } from '../auth/auth.service';
+
+@Component({
+  selector: 'app-company-switcher',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <select [(ngModel)]="selected" (ngModelChange)="onChange($event)">
+      <option *ngFor="let c of auth.getCompanies()" [ngValue]="c">{{ c }}</option>
+    </select>
+  `
+})
+export class CompanySwitcherComponent {
+  protected auth = inject(AuthService);
+  selected = this.auth.getCompany();
+
+  onChange(company: string): void {
+    if (company) {
+      this.auth.setCompany(company);
+    }
+  }
+}

--- a/frontend/src/app/company.interceptor.ts
+++ b/frontend/src/app/company.interceptor.ts
@@ -1,0 +1,12 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from './auth/auth.service';
+
+export const companyInterceptor: HttpInterceptorFn = (req, next) => {
+  const auth = inject(AuthService);
+  const company = auth.getCompany();
+  if (company) {
+    req = req.clone({ setHeaders: { 'X-Company': company } });
+  }
+  return next(req);
+};

--- a/frontend/src/app/layout/layout.component.html
+++ b/frontend/src/app/layout/layout.component.html
@@ -1,5 +1,6 @@
 <header class="header">
   <h1>RF Landscaper Pro</h1>
+  <app-company-switcher *ngIf="auth.getCompanies().length > 1"></app-company-switcher>
 </header>
 <div class="container">
   <nav class="sidebar">

--- a/frontend/src/app/layout/layout.component.ts
+++ b/frontend/src/app/layout/layout.component.ts
@@ -2,11 +2,12 @@ import { Component, inject } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthService } from '../auth/auth.service';
+import { CompanySwitcherComponent } from '../company-switcher/company-switcher.component';
 
 @Component({
   selector: 'app-layout',
   standalone: true,
-  imports: [RouterOutlet, RouterLink, RouterLinkActive, NgIf],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, NgIf, CompanySwitcherComponent],
   templateUrl: './layout.component.html',
   styleUrl: './layout.component.scss'
 })


### PR DESCRIPTION
## Summary
- extend login form to accept a company identifier
- attach company context to auth service and API requests
- add UI for switching between companies

## Testing
- `npm --prefix frontend test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b114209b8c83258af46edc83d25367