### PR TITLE
refactor: centralize entity-to-DTO mapping

### DIFF
--- a/backend/src/contracts/contracts.mapper.ts
+++ b/backend/src/contracts/contracts.mapper.ts
@@ -1,0 +1,21 @@
+import { Contract } from './entities/contract.entity';
+import { ContractResponseDto } from './dto/contract-response.dto';
+
+export function toContractResponseDto(contract: Contract): ContractResponseDto {
+  return {
+    id: contract.id,
+    startDate: contract.startDate,
+    endDate: contract.endDate,
+    frequency: contract.frequency,
+    totalOccurrences: contract.totalOccurrences,
+    occurrencesGenerated: contract.occurrencesGenerated,
+    jobTemplate: contract.jobTemplate,
+    lastGeneratedDate: contract.lastGeneratedDate,
+    active: contract.active,
+    customer: {
+      id: contract.customer.id,
+      name: contract.customer.name,
+      email: contract.customer.email,
+    },
+  };
+}

--- a/backend/src/contracts/contracts.service.ts
+++ b/backend/src/contracts/contracts.service.ts
@@ -7,6 +7,7 @@ import { Job } from '../jobs/entities/job.entity';
 import { CreateContractDto } from './dto/create-contract.dto';
 import { UpdateContractDto } from './dto/update-contract.dto';
 import { ContractResponseDto } from './dto/contract-response.dto';
+import { toContractResponseDto } from './contracts.mapper';
 
 @Injectable()
 export class ContractsService {
@@ -42,7 +43,7 @@ export class ContractsService {
     });
     const saved = await this.contractRepository.save(contract);
     await this.generateJobsForContract(saved);
-    return this.toResponseDto(saved);
+    return toContractResponseDto(saved);
   }
 
   async findAll(companyId: number): Promise<ContractResponseDto[]> {
@@ -50,7 +51,7 @@ export class ContractsService {
       where: { companyId },
       relations: ['customer'],
     });
-    return contracts.map((c) => this.toResponseDto(c));
+    return contracts.map((c) => toContractResponseDto(c));
   }
 
   async update(
@@ -85,7 +86,7 @@ export class ContractsService {
     });
     const saved = await this.contractRepository.save(contract);
     await this.generateJobsForContract(saved);
-    return this.toResponseDto(saved);
+    return toContractResponseDto(saved);
   }
 
   async cancel(id: number, companyId: number): Promise<void> {
@@ -156,24 +157,5 @@ export class ContractsService {
         break;
     }
     return result;
-  }
-
-  private toResponseDto(contract: Contract): ContractResponseDto {
-    return {
-      id: contract.id,
-      startDate: contract.startDate,
-      endDate: contract.endDate,
-      frequency: contract.frequency,
-      totalOccurrences: contract.totalOccurrences,
-      occurrencesGenerated: contract.occurrencesGenerated,
-      jobTemplate: contract.jobTemplate,
-      lastGeneratedDate: contract.lastGeneratedDate,
-      active: contract.active,
-      customer: {
-        id: contract.customer.id,
-        name: contract.customer.name,
-        email: contract.customer.email,
-      },
-    };
   }
 }

--- a/backend/src/customers/customers.mapper.ts
+++ b/backend/src/customers/customers.mapper.ts
@@ -1,0 +1,30 @@
+import { Customer } from './entities/customer.entity';
+import { CustomerResponseDto } from './dto/customer-response.dto';
+
+export function toCustomerResponseDto(customer: Customer): CustomerResponseDto {
+  return {
+    id: customer.id,
+    name: customer.name,
+    email: customer.email,
+    phone: customer.phone,
+    notes: customer.notes,
+    active: customer.active,
+    createdAt: customer.createdAt,
+    updatedAt: customer.updatedAt,
+    userId: customer.userId,
+    jobs: customer.jobs?.map((job) => ({
+      id: job.id,
+      title: job.title,
+    })),
+    addresses: customer.addresses?.map((addr) => ({
+      id: addr.id,
+      street: addr.street,
+      city: addr.city,
+      state: addr.state,
+      zip: addr.zip,
+      unit: addr.unit,
+      notes: addr.notes,
+      primary: addr.primary,
+    })),
+  };
+}

--- a/backend/src/customers/customers.service.ts
+++ b/backend/src/customers/customers.service.ts
@@ -11,6 +11,7 @@ import { CreateCustomerDto } from './dto/create-customer.dto';
 import { UpdateCustomerDto } from './dto/update-customer.dto';
 import { CustomerResponseDto } from './dto/customer-response.dto';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { toCustomerResponseDto } from './customers.mapper';
 
 @Injectable()
 export class CustomersService {
@@ -33,7 +34,7 @@ export class CustomersService {
         })),
       });
       const savedCustomer = await this.customerRepository.save(customer);
-      return this.toCustomerResponseDto(savedCustomer);
+      return toCustomerResponseDto(savedCustomer);
     } catch (error) {
       if (
         error instanceof QueryFailedError &&
@@ -81,7 +82,7 @@ export class CustomersService {
       .getManyAndCount();
 
     return {
-      items: customers.map((customer) => this.toCustomerResponseDto(customer)),
+      items: customers.map((customer) => toCustomerResponseDto(customer)),
       total,
     };
   }
@@ -94,7 +95,7 @@ export class CustomersService {
     if (!customer) {
       throw new NotFoundException(`Customer with ID ${id} not found.`);
     }
-    return this.toCustomerResponseDto(customer);
+    return toCustomerResponseDto(customer);
   }
 
   async findByUserId(
@@ -108,7 +109,7 @@ export class CustomersService {
     if (!customer) {
       throw new NotFoundException(`Customer with userId ${userId} not found.`);
     }
-    return this.toCustomerResponseDto(customer);
+    return toCustomerResponseDto(customer);
   }
 
   async update(
@@ -124,7 +125,7 @@ export class CustomersService {
     }
     Object.assign(customer, updateCustomerDto);
     const updatedCustomer = await this.customerRepository.save(customer);
-    return this.toCustomerResponseDto(updatedCustomer);
+    return toCustomerResponseDto(updatedCustomer);
   }
 
   async remove(id: number, companyId: number): Promise<void> {
@@ -148,33 +149,5 @@ export class CustomersService {
   async activate(id: number, companyId: number): Promise<CustomerResponseDto> {
     await this.findOne(id, companyId);
     return this.update(id, { active: true }, companyId);
-  }
-
-  private toCustomerResponseDto(customer: Customer): CustomerResponseDto {
-    return {
-      id: customer.id,
-      name: customer.name,
-      email: customer.email,
-      phone: customer.phone,
-      notes: customer.notes,
-      active: customer.active,
-      createdAt: customer.createdAt,
-      updatedAt: customer.updatedAt,
-      userId: customer.userId,
-      jobs: customer.jobs?.map((job) => ({
-        id: job.id,
-        title: job.title,
-      })),
-      addresses: customer.addresses?.map((addr) => ({
-        id: addr.id,
-        street: addr.street,
-        city: addr.city,
-        state: addr.state,
-        zip: addr.zip,
-        unit: addr.unit,
-        notes: addr.notes,
-        primary: addr.primary,
-      })),
-    };
   }
 }

--- a/backend/src/equipment/equipment.mapper.ts
+++ b/backend/src/equipment/equipment.mapper.ts
@@ -1,0 +1,18 @@
+import { Equipment } from './entities/equipment.entity';
+import { EquipmentResponseDto } from './dto/equipment-response.dto';
+
+export function toEquipmentResponseDto(
+  equipment: Equipment,
+): EquipmentResponseDto {
+  return {
+    id: equipment.id,
+    name: equipment.name,
+    type: equipment.type,
+    status: equipment.status,
+    location: equipment.location,
+    description: equipment.description,
+    lastMaintenanceDate: equipment.lastMaintenanceDate,
+    createdAt: equipment.createdAt,
+    updatedAt: equipment.updatedAt,
+  };
+}

--- a/backend/src/equipment/equipment.service.ts
+++ b/backend/src/equipment/equipment.service.ts
@@ -10,6 +10,7 @@ import { CreateEquipmentDto } from './dto/create-equipment.dto';
 import { UpdateEquipmentDto } from './dto/update-equipment.dto';
 import { EquipmentResponseDto } from './dto/equipment-response.dto';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { toEquipmentResponseDto } from './equipment.mapper';
 
 @Injectable()
 export class EquipmentService {
@@ -27,7 +28,7 @@ export class EquipmentService {
       companyId,
     });
     const savedEquipment = await this.equipmentRepository.save(equipment);
-    return this.toEquipmentResponseDto(savedEquipment);
+    return toEquipmentResponseDto(savedEquipment);
   }
 
   async findAll(
@@ -64,7 +65,7 @@ export class EquipmentService {
       .getManyAndCount();
 
     return {
-      items: equipments.map((eq) => this.toEquipmentResponseDto(eq)),
+      items: equipments.map((eq) => toEquipmentResponseDto(eq)),
       total,
     };
   }
@@ -76,7 +77,7 @@ export class EquipmentService {
     if (!equipment) {
       throw new NotFoundException(`Equipment with ID ${id} not found.`);
     }
-    return this.toEquipmentResponseDto(equipment);
+    return toEquipmentResponseDto(equipment);
   }
 
   async update(
@@ -104,7 +105,7 @@ export class EquipmentService {
 
     Object.assign(equipment, updateEquipmentDto);
     const updatedEquipment = await this.equipmentRepository.save(equipment);
-    return this.toEquipmentResponseDto(updatedEquipment);
+    return toEquipmentResponseDto(updatedEquipment);
   }
 
   async remove(id: number, companyId: number): Promise<void> {
@@ -163,19 +164,5 @@ export class EquipmentService {
         `Invalid status transition from ${currentStatus} to ${newStatus}`,
       );
     }
-  }
-
-  private toEquipmentResponseDto(equipment: Equipment): EquipmentResponseDto {
-    return {
-      id: equipment.id,
-      name: equipment.name,
-      type: equipment.type,
-      status: equipment.status,
-      location: equipment.location,
-      description: equipment.description,
-      lastMaintenanceDate: equipment.lastMaintenanceDate,
-      createdAt: equipment.createdAt,
-      updatedAt: equipment.updatedAt,
-    };
   }
 }

--- a/backend/src/jobs/jobs.mapper.ts
+++ b/backend/src/jobs/jobs.mapper.ts
@@ -1,0 +1,33 @@
+import { Job } from './entities/job.entity';
+import { JobResponseDto } from './dto/job-response.dto';
+
+export function toJobResponseDto(job: Job): JobResponseDto {
+  return {
+    id: job.id,
+    title: job.title,
+    description: job.description,
+    scheduledDate: job.scheduledDate,
+    completed: job.completed,
+    estimatedHours: job.estimatedHours,
+    actualHours: job.actualHours,
+    notes: job.notes,
+    customer: {
+      id: job.customer.id,
+      name: job.customer.name,
+      email: job.customer.email,
+    },
+    assignments: job.assignments?.map((assignment) => ({
+      id: assignment.id,
+      user: { id: assignment.user.id, username: assignment.user.username },
+      equipment: {
+        id: assignment.equipment.id,
+        name: assignment.equipment.name,
+      },
+      startTime: assignment.startTime,
+      endTime: assignment.endTime,
+      notes: assignment.notes,
+    })),
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+  };
+}

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -17,6 +17,7 @@ import { AssignJobDto } from './dto/assign-job.dto';
 import { BulkAssignJobDto } from './dto/bulk-assign-job.dto';
 import { ScheduleJobDto } from './dto/schedule-job.dto';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { toJobResponseDto } from './jobs.mapper';
 
 @Injectable()
 export class JobsService {
@@ -50,7 +51,7 @@ export class JobsService {
       companyId,
     });
     const savedJob = await this.jobRepository.save(job);
-    return this.toJobResponseDto(savedJob);
+    return toJobResponseDto(savedJob);
   }
 
   async findAll(
@@ -105,7 +106,7 @@ export class JobsService {
       .getManyAndCount();
 
     return {
-      items: jobs.map((job) => this.toJobResponseDto(job)),
+      items: jobs.map((job) => toJobResponseDto(job)),
       total,
     };
   }
@@ -136,7 +137,7 @@ export class JobsService {
     }
     Object.assign(job, updateData);
     const updatedJob = await this.jobRepository.save(job);
-    return this.toJobResponseDto(updatedJob);
+    return toJobResponseDto(updatedJob);
   }
 
   async findOne(id: number, companyId: number): Promise<JobResponseDto> {
@@ -154,7 +155,7 @@ export class JobsService {
       throw new NotFoundException(`Job with ID ${id} not found.`);
     }
 
-    return this.toJobResponseDto(job);
+    return toJobResponseDto(job);
   }
 
   async remove(id: number, companyId: number): Promise<void> {
@@ -163,37 +164,6 @@ export class JobsService {
       throw new NotFoundException(`Job with ID ${id} not found.`);
     }
     await this.jobRepository.remove(job);
-  }
-
-  private toJobResponseDto(job: Job): JobResponseDto {
-    return {
-      id: job.id,
-      title: job.title,
-      description: job.description,
-      scheduledDate: job.scheduledDate,
-      completed: job.completed,
-      estimatedHours: job.estimatedHours,
-      actualHours: job.actualHours,
-      notes: job.notes,
-      customer: {
-        id: job.customer.id,
-        name: job.customer.name,
-        email: job.customer.email,
-      },
-      assignments: job.assignments?.map((assignment) => ({
-        id: assignment.id,
-        user: { id: assignment.user.id, username: assignment.user.username },
-        equipment: {
-          id: assignment.equipment.id,
-          name: assignment.equipment.name,
-        },
-        startTime: assignment.startTime,
-        endTime: assignment.endTime,
-        notes: assignment.notes,
-      })),
-      createdAt: job.createdAt,
-      updatedAt: job.updatedAt,
-    };
   }
 
   private async checkResourceConflicts(
@@ -251,7 +221,7 @@ export class JobsService {
 
     job.scheduledDate = scheduleJobDto.scheduledDate;
     const saved = await this.jobRepository.save(job);
-    return this.toJobResponseDto(saved);
+    return toJobResponseDto(saved);
   }
 
   async assign(


### PR DESCRIPTION
## Summary
- add mapper utilities for customers, equipment, jobs, and contracts
- refactor services to use shared mappers instead of private conversion methods

## Testing
- `npm test` *(fails: CannotExecuteNotConnectedError: Cannot execute operation on "default" connection because connection is not yet established)*
- `npm run lint` *(fails: @typescript-eslint/no-unsafe-member-access, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a5b965d08325be2004dd1a6207a0