### PR TITLE
chore: split CI workflow into lint, test, build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,9 +26,44 @@ jobs:
           cache-dependency-path: ${{ matrix.project }}/package-lock.json
       - run: npm ci
       - run: npm run lint --if-present
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [backend, frontend]
+    defaults:
+      run:
+        working-directory: ${{ matrix.project }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ${{ matrix.project }}/package-lock.json
+      - run: npm ci
       - run: npm test --if-present
         env:
           CI: true
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    strategy:
+      matrix:
+        project: [backend, frontend]
+    defaults:
+      run:
+        working-directory: ${{ matrix.project }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ${{ matrix.project }}/package-lock.json
+      - run: npm ci
       - run: npm run build
       - name: Build production image
         if: matrix.project == 'backend' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))


### PR DESCRIPTION
## Summary
- split monolithic CI job into distinct lint, test, and build jobs
- ensure build job waits for lint and test

## Testing
- `npm test` (backend)
- `npm test -- --watch=false --browsers=ChromeHeadless` (frontend) *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b11d247883259715c2d7dd1a5f05