### PR TITLE
Run frontend tests in headless Chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - run: npm test --if-present
         env:
           CI: true
+          CHROME_BIN: google-chrome
       - run: npm run build
       - name: Build production image
         if: matrix.project == 'backend' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -1,0 +1,35 @@
+const { join } = require('path');
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true
+    },
+    coverageReporter: {
+      dir: join(__dirname, './coverage'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: !process.env.CI,
+    browsers: ['ChromeHeadless'],
+    singleRun: !!process.env.CI,
+    restartOnFileChange: !process.env.CI
+  });
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "build": "ng build",
     "build:ssr": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test",
+    "test": "ng test --watch=false --browsers=ChromeHeadless",
     "serve:ssr": "node dist/frontend/server/server.mjs",
     "seed": "npm --prefix ../backend run seed",
     "seed:drop": "npm --prefix ../backend run seed:drop"


### PR DESCRIPTION
## Summary
- run frontend unit tests with ChromeHeadless
- add Karma config for headless runs and CI singleRun
- ensure CI sets CHROME_BIN for headless testing

## Testing
- `CI=true CHROME_BIN=chromium-browser npm test` *(fails: Chromium snap not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b10593cc8325be218bd82986e108