### PR TITLE
refactor: centralize scheduling and equipment rules

### DIFF
--- a/backend/src/jobs/jobs.module.ts
+++ b/backend/src/jobs/jobs.module.ts
@@ -8,13 +8,14 @@ import { Customer } from '../customers/entities/customer.entity';
 import { Assignment } from './entities/assignment.entity';
 import { User } from '../users/user.entity';
 import { Equipment } from '../equipment/entities/equipment.entity';
+import { SchedulingService } from './scheduling.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Job, Customer, Assignment, User, Equipment]),
   ],
   controllers: [JobsController],
-  providers: [JobsService],
-  exports: [JobsService],
+  providers: [JobsService, SchedulingService],
+  exports: [JobsService, SchedulingService],
 })
 export class JobsModule {}

--- a/backend/src/jobs/scheduling.service.spec.ts
+++ b/backend/src/jobs/scheduling.service.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SelectQueryBuilder } from 'typeorm';
+import { SchedulingService } from './scheduling.service';
+import { Assignment } from './entities/assignment.entity';
+
+describe('SchedulingService', () => {
+  let service: SchedulingService;
+  let repo: { createQueryBuilder: jest.Mock };
+
+  beforeEach(async () => {
+    repo = { createQueryBuilder: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SchedulingService,
+        { provide: getRepositoryToken(Assignment), useValue: repo },
+      ],
+    }).compile();
+
+    service = module.get<SchedulingService>(SchedulingService);
+  });
+
+  it('should detect conflicts', async () => {
+    const qb: Record<string, jest.Mock> = {
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue({ id: 1 }),
+    };
+    repo.createQueryBuilder.mockReturnValue(
+      qb as unknown as SelectQueryBuilder<Assignment>,
+    );
+
+    const result = await service.checkResourceConflicts(
+      new Date(),
+      1,
+      2,
+      3,
+      4,
+    );
+
+    expect(qb.leftJoin).toHaveBeenCalledWith('assignment.job', 'job');
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      '(assignment.userId = :userId OR assignment.equipmentId = :equipmentId)',
+      { userId: 1, equipmentId: 2 },
+    );
+    expect(result).toBe(true);
+  });
+});

--- a/backend/src/jobs/scheduling.service.ts
+++ b/backend/src/jobs/scheduling.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Assignment } from './entities/assignment.entity';
+
+@Injectable()
+export class SchedulingService {
+  constructor(
+    @InjectRepository(Assignment)
+    private readonly assignmentRepository: Repository<Assignment>,
+  ) {}
+
+  async checkResourceConflicts(
+    date: Date,
+    userId: number,
+    equipmentId: number,
+    companyId: number,
+    jobId?: number,
+  ): Promise<boolean> {
+    const query = this.assignmentRepository
+      .createQueryBuilder('assignment')
+      .leftJoin('assignment.job', 'job')
+      .where('job.scheduledDate = :date', { date })
+      .andWhere('assignment.companyId = :companyId', { companyId })
+      .andWhere(
+        '(assignment.userId = :userId OR assignment.equipmentId = :equipmentId)',
+        { userId, equipmentId },
+      );
+
+    if (jobId !== undefined) {
+      query.andWhere('job.id != :jobId', { jobId });
+    }
+
+    const conflict = await query.getOne();
+    return !!conflict;
+  }
+}


### PR DESCRIPTION
## Summary
- move equipment status validation into entity method and remove service helper
- add scheduling service to centralize resource conflict checks
- update jobs service/tests to use domain scheduling service

## Testing
- `npm test` *(fails: CannotExecuteNotConnectedError in rls.policy.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a5fa95dc8325951bdd741969df99