### PR TITLE
feat(frontend): add contracts module

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -32,6 +32,11 @@ export const routes: Routes = [
     loadChildren: () => import('./jobs/jobs.routes').then(m => m.jobsRoutes)
   },
   {
+    path: 'contracts',
+    canActivate: [AuthGuard],
+    loadChildren: () => import('./contracts/contracts.routes').then(m => m.contractsRoutes)
+  },
+  {
     path: 'users',
     canActivate: [AuthGuard],
     loadChildren: () => import('./users/users.routes').then(m => m.usersRoutes)

--- a/frontend/src/app/contracts/contract-editor.component.html
+++ b/frontend/src/app/contracts/contract-editor.component.html
@@ -1,0 +1,29 @@
+<h2>Contract Editor</h2>
+<form (ngSubmit)="save()" #contractForm="ngForm">
+  <label>
+    Customer ID
+    <input type="number" name="customerId" [(ngModel)]="contract.customerId" required />
+  </label>
+  <label>
+    Start Date
+    <input type="date" name="startDate" [(ngModel)]="contract.startDate" required />
+  </label>
+  <label>
+    End Date
+    <input type="date" name="endDate" [(ngModel)]="contract.endDate" />
+  </label>
+  <label>
+    Frequency
+    <select name="frequency" [(ngModel)]="contract.frequency">
+      <option value="WEEKLY">Weekly</option>
+      <option value="BIWEEKLY">Biweekly</option>
+      <option value="MONTHLY">Monthly</option>
+      <option value="BIMONTHLY">Bimonthly</option>
+    </select>
+  </label>
+  <label>
+    Job Title
+    <input type="text" name="jobTitle" [(ngModel)]="contract.jobTemplate!.title" required />
+  </label>
+  <button type="submit" [disabled]="contractForm.invalid">Save</button>
+</form>

--- a/frontend/src/app/contracts/contract-editor.component.ts
+++ b/frontend/src/app/contracts/contract-editor.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, RouterModule, Router } from '@angular/router';
+import { ContractsService, Contract } from './contracts.service';
+
+@Component({
+  selector: 'app-contract-editor',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  templateUrl: './contract-editor.component.html'
+})
+export class ContractEditorComponent implements OnInit {
+  private contractsService = inject(ContractsService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+
+  contract: Contract = {
+    customerId: 1,
+    startDate: '',
+    frequency: 'WEEKLY',
+    jobTemplate: { title: '' }
+  };
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      const contractId = Number(id);
+      if (!isNaN(contractId)) {
+        this.contractsService.get(contractId).subscribe(contract => (this.contract = contract));
+      }
+    }
+  }
+
+  save(): void {
+    if (this.contract.id) {
+      this.contractsService
+        .update(this.contract.id, this.contract)
+        .subscribe(() => this.router.navigate(['/contracts']));
+    } else {
+      this.contractsService
+        .create(this.contract)
+        .subscribe(() => this.router.navigate(['/contracts']));
+    }
+  }
+}
+

--- a/frontend/src/app/contracts/contract-list.component.html
+++ b/frontend/src/app/contracts/contract-list.component.html
@@ -1,0 +1,10 @@
+<h2>Contracts</h2>
+<ul>
+  <li *ngFor="let contract of contracts">
+    <a [routerLink]="['/contracts', contract.id]">
+      Contract {{ contract.id }} - {{ contract.customer?.name || contract.customerId }}
+    </a>
+    <button type="button" (click)="cancel(contract.id!)">Cancel</button>
+  </li>
+</ul>
+<a routerLink="/contracts/new">Create Contract</a>

--- a/frontend/src/app/contracts/contract-list.component.ts
+++ b/frontend/src/app/contracts/contract-list.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { ContractsService, Contract } from './contracts.service';
+
+@Component({
+  selector: 'app-contract-list',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './contract-list.component.html'
+})
+export class ContractListComponent implements OnInit {
+  private contractsService = inject(ContractsService);
+  contracts: Contract[] = [];
+
+  ngOnInit(): void {
+    this.contractsService.list().subscribe(contracts => (this.contracts = contracts));
+  }
+
+  cancel(id: number): void {
+    this.contractsService.cancel(id).subscribe(() => {
+      this.contracts = this.contracts.filter(c => c.id !== id);
+    });
+  }
+}
+

--- a/frontend/src/app/contracts/contracts.routes.ts
+++ b/frontend/src/app/contracts/contracts.routes.ts
@@ -1,0 +1,16 @@
+import { Routes } from '@angular/router';
+
+export const contractsRoutes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./contract-list.component').then(m => m.ContractListComponent)
+  },
+  {
+    path: 'new',
+    loadComponent: () => import('./contract-editor.component').then(m => m.ContractEditorComponent)
+  },
+  {
+    path: ':id',
+    loadComponent: () => import('./contract-editor.component').then(m => m.ContractEditorComponent)
+  }
+];

--- a/frontend/src/app/contracts/contracts.service.ts
+++ b/frontend/src/app/contracts/contracts.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface Contract {
+  id?: number;
+  customerId: number;
+  startDate: string;
+  endDate?: string;
+  frequency: string;
+  totalOccurrences?: number;
+  jobTemplate?: {
+    title: string;
+    description?: string;
+    estimatedHours?: number;
+    notes?: string;
+  };
+  active?: boolean;
+  customer?: { id: number; name: string; email: string };
+}
+
+@Injectable({ providedIn: 'root' })
+export class ContractsService {
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.apiUrl}/contracts`;
+
+  list(): Observable<Contract[]> {
+    return this.http.get<Contract[]>(this.baseUrl);
+  }
+
+  get(id: number): Observable<Contract> {
+    return this.http.get<Contract>(`${this.baseUrl}/${id}`);
+  }
+
+  create(contract: Contract): Observable<Contract> {
+    return this.http.post<Contract>(this.baseUrl, contract);
+  }
+
+  update(id: number, contract: Contract): Observable<Contract> {
+    return this.http.patch<Contract>(`${this.baseUrl}/${id}`, contract);
+  }
+
+  cancel(id: number): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/${id}/cancel`, {});
+  }
+}
+


### PR DESCRIPTION
## Summary
- add contracts service with list, create, update, and cancel API calls
- introduce contract list and editor components with routes
- wire contracts feature into main application routes

## Testing
- `npm test` *(frontend)* (fails: No binary for Chrome browser)
- `npm test` *(backend)* (fails: CannotExecuteNotConnectedError)


------
https://chatgpt.com/codex/tasks/task_e_68b1a6b031bc8325a4b99f119f236efa