### PR TITLE
refactor: strengthen frontend typings

### DIFF
--- a/frontend/src/app/companies/company.model.ts
+++ b/frontend/src/app/companies/company.model.ts
@@ -1,8 +1,9 @@
-export interface Company {
-  id?: number;
-  name: string;
-  address?: string | null;
-  phone?: string | null;
-  email?: string | null;
-  ownerId?: number | null;
-}
+import {
+  Company as ApiCompany,
+  CreateCompany as ApiCreateCompany,
+  UpdateCompany as ApiUpdateCompany,
+} from '../api.service';
+
+export type Company = ApiCompany;
+export type CreateCompany = ApiCreateCompany;
+export type UpdateCompany = ApiUpdateCompany;

--- a/frontend/src/app/companies/company.service.ts
+++ b/frontend/src/app/companies/company.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { Company } from './company.model';
-import { User } from '../users/user.service';
+import { Company, CreateCompany, UpdateCompany } from './company.model';
+import { User } from '../users/user.model';
 import { ApiService } from '../api.service';
 
 @Injectable({ providedIn: 'root' })
@@ -16,13 +16,11 @@ export class CompanyService {
     return this.api.getCompanyWorkers();
   }
 
-  createCompany(company: Partial<Company>): Observable<Company> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return this.api.createCompany(company as any);
+  createCompany(company: CreateCompany): Observable<Company> {
+    return this.api.createCompany(company);
   }
 
-  updateCompany(id: number, company: Partial<Company>): Observable<Company> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return this.api.updateCompany(id, company as any);
+  updateCompany(id: number, company: UpdateCompany): Observable<Company> {
+    return this.api.updateCompany(id, company);
   }
 }

--- a/frontend/src/app/companies/worker-list.component.ts
+++ b/frontend/src/app/companies/worker-list.component.ts
@@ -2,7 +2,8 @@ import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink, Router } from '@angular/router';
 import { CompanyService } from './company.service';
-import { UserService, User } from '../users/user.service';
+import { UserService } from '../users/user.service';
+import { User } from '../users/user.model';
 import { AuthService } from '../auth/auth.service';
 
 @Component({

--- a/frontend/src/app/jobs/job-calendar.component.ts
+++ b/frontend/src/app/jobs/job-calendar.component.ts
@@ -1,7 +1,8 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { JobsService, Job } from './jobs.service';
+import { JobsService } from './jobs.service';
+import { Job } from './job.model';
 
 @Component({
   selector: 'app-job-calendar',

--- a/frontend/src/app/jobs/job-editor.component.ts
+++ b/frontend/src/app/jobs/job-editor.component.ts
@@ -2,7 +2,8 @@ import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, RouterModule, Router } from '@angular/router';
-import { JobsService, Job } from './jobs.service';
+import { JobsService } from './jobs.service';
+import { Job } from './job.model';
 import { ErrorService } from '../error.service';
 
 @Component({

--- a/frontend/src/app/jobs/job-list.component.ts
+++ b/frontend/src/app/jobs/job-list.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { JobsService, Job } from './jobs.service';
+import { JobsService } from './jobs.service';
+import { Job } from './job.model';
 
 @Component({
   selector: 'app-job-list',

--- a/frontend/src/app/jobs/job.model.ts
+++ b/frontend/src/app/jobs/job.model.ts
@@ -1,0 +1,25 @@
+import {
+  Job as ApiJob,
+  CreateJob as ApiCreateJob,
+  UpdateJob as ApiUpdateJob,
+} from '../api.service';
+
+export interface Job extends Omit<ApiJob, 'id' | 'completed'> {
+  id?: number;
+  completed?: boolean;
+  description?: string;
+  scheduledDate?: string;
+  customerId?: number;
+}
+
+export type CreateJob = ApiCreateJob & {
+  description?: string;
+  scheduledDate?: string;
+  customerId?: number;
+};
+
+export type UpdateJob = ApiUpdateJob & {
+  description?: string;
+  scheduledDate?: string;
+  customerId?: number;
+};

--- a/frontend/src/app/jobs/jobs.service.ts
+++ b/frontend/src/app/jobs/jobs.service.ts
@@ -1,15 +1,8 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { ApiService, Job as ApiJob } from '../api.service';
-
-export interface Job extends Omit<ApiJob, 'id' | 'completed'> {
-  id?: number;
-  completed?: boolean;
-  description?: string;
-  scheduledDate?: string;
-  customerId?: number;
-}
+import { ApiService } from '../api.service';
+import { Job, CreateJob, UpdateJob } from './job.model';
 
 @Injectable({ providedIn: 'root' })
 export class JobsService {
@@ -23,14 +16,12 @@ export class JobsService {
     return this.api.getJob(id);
   }
 
-  create(job: Job): Observable<Job> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return this.api.createJob(job as any);
+  create(job: CreateJob): Observable<Job> {
+    return this.api.createJob(job);
   }
 
-  update(id: number, job: Job): Observable<Job> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return this.api.updateJob(id, job as any);
+  update(id: number, job: UpdateJob): Observable<Job> {
+    return this.api.updateJob(id, job);
   }
 
   assign(id: number, payload: { userId: number; equipmentId: number }): Observable<Job> {

--- a/frontend/src/app/users/user-detail.component.ts
+++ b/frontend/src/app/users/user-detail.component.ts
@@ -2,7 +2,8 @@ import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import { UserService, User } from './user.service';
+import { UserService } from './user.service';
+import { User } from './user.model';
 import { AuthService } from '../auth/auth.service';
 import { ErrorService } from '../error.service';
 

--- a/frontend/src/app/users/user-list.component.ts
+++ b/frontend/src/app/users/user-list.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink, Router } from '@angular/router';
-import { UserService, User } from './user.service';
+import { UserService } from './user.service';
+import { User } from './user.model';
 import { AuthService } from '../auth/auth.service';
 
 @Component({

--- a/frontend/src/app/users/user.model.ts
+++ b/frontend/src/app/users/user.model.ts
@@ -1,0 +1,9 @@
+import {
+  User as ApiUser,
+  CreateUser as ApiCreateUser,
+  UpdateUser as ApiUpdateUser,
+} from '../api.service';
+
+export type User = ApiUser;
+export type CreateUser = ApiCreateUser;
+export type UpdateUser = ApiUpdateUser;

--- a/frontend/src/app/users/user.service.ts
+++ b/frontend/src/app/users/user.service.ts
@@ -1,18 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { Company } from '../companies/company.model';
 import { ApiService } from '../api.service';
-
-export interface User {
-  id: number;
-  username: string;
-  email: string;
-  role: string;
-  company?: Company;
-  firstName?: string;
-  lastName?: string;
-  phone?: string;
-}
+import { User, CreateUser, UpdateUser } from './user.model';
 
 @Injectable({ providedIn: 'root' })
 export class UserService {
@@ -23,17 +12,16 @@ export class UserService {
   }
 
   getUser(id: number): Observable<User> {
-    return this.api.getUser(id) as Observable<User>;
+    return this.api.getUser(id);
   }
 
-  createUser(user: Partial<User>): Observable<User> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return this.api.createUser(user as any) as Observable<User>;
+  createUser(user: CreateUser): Observable<User> {
+    return this.api.createUser(user);
   }
 
-  updateUser(user: User): Observable<User> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return this.api.updateUser(user.id, user as any) as Observable<User>;
+  updateUser(user: UpdateUser & { id: number }): Observable<User> {
+    const { id, ...payload } = user;
+    return this.api.updateUser(id, payload);
   }
 
   deleteUser(id: number): Observable<void> {


### PR DESCRIPTION
## Summary
- centralize User and Job types into dedicated model files
- use typed payloads in User, Company, and Jobs services without ESLint suppressions
- update components to import shared models

## Testing
- `npm test` *(fails: No binary for ChromeHeadless)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1c9c2939c8325ab4f9a94807d3df6