### PR TITLE
feat: surface errors in forms

### DIFF
--- a/frontend/src/app/companies/company-profile.component.ts
+++ b/frontend/src/app/companies/company-profile.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { CompanyService } from './company.service';
 import { Company } from './company.model';
+import { ErrorService } from '../error.service';
 
 @Component({
   selector: 'app-company-profile',
@@ -35,16 +36,27 @@ import { Company } from './company.model';
 })
 export class CompanyProfileComponent implements OnInit {
   private readonly companyService = inject(CompanyService);
+  private readonly errorService = inject(ErrorService);
   company?: Company;
 
   ngOnInit(): void {
-    this.companyService.getProfile().subscribe((c) => (this.company = c));
+    this.companyService.getProfile().subscribe({
+      next: (c) => (this.company = c),
+      error: () => this.errorService.show('Failed to load company profile'),
+    });
   }
 
   save(): void {
     if (!this.company || !this.company.id) {
       return;
     }
-    this.companyService.updateCompany(this.company.id, this.company).subscribe();
+    this.companyService.updateCompany(this.company.id, this.company).subscribe({
+      next: () => {
+        if (typeof window !== 'undefined') {
+          window.alert('Company updated successfully');
+        }
+      },
+      error: () => this.errorService.show('Failed to save company'),
+    });
   }
 }

--- a/frontend/src/app/equipment/equipment-detail.component.ts
+++ b/frontend/src/app/equipment/equipment-detail.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { EquipmentService, Equipment } from './equipment.service';
+import { ErrorService } from '../error.service';
 
 @Component({
   selector: 'app-equipment-detail',
@@ -31,30 +32,52 @@ export class EquipmentDetailComponent {
   private equipmentService = inject(EquipmentService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private errorService = inject(ErrorService);
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
     if (id && id !== 'new') {
-      this.equipmentService.getEquipment(+id).subscribe((data) => (this.equipment = data));
+      this.equipmentService.getEquipment(+id).subscribe({
+        next: (data) => (this.equipment = data),
+        error: () => this.errorService.show('Failed to load equipment'),
+      });
     }
   }
 
   save(): void {
     if (this.equipment.id) {
-      this.equipmentService.updateEquipment(this.equipment.id, this.equipment).subscribe(() => {
-        void this.router.navigate(['/equipment']);
+      this.equipmentService.updateEquipment(this.equipment.id, this.equipment).subscribe({
+        next: () => {
+          if (typeof window !== 'undefined') {
+            window.alert('Equipment updated successfully');
+          }
+          void this.router.navigate(['/equipment']);
+        },
+        error: () => this.errorService.show('Failed to update equipment'),
       });
     } else {
-      this.equipmentService.createEquipment(this.equipment).subscribe(() => {
-        void this.router.navigate(['/equipment']);
+      this.equipmentService.createEquipment(this.equipment).subscribe({
+        next: () => {
+          if (typeof window !== 'undefined') {
+            window.alert('Equipment created successfully');
+          }
+          void this.router.navigate(['/equipment']);
+        },
+        error: () => this.errorService.show('Failed to create equipment'),
       });
     }
   }
 
   remove(): void {
     if (this.equipment.id) {
-      this.equipmentService.deleteEquipment(this.equipment.id).subscribe(() => {
-        void this.router.navigate(['/equipment']);
+      this.equipmentService.deleteEquipment(this.equipment.id).subscribe({
+        next: () => {
+          if (typeof window !== 'undefined') {
+            window.alert('Equipment deleted successfully');
+          }
+          void this.router.navigate(['/equipment']);
+        },
+        error: () => this.errorService.show('Failed to delete equipment'),
       });
     }
   }

--- a/frontend/src/app/users/user-detail.component.ts
+++ b/frontend/src/app/users/user-detail.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { UserService, User } from './user.service';
 import { AuthService } from '../auth/auth.service';
+import { ErrorService } from '../error.service';
 
 @Component({
   selector: 'app-user-detail',
@@ -48,12 +49,16 @@ export class UserDetailComponent implements OnInit {
   private readonly userService = inject(UserService);
   private readonly route = inject(ActivatedRoute);
   protected readonly auth = inject(AuthService);
+  private readonly errorService = inject(ErrorService);
   user?: User;
 
   ngOnInit(): void {
     const id = Number(this.route.snapshot.paramMap.get('id'));
-    this.userService.getUser(id).subscribe((u) => {
-      this.user = u;
+    this.userService.getUser(id).subscribe({
+      next: (u) => {
+        this.user = u;
+      },
+      error: () => this.errorService.show('Failed to load user'),
     });
   }
 
@@ -61,6 +66,13 @@ export class UserDetailComponent implements OnInit {
     if (!this.user) {
       return;
     }
-    this.userService.updateUser(this.user).subscribe();
+    this.userService.updateUser(this.user).subscribe({
+      next: () => {
+        if (typeof window !== 'undefined') {
+          window.alert('User updated successfully');
+        }
+      },
+      error: () => this.errorService.show('Failed to save user'),
+    });
   }
 }

--- a/frontend/src/app/users/user-form.component.ts
+++ b/frontend/src/app/users/user-form.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { UserService } from './user.service';
+import { ErrorService } from '../error.service';
 
 @Component({
   selector: 'app-user-form',
@@ -69,6 +70,7 @@ export class UserFormComponent {
   private fb = inject(FormBuilder);
   private userService = inject(UserService);
   private router = inject(Router);
+  private errorService = inject(ErrorService);
 
   form = this.fb.nonNullable.group({
     username: ['', Validators.required.bind(Validators)],
@@ -100,8 +102,14 @@ export class UserFormComponent {
       if (phone) payload.phone = phone;
       if (role) payload.role = role;
       if (this.isOwner) payload.company = company;
-      this.userService.createUser(payload).subscribe(() => {
-        void this.router.navigate(['/users']);
+      this.userService.createUser(payload).subscribe({
+        next: () => {
+          if (typeof window !== 'undefined') {
+            window.alert('User created successfully');
+          }
+          void this.router.navigate(['/users']);
+        },
+        error: () => this.errorService.show('Failed to create user'),
       });
     }
   }


### PR DESCRIPTION
## Summary
- inject ErrorService across customer, user, equipment, job, and company components
- show error alerts for failed API operations
- display basic success alerts after save/delete actions

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend test` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c742491083259314a78c6513b5b0