### PR TITLE
test: provide router and httpclient for app tests

### DIFF
--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -1,10 +1,13 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 import { App } from './app';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [provideHttpClient(), provideRouter([])],
     }).compileComponents();
   });
 


### PR DESCRIPTION
## Summary
- supply HttpClient and Router providers in App test setup

## Testing
- `npm test` *(fails: ChromeHeadless requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c6b1b7bc8325ad9647b7a216087a