### PR TITLE
refactor: migrate template-driven forms to reactive forms with validation

### DIFF
--- a/frontend/src/app/companies/company-profile.component.ts
+++ b/frontend/src/app/companies/company-profile.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { CompanyService } from './company.service';
 import { Company } from './company.model';
 import { ErrorService } from '../error.service';
@@ -8,27 +8,56 @@ import { ErrorService } from '../error.service';
 @Component({
   selector: 'app-company-profile',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, ReactiveFormsModule],
   template: `
     <div *ngIf="company">
       <h2>Company Profile</h2>
-      <form (ngSubmit)="save()">
-        <label
-          >Name:
-          <input name="name" [(ngModel)]="company.name" />
+      <form [formGroup]="form" (ngSubmit)="save()">
+        <label>
+          Name:
+          <input formControlName="name" />
         </label>
-        <label
-          >Address:
-          <input name="address" [(ngModel)]="company.address" />
+        <div
+          *ngIf="
+            form.controls.name.errors && (form.controls.name.dirty || form.controls.name.touched)
+          "
+        >
+          {{ form.controls.name.errors | json }}
+        </div>
+        <label>
+          Address:
+          <input formControlName="address" />
         </label>
-        <label
-          >Phone:
-          <input name="phone" [(ngModel)]="company.phone" />
+        <div
+          *ngIf="
+            form.controls.address.errors &&
+            (form.controls.address.dirty || form.controls.address.touched)
+          "
+        >
+          {{ form.controls.address.errors | json }}
+        </div>
+        <label>
+          Phone:
+          <input formControlName="phone" />
         </label>
-        <label
-          >Email:
-          <input name="email" [(ngModel)]="company.email" />
+        <div
+          *ngIf="
+            form.controls.phone.errors && (form.controls.phone.dirty || form.controls.phone.touched)
+          "
+        >
+          {{ form.controls.phone.errors | json }}
+        </div>
+        <label>
+          Email:
+          <input formControlName="email" />
         </label>
+        <div
+          *ngIf="
+            form.controls.email.errors && (form.controls.email.dirty || form.controls.email.touched)
+          "
+        >
+          {{ form.controls.email.errors | json }}
+        </div>
         <button type="submit">Save</button>
       </form>
     </div>
@@ -37,11 +66,27 @@ import { ErrorService } from '../error.service';
 export class CompanyProfileComponent implements OnInit {
   private readonly companyService = inject(CompanyService);
   private readonly errorService = inject(ErrorService);
+  private fb = inject(FormBuilder);
   company?: Company;
+
+  form = this.fb.nonNullable.group({
+    name: ['', Validators.required.bind(Validators)],
+    address: ['', Validators.required.bind(Validators)],
+    phone: ['', [Validators.required.bind(Validators), Validators.pattern(/^\d{10}$/)]],
+    email: ['', [Validators.required.bind(Validators), Validators.email.bind(Validators)]],
+  });
 
   ngOnInit(): void {
     this.companyService.getProfile().subscribe({
-      next: (c) => (this.company = c),
+      next: (c) => {
+        this.company = c;
+        this.form.patchValue({
+          name: c.name,
+          address: c.address ?? '',
+          phone: c.phone ?? '',
+          email: c.email ?? '',
+        });
+      },
       error: () => this.errorService.show('Failed to load company profile'),
     });
   }
@@ -50,13 +95,19 @@ export class CompanyProfileComponent implements OnInit {
     if (!this.company || !this.company.id) {
       return;
     }
-    this.companyService.updateCompany(this.company.id, this.company).subscribe({
-      next: () => {
-        if (typeof window !== 'undefined') {
-          window.alert('Company updated successfully');
-        }
-      },
-      error: () => this.errorService.show('Failed to save company'),
-    });
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.companyService
+      .updateCompany(this.company.id, { ...this.company, ...this.form.getRawValue() })
+      .subscribe({
+        next: () => {
+          if (typeof window !== 'undefined') {
+            window.alert('Company updated successfully');
+          }
+        },
+        error: () => this.errorService.show('Failed to save company'),
+      });
   }
 }

--- a/frontend/src/app/companies/company.service.spec.ts
+++ b/frontend/src/app/companies/company.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { CompanyService } from './company.service';
 import { ApiService } from '../api.service';
-import { Company } from './company.model';
+import { Company } from '../api.service';
 
 describe('CompanyService', () => {
   let service: CompanyService;

--- a/frontend/src/app/jobs/job-editor.component.html
+++ b/frontend/src/app/jobs/job-editor.component.html
@@ -1,17 +1,30 @@
 <h2>Job Editor</h2>
-<form (ngSubmit)="save()" #jobForm="ngForm">
+<form [formGroup]="form" (ngSubmit)="save()">
   <label>
     Title
-    <input type="text" name="title" [(ngModel)]="job.title" required />
+    <input type="text" formControlName="title" />
   </label>
+  <div *ngIf="form.controls.title.errors && (form.controls.title.dirty || form.controls.title.touched)">
+    {{ form.controls.title.errors | json }}
+  </div>
   <label>
     Description
-    <textarea name="description" [(ngModel)]="job.description"></textarea>
+    <textarea formControlName="description"></textarea>
   </label>
+  <div
+    *ngIf="form.controls.description.errors && (form.controls.description.dirty || form.controls.description.touched)"
+  >
+    {{ form.controls.description.errors | json }}
+  </div>
   <label>
     Schedule Date
-    <input type="date" name="scheduledDate" [(ngModel)]="job.scheduledDate" (change)="schedule()" />
+    <input type="date" formControlName="scheduledDate" (change)="schedule()" />
   </label>
+  <div
+    *ngIf="form.controls.scheduledDate.errors && (form.controls.scheduledDate.dirty || form.controls.scheduledDate.touched)"
+  >
+    {{ form.controls.scheduledDate.errors | json }}
+  </div>
   <fieldset>
     <legend>Assign</legend>
     <label>
@@ -24,5 +37,5 @@
     </label>
     <button type="button" (click)="assign(worker.valueAsNumber, equipment.valueAsNumber)">Assign</button>
   </fieldset>
-  <button type="submit" [disabled]="jobForm.invalid">Save</button>
+  <button type="submit">Save</button>
 </form>

--- a/frontend/src/app/users/user-detail.component.ts
+++ b/frontend/src/app/users/user-detail.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { UserService, User } from './user.service';
 import { AuthService } from '../auth/auth.service';
@@ -9,36 +9,81 @@ import { ErrorService } from '../error.service';
 @Component({
   selector: 'app-user-detail',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, ReactiveFormsModule],
   template: `
     <div *ngIf="user">
-      <h3>{{ user.username }}</h3>
-      <form (ngSubmit)="save()">
-        <label
-          >Username:
-          <input name="username" [(ngModel)]="user.username" />
+      <h3>{{ form.controls.username.value }}</h3>
+      <form [formGroup]="form" (ngSubmit)="save()">
+        <label>
+          Username:
+          <input formControlName="username" />
         </label>
-        <label
-          >Email:
-          <input name="email" [(ngModel)]="user.email" />
+        <div
+          *ngIf="
+            form.controls.username.errors &&
+            (form.controls.username.dirty || form.controls.username.touched)
+          "
+        >
+          {{ form.controls.username.errors | json }}
+        </div>
+        <label>
+          Email:
+          <input formControlName="email" />
         </label>
-        <label
-          >First Name:
-          <input name="firstName" [(ngModel)]="user.firstName" />
+        <div
+          *ngIf="
+            form.controls.email.errors && (form.controls.email.dirty || form.controls.email.touched)
+          "
+        >
+          {{ form.controls.email.errors | json }}
+        </div>
+        <label>
+          First Name:
+          <input formControlName="firstName" />
         </label>
-        <label
-          >Last Name:
-          <input name="lastName" [(ngModel)]="user.lastName" />
+        <div
+          *ngIf="
+            form.controls.firstName.errors &&
+            (form.controls.firstName.dirty || form.controls.firstName.touched)
+          "
+        >
+          {{ form.controls.firstName.errors | json }}
+        </div>
+        <label>
+          Last Name:
+          <input formControlName="lastName" />
         </label>
-        <label
-          >Phone:
-          <input name="phone" [(ngModel)]="user.phone" />
+        <div
+          *ngIf="
+            form.controls.lastName.errors &&
+            (form.controls.lastName.dirty || form.controls.lastName.touched)
+          "
+        >
+          {{ form.controls.lastName.errors | json }}
+        </div>
+        <label>
+          Phone:
+          <input formControlName="phone" />
         </label>
+        <div
+          *ngIf="
+            form.controls.phone.errors && (form.controls.phone.dirty || form.controls.phone.touched)
+          "
+        >
+          {{ form.controls.phone.errors | json }}
+        </div>
         <div *ngIf="auth.hasRole('admin')">
-          <label
-            >Role:
-            <input name="role" [(ngModel)]="user.role" />
+          <label>
+            Role:
+            <input formControlName="role" />
           </label>
+          <div
+            *ngIf="
+              form.controls.role.errors && (form.controls.role.dirty || form.controls.role.touched)
+            "
+          >
+            {{ form.controls.role.errors | json }}
+          </div>
         </div>
         <button type="submit">Save</button>
       </form>
@@ -50,13 +95,24 @@ export class UserDetailComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   protected readonly auth = inject(AuthService);
   private readonly errorService = inject(ErrorService);
+  private fb = inject(FormBuilder);
   user?: User;
+
+  form = this.fb.nonNullable.group({
+    username: ['', Validators.required.bind(Validators)],
+    email: ['', [Validators.required.bind(Validators), Validators.email.bind(Validators)]],
+    firstName: ['', Validators.required.bind(Validators)],
+    lastName: ['', Validators.required.bind(Validators)],
+    phone: ['', [Validators.required.bind(Validators), Validators.pattern(/^\d{10}$/)]],
+    role: [''],
+  });
 
   ngOnInit(): void {
     const id = Number(this.route.snapshot.paramMap.get('id'));
     this.userService.getUser(id).subscribe({
       next: (u) => {
         this.user = u;
+        this.form.patchValue(u);
       },
       error: () => this.errorService.show('Failed to load user'),
     });
@@ -66,7 +122,12 @@ export class UserDetailComponent implements OnInit {
     if (!this.user) {
       return;
     }
-    this.userService.updateUser(this.user).subscribe({
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    const payload: User = { ...this.user, ...this.form.getRawValue() } as User;
+    this.userService.updateUser(payload).subscribe({
       next: () => {
         if (typeof window !== 'undefined') {
           window.alert('User updated successfully');


### PR DESCRIPTION
## Summary
- convert company profile, job editor, equipment detail, and user detail components to reactive forms
- add required, email, and phone validators with inline error displays
- update company service spec to match ApiService types

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c998b8ac8325a9ebc89fea9c89cd