### PR TITLE
feat: add company profile and worker management components

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -37,6 +37,11 @@ export const routes: Routes = [
     loadChildren: () => import('./users/users.routes').then(m => m.usersRoutes)
   },
   {
+    path: 'company',
+    canActivate: [AuthGuard],
+    loadChildren: () => import('./companies/companies.routes').then(m => m.companiesRoutes)
+  },
+  {
     path: 'admin',
     canActivate: [AdminGuard],
     loadChildren: () => import('./admin/admin.routes').then(m => m.adminRoutes)

--- a/frontend/src/app/companies/companies.routes.ts
+++ b/frontend/src/app/companies/companies.routes.ts
@@ -1,0 +1,20 @@
+import { Routes } from '@angular/router';
+
+export const companiesRoutes: Routes = [
+  {
+    path: 'profile',
+    loadComponent: () =>
+      import('./company-profile.component').then(m => m.CompanyProfileComponent)
+  },
+  {
+    path: 'workers',
+    loadComponent: () =>
+      import('./worker-list.component').then(m => m.WorkerListComponent)
+  },
+  {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: 'profile'
+  }
+];
+

--- a/frontend/src/app/companies/company-profile.component.ts
+++ b/frontend/src/app/companies/company-profile.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { CompanyService } from './company.service';
+import { Company } from './company.model';
+
+@Component({
+  selector: 'app-company-profile',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div *ngIf="company">
+      <h2>Company Profile</h2>
+      <form (ngSubmit)="save()">
+        <label>Name:
+          <input name="name" [(ngModel)]="company.name" />
+        </label>
+        <label>Address:
+          <input name="address" [(ngModel)]="company.address" />
+        </label>
+        <label>Phone:
+          <input name="phone" [(ngModel)]="company.phone" />
+        </label>
+        <label>Email:
+          <input name="email" [(ngModel)]="company.email" />
+        </label>
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  `
+})
+export class CompanyProfileComponent implements OnInit {
+  private readonly companyService = inject(CompanyService);
+  company?: Company;
+
+  ngOnInit(): void {
+    this.companyService.getProfile().subscribe(c => (this.company = c));
+  }
+
+  save(): void {
+    if (!this.company || !this.company.id) {
+      return;
+    }
+    this.companyService.updateCompany(this.company.id, this.company).subscribe();
+  }
+}
+

--- a/frontend/src/app/companies/worker-list.component.ts
+++ b/frontend/src/app/companies/worker-list.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink, Router } from '@angular/router';
+import { CompanyService } from './company.service';
+import { UserService, User } from '../users/user.service';
+import { AuthService } from '../auth/auth.service';
+
+@Component({
+  selector: 'app-worker-list',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  template: `
+    <h2>Workers</h2>
+    <ul>
+      <li *ngFor="let w of workers">
+        <a [routerLink]="['/users', w.id]">{{ w.username }}</a>
+        <button *ngIf="auth.hasRole('admin')" (click)="delete(w.id)">Delete</button>
+      </li>
+    </ul>
+    <button *ngIf="auth.hasRole('admin')" (click)="addWorker()">Add Worker</button>
+  `
+})
+export class WorkerListComponent implements OnInit {
+  private readonly companyService = inject(CompanyService);
+  private readonly userService = inject(UserService);
+  private readonly router = inject(Router);
+  protected readonly auth = inject(AuthService);
+  workers: User[] = [];
+
+  ngOnInit(): void {
+    this.companyService.getWorkers().subscribe(ws => (this.workers = ws));
+  }
+
+  delete(id: number): void {
+    this.userService.deleteUser(id).subscribe(() => {
+      this.workers = this.workers.filter(w => w.id !== id);
+    });
+  }
+
+  addWorker(): void {
+    this.router.navigate(['/users/new']);
+  }
+}
+

--- a/frontend/src/app/layout/layout.component.html
+++ b/frontend/src/app/layout/layout.component.html
@@ -12,6 +12,8 @@
     <a routerLink="/customers" routerLinkActive="active">Customers</a>
     <a routerLink="/equipment" routerLinkActive="active">Equipment</a>
     <a routerLink="/jobs" routerLinkActive="active">Jobs</a>
+    <a routerLink="/company/profile" routerLinkActive="active">Company</a>
+    <a routerLink="/company/workers" routerLinkActive="active">Workers</a>
   </nav>
   <main class="content">
     <router-outlet></router-outlet>


### PR DESCRIPTION
## Summary
- add standalone company profile and worker list components
- wire up new company routes and navigation links

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a6cdfa7883258a99517e5e5e1e9a