### PR TITLE
feat: add shared pagination utility

### DIFF
--- a/backend/src/common/pagination.spec.ts
+++ b/backend/src/common/pagination.spec.ts
@@ -1,0 +1,39 @@
+import { paginate } from './pagination';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+
+describe('paginate', () => {
+  let repo: jest.Mocked<Repository<any>>;
+  let qb: Record<string, jest.Mock>;
+
+  beforeEach(() => {
+    qb = {
+      andWhere: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+
+    repo = {
+      createQueryBuilder: jest.fn().mockReturnValue(qb as unknown as SelectQueryBuilder<any>),
+    } as unknown as jest.Mocked<Repository<any>>;
+  });
+
+  it('caps limit at 100', async () => {
+    await paginate(repo, { page: 1, limit: 1000 }, 'entity');
+    expect(qb.take).toHaveBeenCalledWith(100);
+  });
+
+  it('applies provided filters', async () => {
+    const filter = (qb: SelectQueryBuilder<any>) =>
+      qb.andWhere('entity.active = :active', { active: true });
+
+    await paginate(repo, { page: 1, limit: 10 }, 'entity', filter);
+    expect(qb.andWhere).toHaveBeenCalledWith('entity.active = :active', {
+      active: true,
+    });
+  });
+});

--- a/backend/src/common/pagination.ts
+++ b/backend/src/common/pagination.ts
@@ -1,0 +1,32 @@
+import { Repository, SelectQueryBuilder, ObjectLiteral } from 'typeorm';
+import { PaginationQueryDto } from './dto/pagination-query.dto';
+
+export type QueryBuilderCustomizer<T extends ObjectLiteral> = (
+  qb: SelectQueryBuilder<T>,
+) => SelectQueryBuilder<T>;
+
+/**
+ * Applies pagination to a repository with optional query customizations.
+ * Caps the limit at 100 items to prevent excessive queries.
+ */
+export async function paginate<T extends ObjectLiteral>(
+  repository: Repository<T>,
+  pagination: PaginationQueryDto,
+  alias: string,
+  customizeQuery?: QueryBuilderCustomizer<T>,
+): Promise<{ items: T[]; total: number }> {
+  const { page = 1, limit = 10 } = pagination;
+  const cappedLimit = Math.min(limit, 100);
+
+  let qb = repository.createQueryBuilder(alias);
+  if (customizeQuery) {
+    qb = customizeQuery(qb);
+  }
+
+  const [items, total] = await qb
+    .skip((page - 1) * cappedLimit)
+    .take(cappedLimit)
+    .getManyAndCount();
+
+  return { items, total };
+}


### PR DESCRIPTION
## Summary
- add reusable paginate helper for repositories
- delegate Customers, Equipment and Jobs service pagination to shared helper
- test pagination utility for limit cap and filter behavior

## Testing
- `npm test --prefix backend` *(fails: CannotExecuteNotConnectedError: Cannot execute operation on "default" connection because connection is not yet established)*
- `npm test --prefix backend src/common/pagination.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1a5dff99883258b49fb615bfa7553