### PR TITLE
feat: support self-serve owner signup

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -17,6 +17,7 @@ describe('AuthController', () => {
     resetPassword: jest.Mock;
     refresh: jest.Mock;
     logout: jest.Mock;
+    signupOwner: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -29,6 +30,7 @@ describe('AuthController', () => {
       resetPassword: jest.fn(),
       refresh: jest.fn(),
       logout: jest.fn(),
+      signupOwner: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -77,6 +79,22 @@ describe('AuthController', () => {
     );
     expect(authService.login).toHaveBeenCalledWith(user);
     expect(result).toEqual(resultPayload);
+  });
+
+  it('signs up a new owner', async () => {
+    const dto = {
+      name: 'Owner',
+      email: 'owner@example.com',
+      password: 'Password1!',
+      companyName: 'Acme Co',
+    };
+    const response = { access_token: 'jwt' };
+    authService.signupOwner.mockResolvedValue(response);
+
+    const result = await controller.signupOwner(dto as any);
+
+    expect(authService.signupOwner).toHaveBeenCalledWith(dto);
+    expect(result).toEqual(response);
   });
 
   it('registers a new user and sends verification email', async () => {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -9,11 +9,20 @@ import { Public } from '../common/decorators/public.decorator';
 import { User } from '../users/user.entity';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { VerifyEmailDto } from './dto/verify-email.dto';
+import { SignupOwnerDto } from './dto/signup-owner.dto';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
+
+  @Public()
+  @Post('signup-owner')
+  @ApiOperation({ summary: 'Self-register a new company owner' })
+  @ApiResponse({ status: 201, description: 'Created owner and company' })
+  async signupOwner(@Body() dto: SignupOwnerDto) {
+    return this.authService.signupOwner(dto);
+  }
 
   @Public()
   @Post('login')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -10,12 +10,14 @@ import { RefreshToken } from './refresh-token.entity';
 import { VerificationToken } from './verification-token.entity';
 import { User } from '../users/user.entity';
 import { EmailService } from '../common/email.service';
+import { Company } from '../companies/entities/company.entity';
+import { CompanyUser } from '../companies/entities/company-user.entity';
 
 @Module({
   imports: [
     UsersModule,
     ConfigModule,
-    TypeOrmModule.forFeature([RefreshToken, VerificationToken, User]),
+    TypeOrmModule.forFeature([RefreshToken, VerificationToken, User, Company, CompanyUser]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/auth/dto/signup-owner.dto.ts
+++ b/backend/src/auth/dto/signup-owner.dto.ts
@@ -1,0 +1,30 @@
+import { IsEmail, IsString, MinLength, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { PASSWORD_REGEX } from '../password.util';
+
+export class SignupOwnerDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty()
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({
+    description:
+      'Password must be at least 8 characters with uppercase, lowercase, number, and special character',
+    example: 'SecurePass123!',
+  })
+  @IsString()
+  @MinLength(8, { message: 'Password must be at least 8 characters long' })
+  @Matches(PASSWORD_REGEX, {
+    message:
+      'Password must contain uppercase, lowercase, number, and special character',
+  })
+  password: string;
+
+  @ApiProperty()
+  @IsString()
+  companyName: string;
+}

--- a/backend/test/auth-signup-owner.e2e-spec.ts
+++ b/backend/test/auth-signup-owner.e2e-spec.ts
@@ -1,0 +1,75 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ConflictException, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AuthController } from '../src/auth/auth.controller';
+import { AuthService } from '../src/auth/auth.service';
+
+describe('Auth signup-owner endpoint (e2e)', () => {
+  let app: INestApplication<App>;
+  let signupOwner: jest.Mock;
+
+  beforeEach(async () => {
+    signupOwner = jest.fn();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: { signupOwner } }],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        errorHttpStatusCode: 422,
+      }),
+    );
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('signs up an owner and returns a token', () => {
+    signupOwner.mockResolvedValue({ access_token: 'jwt' });
+    return request(app.getHttpServer())
+      .post('/api/auth/signup-owner')
+      .send({
+        name: 'Owner',
+        email: 'owner@example.com',
+        password: 'Password1!',
+        companyName: 'Acme Co',
+      })
+      .expect(201)
+      .expect((res: request.Response) => {
+        expect(res.body.access_token).toBe('jwt');
+        expect(signupOwner).toHaveBeenCalled();
+      });
+  });
+
+  it('returns 409 when email already exists', () => {
+    signupOwner.mockRejectedValue(
+      new ConflictException('Email already exists'),
+    );
+    return request(app.getHttpServer())
+      .post('/api/auth/signup-owner')
+      .send({
+        name: 'Owner',
+        email: 'owner@example.com',
+        password: 'Password1!',
+        companyName: 'Acme Co',
+      })
+      .expect(409);
+  });
+
+  it('returns 422 for invalid body', () => {
+    return request(app.getHttpServer())
+      .post('/api/auth/signup-owner')
+      .send({ email: 'owner@example.com' })
+      .expect(422);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/auth/signup-owner` for owners to create an account with company
- create company and membership then return login tokens
- cover signup-owner flow with controller and e2e tests

## Testing
- `npm test`
- `npx jest -c test/jest-e2e.json test/auth-signup-owner.e2e-spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1ced9ef7083258310f57dcc5e7927