### PR TITLE
Refactor backend services and stabilize tests

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-import { UserRole } from '../users/user.entity';
 import { RegisterDto } from './dto/register.dto';
 import { RequestPasswordResetDto } from './dto/request-password-reset.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -188,8 +188,11 @@ export class AuthService {
 
   private async saveRefreshToken(userId: number, token: string): Promise<void> {
     const hashed = this.hashToken(token);
-    const decoded = this.jwtService.decode(token) as { exp?: number } | null;
-    const expiresAt = decoded?.exp ? new Date(decoded.exp * 1000) : new Date();
+    const decoded: unknown = this.jwtService.decode(token);
+    const expiresAt =
+      typeof decoded === 'object' && decoded !== null && 'exp' in decoded
+        ? new Date((decoded as { exp: number }).exp * 1000)
+        : new Date();
     const entity = this.refreshTokenRepository.create({
       token: hashed,
       userId,

--- a/backend/src/common/decorators/auth-user.decorator.spec.ts
+++ b/backend/src/common/decorators/auth-user.decorator.spec.ts
@@ -1,5 +1,6 @@
-import "reflect-metadata";
+import 'reflect-metadata';
 import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
+import { ExecutionContext } from '@nestjs/common';
 import { AuthUser } from './auth-user.decorator';
 import { User } from '../../users/user.entity';
 
@@ -13,14 +14,17 @@ describe('AuthUser Decorator', () => {
       ROUTE_ARGS_METADATA,
       TestController,
       'test',
-    );
+    ) as Record<
+      string,
+      { factory: (data: unknown, ctx: ExecutionContext) => User | undefined }
+    >;
     const key = Object.keys(metadata)[0];
     const { factory } = metadata[key];
 
     const mockUser = {
       userId: 1,
       username: 'test',
-      role: 'customer',
+      role: 'customer' as User['role'],
       companyId: 2,
     };
 
@@ -28,9 +32,9 @@ describe('AuthUser Decorator', () => {
       switchToHttp: () => ({
         getRequest: () => ({ user: mockUser }),
       }),
-    } as any;
+    } as unknown as ExecutionContext;
 
-    const result = factory(null, ctx);
+    const result = factory(undefined, ctx);
     expect(result).toEqual(
       expect.objectContaining({
         id: 1,

--- a/backend/src/common/decorators/auth-user.decorator.ts
+++ b/backend/src/common/decorators/auth-user.decorator.ts
@@ -1,10 +1,17 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { User } from '../../users/user.entity';
 
+interface RequestUser {
+  userId: number;
+  username: string;
+  role: User['role'];
+  companyId: number;
+}
+
 export const AuthUser = createParamDecorator(
   (_data: unknown, ctx: ExecutionContext): User => {
-    const request = ctx.switchToHttp().getRequest<{ user?: any }>();
-    const user = request.user;
+    const request = ctx.switchToHttp().getRequest<{ user?: RequestUser }>();
+    const { user } = request;
     if (!user) {
       return undefined as unknown as User;
     }

--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -86,9 +86,7 @@ describe('CustomersService', () => {
   });
 
   it('allows duplicate emails across different companies', async () => {
-    repo.create.mockImplementation(
-      (dto: Partial<Customer>) => dto as Customer,
-    );
+    repo.create.mockImplementation((dto: Partial<Customer>) => dto as Customer);
     repo.save
       .mockResolvedValueOnce({ id: 1 } as Customer)
       .mockResolvedValueOnce({ id: 2 } as Customer);
@@ -114,6 +112,7 @@ describe('CustomersService', () => {
     repo.findAll.mockResolvedValue([[], 0]);
     const pagination: PaginationQueryDto = { page: 1, limit: 10 };
     await service.findAll(pagination, 1, undefined, 'Jane');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(repo.findAll).toHaveBeenCalledWith(pagination, 1, undefined, 'Jane');
   });
 });

--- a/backend/src/equipment/equipment.service.spec.ts
+++ b/backend/src/equipment/equipment.service.spec.ts
@@ -58,6 +58,7 @@ describe('EquipmentService', () => {
     repo.findAll.mockResolvedValue([[], 0]);
     const pagination: PaginationQueryDto = { page: 1, limit: 10 };
     await service.findAll(pagination, 1, undefined, undefined, 'truck');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(repo.findAll).toHaveBeenCalledWith(
       pagination,
       1,

--- a/backend/src/equipment/equipment.service.ts
+++ b/backend/src/equipment/equipment.service.ts
@@ -3,7 +3,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { Equipment, EquipmentStatus } from './entities/equipment.entity';
+import { EquipmentStatus } from './entities/equipment.entity';
 import { CreateEquipmentDto } from './dto/create-equipment.dto';
 import { UpdateEquipmentDto } from './dto/update-equipment.dto';
 import { EquipmentResponseDto } from './dto/equipment-response.dto';
@@ -13,9 +13,7 @@ import {
   IEquipmentRepository,
 } from './repositories/equipment.repository';
 import { Inject } from '@nestjs/common';
-import { paginate } from '../common/pagination';
 import { toEquipmentResponseDto } from './equipment.mapper';
-
 
 @Injectable()
 export class EquipmentService {
@@ -46,38 +44,12 @@ export class EquipmentService {
     type?: string,
     search?: string,
   ): Promise<{ items: EquipmentResponseDto[]; total: number }> {
-
     const [equipments, total] = await this.equipmentRepository.findAll(
       pagination,
       companyId,
       status,
       type,
       search,
-
-    const { items: equipments, total } = await paginate(
-      this.equipmentRepository,
-      pagination,
-      'equipment',
-      (qb) => {
-        qb.where('equipment.companyId = :companyId', { companyId });
-
-        if (status) {
-          qb.andWhere('equipment.status = :status', { status });
-        }
-
-        if (type) {
-          qb.andWhere('equipment.type = :type', { type });
-        }
-
-        if (search) {
-          qb.andWhere(
-            '(equipment.name ILIKE :search OR equipment.type ILIKE :search OR equipment.description ILIKE :search)',
-            { search: `%${search}%` },
-          );
-        }
-
-        return qb;
-      },
     );
 
     return {

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -7,17 +7,6 @@ import { EmailService } from '../common/email.service';
 import { UserCreationService } from './user-creation.service';
 import { CustomerRegistrationService } from './customer-registration.service';
 import { CompanyOnboardingService } from './company-onboarding.service';
-
-@Module({
-  imports: [TypeOrmModule.forFeature([User])],
-  providers: [
-    UsersService,
-    EmailService,
-    UserCreationService,
-    CustomerRegistrationService,
-    CompanyOnboardingService,
-  ],
-
 import {
   USER_REPOSITORY,
   UserRepository,
@@ -29,9 +18,15 @@ const userRepositoryProvider = {
 };
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Customer, Company])],
-  providers: [UsersService, EmailService, userRepositoryProvider],
-
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [
+    UsersService,
+    EmailService,
+    UserCreationService,
+    CustomerRegistrationService,
+    CompanyOnboardingService,
+    userRepositoryProvider,
+  ],
   controllers: [UsersController],
   exports: [UsersService, userRepositoryProvider],
 })


### PR DESCRIPTION
## Summary
- type AuthUser decorator and ensure JWT refresh tokens decoded safely
- simplify repository-backed service queries for customers, equipment, and jobs
- add proper UsersModule provider wiring and clean up tests

## Testing
- `npm run lint --if-present`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1acf4351c8325a813e6f975078670