### PR TITLE
Align company tenancy headers and context

### DIFF
--- a/backend/src/common/tenant.guard.ts
+++ b/backend/src/common/tenant.guard.ts
@@ -1,6 +1,7 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { IS_PUBLIC_KEY } from './decorators/public.decorator';
+import { tenantStorage } from './tenant/tenant-context';
 
 @Injectable()
 export class TenantGuard implements CanActivate {
@@ -14,9 +15,25 @@ export class TenantGuard implements CanActivate {
     if (isPublic) {
       return true;
     }
-    const request = context
-      .switchToHttp()
-      .getRequest<{ user?: { companyId?: number } }>();
-    return Boolean(request.user?.companyId);
+    const request = context.switchToHttp().getRequest<{
+      user?: { companyId?: number };
+      headers?: Record<string, string | string[]>;
+    }>();
+    const header = request.headers?.['x-company-id'];
+    let companyId = request.user?.companyId;
+    if (header) {
+      const value = Array.isArray(header) ? header[0] : header;
+      const parsed = parseInt(value, 10);
+      if (!isNaN(parsed)) {
+        companyId = parsed;
+        if (request.user) {
+          request.user.companyId = parsed;
+        }
+      }
+    }
+    if (companyId !== undefined) {
+      tenantStorage.enterWith({ companyId });
+    }
+    return Boolean(companyId);
   }
 }

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -56,7 +56,7 @@ export class AuthService {
   logout(): void {
     if (this.hasLocalStorage()) {
       localStorage.removeItem('token');
-      localStorage.removeItem('company');
+      localStorage.removeItem('companyId');
       localStorage.removeItem('companies');
     }
     this.roles.set([]);
@@ -85,7 +85,7 @@ export class AuthService {
 
   setCompany(company: string): void {
     if (this.hasLocalStorage()) {
-      localStorage.setItem('company', company);
+      localStorage.setItem('companyId', company);
     }
     this.company.set(company);
   }
@@ -101,7 +101,7 @@ export class AuthService {
     if (!this.hasLocalStorage()) {
       return null;
     }
-    return localStorage.getItem('company');
+    return localStorage.getItem('companyId');
   }
 
   private getCompaniesFromStorage(): string[] {

--- a/frontend/src/app/company.interceptor.ts
+++ b/frontend/src/app/company.interceptor.ts
@@ -6,7 +6,7 @@ export const companyInterceptor: HttpInterceptorFn = (req, next) => {
   const auth = inject(AuthService);
   const company = auth.getCompany();
   if (company) {
-    req = req.clone({ setHeaders: { 'X-Company': company } });
+    req = req.clone({ setHeaders: { 'X-Company-ID': company } });
   }
   return next(req);
 };


### PR DESCRIPTION
## Summary
- propagate company id from `x-company-id` header into tenant context
- send `X-Company-ID` header on frontend requests
- store selected company id consistently in auth service

## Testing
- `npm --prefix backend test` *(fails: CannotExecuteNotConnectedError: connection is not yet established)*
- `npm --prefix frontend test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a397710c8325a8aa0c482dc0cb3e