### PR TITLE
feat(frontend): add auth interceptor and token flows

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -3,6 +3,7 @@ import { provideRouter } from '@angular/router';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { companyInterceptor } from './company.interceptor';
+import { authInterceptor } from './auth.interceptor';
 
 import { routes } from './app.routes';
 
@@ -12,6 +13,6 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
-    provideHttpClient(withInterceptors([companyInterceptor]))
+    provideHttpClient(withInterceptors([authInterceptor, companyInterceptor]))
   ]
 };

--- a/frontend/src/app/auth.interceptor.ts
+++ b/frontend/src/app/auth.interceptor.ts
@@ -1,0 +1,12 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from './auth/auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const auth = inject(AuthService);
+  const token = auth.getToken();
+  if (token) {
+    req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+  }
+  return next(req);
+};

--- a/frontend/src/app/layout/layout.component.ts
+++ b/frontend/src/app/layout/layout.component.ts
@@ -15,7 +15,7 @@ export class LayoutComponent {
   protected readonly auth = inject(AuthService);
 
   logout(): void {
-    this.auth.logout();
+    this.auth.logout().subscribe();
   }
 }
 


### PR DESCRIPTION
## Summary
- attach JWT as Authorization header on all HTTP requests via new interceptor
- enhance AuthService with password reset, refresh token, and logout API calls
- update layout to await logout

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a69c8bb48325bda75e96a1318fb8