### PR TITLE
feat(auth): support company during login

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -4,6 +4,7 @@ import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { RequestPasswordResetDto } from './dto/request-password-reset.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { LoginDto } from './dto/login.dto';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -36,6 +37,46 @@ describe('AuthController', () => {
     }).compile();
 
     controller = module.get<AuthController>(AuthController);
+  });
+
+  it('logs in without company', async () => {
+    const dto: LoginDto = { email: 'user@example.com', password: 'pass' };
+    const user = { id: 1 } as any;
+    const resultPayload = { access_token: 'token' };
+    authService.validateUser.mockResolvedValue(user);
+    authService.login.mockResolvedValue(resultPayload);
+
+    const result = await controller.login(dto);
+
+    expect(authService.validateUser).toHaveBeenCalledWith(
+      'user@example.com',
+      'pass',
+      undefined,
+    );
+    expect(authService.login).toHaveBeenCalledWith(user);
+    expect(result).toEqual(resultPayload);
+  });
+
+  it('logs in with company', async () => {
+    const dto: LoginDto = {
+      email: 'user@example.com',
+      password: 'pass',
+      company: 'Acme',
+    };
+    const user = { id: 1 } as any;
+    const resultPayload = { access_token: 'token' };
+    authService.validateUser.mockResolvedValue(user);
+    authService.login.mockResolvedValue(resultPayload);
+
+    const result = await controller.login(dto);
+
+    expect(authService.validateUser).toHaveBeenCalledWith(
+      'user@example.com',
+      'pass',
+      'Acme',
+    );
+    expect(authService.login).toHaveBeenCalledWith(user);
+    expect(result).toEqual(resultPayload);
   });
 
   it('registers a new user and sends verification email', async () => {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -23,6 +23,7 @@ export class AuthController {
     const user: User = await this.authService.validateUser(
       loginDto.email,
       loginDto.password,
+      loginDto.company,
     );
     return this.authService.login(user);
   }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -27,8 +27,15 @@ export class AuthService {
     private readonly emailService: EmailService,
   ) {}
 
-  async validateUser(email: string, pass: string): Promise<User> {
-    const user = await this.usersService.findByEmail(email);
+  async validateUser(
+    email: string,
+    pass: string,
+    company?: string,
+  ): Promise<User> {
+    const user = await this.usersRepository.findOne({
+      where: { email },
+      relations: ['company'],
+    });
     if (!user) {
       throw new UnauthorizedException('Invalid credentials');
     }
@@ -40,6 +47,12 @@ export class AuthService {
 
     if (!user.isVerified) {
       throw new UnauthorizedException('Email not verified');
+    }
+
+    if (company !== undefined) {
+      if (!user.company || user.company.name !== company) {
+        throw new UnauthorizedException('Invalid company');
+      }
     }
 
     return user;

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,5 +1,5 @@
-import { IsEmail, IsString } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class LoginDto {
   @ApiProperty()
@@ -9,4 +9,9 @@ export class LoginDto {
   @ApiProperty()
   @IsString()
   password: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  company?: string;
 }


### PR DESCRIPTION
## Summary
- allow LoginDto to include optional company context
- verify user company membership during authentication
- test login flow with and without company field

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1c714702c8325adef5cff5e751da7