### PR TITLE
Allow unauthenticated metrics access

### DIFF
--- a/backend/src/common/tenant.guard.spec.ts
+++ b/backend/src/common/tenant.guard.spec.ts
@@ -1,0 +1,18 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { TenantGuard } from './tenant.guard';
+
+describe('TenantGuard', () => {
+  it('allows access to metrics endpoint without company ID', () => {
+    const guard = new TenantGuard(new Reflector());
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ path: '/api/metrics', headers: {} }),
+      }),
+      getHandler: () => undefined,
+      getClass: () => undefined,
+    } as unknown as ExecutionContext;
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+});

--- a/backend/src/common/tenant.guard.ts
+++ b/backend/src/common/tenant.guard.ts
@@ -1,5 +1,6 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
 import { IS_PUBLIC_KEY } from './decorators/public.decorator';
 import { tenantStorage } from './tenant/tenant-context';
 
@@ -8,6 +9,17 @@ export class TenantGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<
+      Request & {
+        user?: { companyId?: number };
+        headers?: Record<string, string | string[]>;
+      }
+    >();
+    const path = request.path || request.originalUrl || '';
+    if (path.startsWith('/api/metrics') || path.startsWith('/metrics')) {
+      return true;
+    }
+
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
       context.getClass(),
@@ -15,10 +27,7 @@ export class TenantGuard implements CanActivate {
     if (isPublic) {
       return true;
     }
-    const request = context.switchToHttp().getRequest<{
-      user?: { companyId?: number };
-      headers?: Record<string, string | string[]>;
-    }>();
+
     const header = request.headers?.['x-company-id'];
     let companyId = request.user?.companyId;
     if (header) {


### PR DESCRIPTION
## Summary
- Skip tenant guard for `/api/metrics` so metrics endpoint is accessible without company context
- Cover metrics access in new tenant guard unit test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1c7b4bc948325b2e9af0e82eff7d4