### PR TITLE
refactor: extract user creation services

### DIFF
--- a/backend/src/users/__tests__/user-creation.service.spec.ts
+++ b/backend/src/users/__tests__/user-creation.service.spec.ts
@@ -1,0 +1,132 @@
+import * as bcrypt from 'bcrypt';
+import { QueryFailedError, Repository } from 'typeorm';
+import { UserCreationService } from '../user-creation.service';
+import { User, UserRole } from '../user.entity';
+import { CustomerRegistrationService } from '../customer-registration.service';
+import { CompanyOnboardingService } from '../company-onboarding.service';
+import { BadRequestException } from '@nestjs/common';
+
+const UNIQUE_VIOLATION = '23505';
+
+describe('UserCreationService', () => {
+  let service: UserCreationService;
+  let usersRepository: Repository<User> & { manager: any };
+  let customerRegistrationService: jest.Mocked<
+    Pick<CustomerRegistrationService, 'register'>
+  >;
+  let companyOnboardingService: jest.Mocked<
+    Pick<CompanyOnboardingService, 'onboard'>
+  >;
+  let manager: any;
+
+  beforeEach(() => {
+    usersRepository = {
+      create: jest.fn(
+        (dto) =>
+          Object.assign(new User(), { role: UserRole.Customer, ...dto }) as User,
+      ),
+      save: jest.fn(async (user: User) => {
+        if (user.password) {
+          await user.hashPassword();
+        }
+        if (!user.id) {
+          user.id = 1;
+        }
+        return user;
+      }),
+    } as unknown as Repository<User> & { manager: any };
+
+    manager = {
+      getRepository: jest.fn(() => usersRepository),
+    };
+
+    usersRepository.manager = {
+      transaction: jest.fn(async (cb) => cb(manager)),
+    };
+
+    customerRegistrationService = {
+      register: jest.fn(),
+    } as jest.Mocked<Pick<CustomerRegistrationService, 'register'>>;
+
+    companyOnboardingService = {
+      onboard: jest.fn(),
+    } as jest.Mocked<Pick<CompanyOnboardingService, 'onboard'>>;
+
+    service = new UserCreationService(
+      usersRepository as Repository<User>,
+      customerRegistrationService as unknown as CustomerRegistrationService,
+      companyOnboardingService as unknown as CompanyOnboardingService,
+    );
+  });
+
+  it('hashes passwords and registers customer by default', async () => {
+    const password = 'plainpassword';
+    const user = await service.createUser({
+      username: 'user1',
+      email: 'user1@example.com',
+      password,
+    });
+    expect(usersRepository.create).toHaveBeenCalledWith({
+      username: 'user1',
+      email: 'user1@example.com',
+      password,
+    });
+    expect(customerRegistrationService.register).toHaveBeenCalled();
+    expect(user.role).toBe(UserRole.Customer);
+    const isMatch = await bcrypt.compare(password, user.password);
+    expect(isMatch).toBe(true);
+  });
+
+  it('onboards company for owner accounts', async () => {
+    companyOnboardingService.onboard.mockImplementation(
+      async (user: User) => {
+        user.companyId = 1;
+        return {} as any;
+      },
+    );
+    const user = await service.createUser({
+      username: 'owner',
+      email: 'owner@example.com',
+      password: 'secret',
+      role: UserRole.Owner,
+      company: { name: 'ACME Landscaping' },
+    });
+    expect(companyOnboardingService.onboard).toHaveBeenCalled();
+    expect(user.companyId).toBe(1);
+  });
+
+  it('requires company for worker accounts', async () => {
+    companyOnboardingService.onboard.mockRejectedValueOnce(
+      new BadRequestException(),
+    );
+    await expect(
+      service.createUser({
+        username: 'worker',
+        email: 'w@example.com',
+        password: 'secret',
+        role: UserRole.Worker,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(companyOnboardingService.onboard).toHaveBeenCalled();
+  });
+
+  it('throws conflict when username exists', async () => {
+    const error = new QueryFailedError(
+      '',
+      [],
+      Object.assign(new Error(), { code: UNIQUE_VIOLATION }),
+    );
+    (usersRepository.save as jest.Mock).mockRejectedValueOnce(error);
+
+    await expect(
+      service.createUser({
+        username: 'existing',
+        email: 'existing@example.com',
+        password: 'secret',
+      }),
+    ).rejects.toMatchObject({
+      message: 'Username or email already exists',
+      status: 409,
+    });
+  });
+});

--- a/backend/src/users/__tests__/users.service.spec.ts
+++ b/backend/src/users/__tests__/users.service.spec.ts
@@ -1,26 +1,18 @@
 import * as bcrypt from 'bcrypt';
 import * as crypto from 'crypto';
-import { QueryFailedError, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import { UsersService } from '../users.service';
 import { User, UserRole } from '../user.entity';
-import { Company } from '../../companies/entities/company.entity';
-import { Customer } from '../../customers/entities/customer.entity';
 import { EmailService } from '../../common/email.service';
-
-const UNIQUE_VIOLATION = '23505';
+import { UserCreationService } from '../user-creation.service';
 
 describe('UsersService', () => {
   let service: UsersService;
   let usersRepository: jest.Mocked<
     Pick<Repository<User>, 'create' | 'save' | 'findOne' | 'find' | 'remove'>
   >;
-  let customerRepository: jest.Mocked<
-    Pick<Repository<Customer>, 'create' | 'save'>
-  >;
-  let companyRepository: jest.Mocked<
-    Pick<Repository<Company>, 'create' | 'save' | 'findOne'>
-  >;
+  let userCreationService: jest.Mocked<Pick<UserCreationService, 'createUser'>>;
   let emailService: {
     sendPasswordResetEmail: jest.Mock<void, [string, string]>;
   };
@@ -49,112 +41,32 @@ describe('UsersService', () => {
     } as unknown as jest.Mocked<
       Pick<Repository<User>, 'create' | 'save' | 'findOne' | 'find' | 'remove'>
     >;
-    customerRepository = {
-      create: jest.fn((dto) => Object.assign(new Customer(), dto) as Customer),
-      save: jest.fn((customer: Customer) => customer),
-    } as unknown as jest.Mocked<Pick<Repository<Customer>, 'create' | 'save'>>;
-    companyRepository = {
-      create: jest.fn((dto) => Object.assign(new Company(), dto) as Company),
-      save: jest.fn((company: Company) => {
-        if (!company.id) {
-          company.id = 1;
-        }
-        return company;
-      }),
-      findOne: jest.fn(),
-    } as unknown as jest.Mocked<
-      Pick<Repository<Company>, 'create' | 'save' | 'findOne'>
-    >;
+    userCreationService = {
+      createUser: jest.fn(),
+    } as jest.Mocked<Pick<UserCreationService, 'createUser'>>;
     emailService = {
       sendPasswordResetEmail: jest.fn<void, [string, string]>(),
     };
     service = new UsersService(
       usersRepository as unknown as Repository<User>,
-      customerRepository as unknown as Repository<Customer>,
-      companyRepository as unknown as Repository<Company>,
       emailService as unknown as EmailService,
+      userCreationService as unknown as UserCreationService,
     );
   });
 
-  it('hashes passwords before saving', async () => {
-    const password = 'plainpassword';
-    const user = await service.create({
+  it('delegates user creation to UserCreationService', async () => {
+    const dto = {
       username: 'user1',
       email: 'user1@example.com',
-      password,
-    });
-    expect(usersRepository.create).toHaveBeenCalledWith({
-      username: 'user1',
-      email: 'user1@example.com',
-      password,
-    });
-    expect(user.password).not.toBe(password);
-    const isMatch = await bcrypt.compare(password, user.password);
-    expect(isMatch).toBe(true);
-  });
-
-  it('assigns default role when none provided', async () => {
-    const user = await service.create({
-      username: 'user2',
-      email: 'user2@example.com',
       password: 'secret',
-    });
-    expect(user.role).toBe(UserRole.Customer);
-    expect(customerRepository.create).toHaveBeenCalledWith({
-      name: 'user2',
-      email: 'user2@example.com',
-      userId: 1,
-    });
-    expect(customerRepository.save).toHaveBeenCalled();
-  });
+    };
+    const created = Object.assign(new User(), dto);
+    userCreationService.createUser.mockResolvedValueOnce(created);
 
-  it('creates company for owner accounts', async () => {
-    companyRepository.findOne.mockResolvedValueOnce(null);
-    const user = await service.create({
-      username: 'owner',
-      email: 'owner@example.com',
-      password: 'secret',
-      role: UserRole.Owner,
-      company: { name: 'ACME Landscaping' },
-    });
-    expect(companyRepository.create).toHaveBeenCalledWith({
-      name: 'ACME Landscaping',
-      ownerId: 1,
-    });
-    expect(companyRepository.save).toHaveBeenCalled();
-    expect(usersRepository.save).toHaveBeenCalledTimes(2);
-    expect(user.companyId).toBe(1);
-  });
+    const result = await service.create(dto);
 
-  it('requires company for worker accounts', async () => {
-    await expect(
-      service.create({
-        username: 'worker',
-        email: 'w@example.com',
-        password: 'secret',
-        role: UserRole.Worker,
-      }),
-    ).rejects.toMatchObject({ status: 400 });
-  });
-
-  it('throws conflict when username exists', async () => {
-    const error = new QueryFailedError(
-      '',
-      [],
-      Object.assign(new Error(), { code: UNIQUE_VIOLATION }),
-    );
-    usersRepository.save.mockRejectedValueOnce(error);
-
-    await expect(
-      service.create({
-        username: 'existing',
-        email: 'existing@example.com',
-        password: 'secret',
-      }),
-    ).rejects.toMatchObject({
-      message: 'Username or email already exists',
-      status: 409,
-    });
+    expect(userCreationService.createUser).toHaveBeenCalledWith(dto);
+    expect(result).toBe(created);
   });
 
   it('generates reset token and emails user', async () => {

--- a/backend/src/users/company-onboarding.service.ts
+++ b/backend/src/users/company-onboarding.service.ts
@@ -1,0 +1,34 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
+import { Company } from '../companies/entities/company.entity';
+import { CreateCompanyDto } from '../companies/dto/create-company.dto';
+import { User, UserRole } from './user.entity';
+
+@Injectable()
+export class CompanyOnboardingService {
+  async onboard(
+    user: User,
+    company: CreateCompanyDto | undefined,
+    manager: EntityManager,
+  ) {
+    if (!company) {
+      throw new BadRequestException(
+        'Company information is required for owner and worker accounts',
+      );
+    }
+    const companyRepository = manager.getRepository(Company);
+    let existing = await companyRepository.findOne({
+      where: { name: company.name },
+    });
+    if (!existing) {
+      existing = companyRepository.create({
+        ...company,
+        ownerId: user.role === UserRole.Owner ? user.id : undefined,
+      });
+      existing = await companyRepository.save(existing);
+    }
+    user.companyId = existing.id;
+    await manager.getRepository(User).save(user);
+    return existing;
+  }
+}

--- a/backend/src/users/customer-registration.service.ts
+++ b/backend/src/users/customer-registration.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
+import { Customer } from '../customers/entities/customer.entity';
+import { User } from './user.entity';
+
+@Injectable()
+export class CustomerRegistrationService {
+  async register(user: User, manager: EntityManager) {
+    const customerRepository = manager.getRepository(Customer);
+    const customer = customerRepository.create({
+      name: user.username,
+      email: user.email,
+      userId: user.id,
+    });
+    return customerRepository.save(customer);
+  }
+}

--- a/backend/src/users/user-creation.service.ts
+++ b/backend/src/users/user-creation.service.ts
@@ -1,0 +1,53 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { CreateUserDto } from './dto/create-user.dto';
+import { User, UserRole } from './user.entity';
+import { CustomerRegistrationService } from './customer-registration.service';
+import { CompanyOnboardingService } from './company-onboarding.service';
+
+const UNIQUE_VIOLATION = '23505';
+
+@Injectable()
+export class UserCreationService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+    private readonly customerRegistrationService: CustomerRegistrationService,
+    private readonly companyOnboardingService: CompanyOnboardingService,
+  ) {}
+
+  async createUser(createUserDto: CreateUserDto): Promise<User> {
+    const { company, ...userData } = createUserDto;
+    try {
+      return await this.usersRepository.manager.transaction(async (manager) => {
+        const userRepo = manager.getRepository(User);
+        const user = userRepo.create(userData);
+        const savedUser = await userRepo.save(user);
+
+        if (savedUser.role === UserRole.Customer) {
+          await this.customerRegistrationService.register(savedUser, manager);
+        } else if (
+          savedUser.role === UserRole.Owner ||
+          savedUser.role === UserRole.Worker
+        ) {
+          await this.companyOnboardingService.onboard(
+            savedUser,
+            company,
+            manager,
+          );
+        }
+
+        return savedUser;
+      });
+    } catch (error) {
+      if (error instanceof QueryFailedError) {
+        const { code } = error.driverError as { code?: string };
+        if (code === UNIQUE_VIOLATION) {
+          throw new ConflictException('Username or email already exists');
+        }
+      }
+      throw error;
+    }
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,15 +1,22 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
-import { Customer } from '../customers/entities/customer.entity';
-import { Company } from '../companies/entities/company.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { EmailService } from '../common/email.service';
+import { UserCreationService } from './user-creation.service';
+import { CustomerRegistrationService } from './customer-registration.service';
+import { CompanyOnboardingService } from './company-onboarding.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Customer, Company])],
-  providers: [UsersService, EmailService],
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [
+    UsersService,
+    EmailService,
+    UserCreationService,
+    CustomerRegistrationService,
+    CompanyOnboardingService,
+  ],
   controllers: [UsersController],
   exports: [UsersService],
 })


### PR DESCRIPTION
## Summary
- add dedicated user, customer, and company creation services
- delegate UsersService.create to new UserCreationService for transactional orchestration
- update users module and tests for new service structure

## Testing
- `npm test` *(fails: CannotExecuteNotConnectedError: connection is not established)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a60f40708325b19bb0f34af595dc