### PR TITLE
feat: add invitation preview endpoint

### DIFF
--- a/backend/src/companies/__tests__/invitations.preview.spec.ts
+++ b/backend/src/companies/__tests__/invitations.preview.spec.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/require-await */
+import * as crypto from 'crypto';
+import { Repository } from 'typeorm';
+import { InvitationsService } from '../invitations.service';
+import { Invitation, InvitationRole } from '../entities/invitation.entity';
+import { Company } from '../entities/company.entity';
+import { CompanyUser } from '../entities/company-user.entity';
+import { User } from '../../users/user.entity';
+import { EmailService } from '../../common/email.service';
+
+describe('InvitationsService previewInvitation', () => {
+  let service: InvitationsService;
+  let invitationsRepo: jest.Mocked<Pick<Repository<Invitation>, 'findOne'>>;
+
+  beforeEach(() => {
+    invitationsRepo = {
+      findOne: jest.fn(),
+    } as unknown as jest.Mocked<Pick<Repository<Invitation>, 'findOne'>>;
+
+    service = new InvitationsService(
+      invitationsRepo as unknown as Repository<Invitation>,
+      {} as unknown as Repository<CompanyUser>,
+      {} as unknown as Repository<User>,
+      {} as unknown as EmailService,
+    );
+  });
+
+  it('returns valid status for active invitation', async () => {
+    const invitation = Object.assign(new Invitation(), {
+      company: Object.assign(new Company(), { name: 'ACME' }),
+      email: 'worker@example.com',
+      role: InvitationRole.WORKER,
+      expiresAt: new Date(Date.now() + 1000),
+    });
+    invitationsRepo.findOne.mockResolvedValue(invitation);
+
+    const result = await service.previewInvitation('tok');
+
+    expect(result).toEqual({
+      companyName: 'ACME',
+      email: 'worker@example.com',
+      role: InvitationRole.WORKER,
+      status: 'valid',
+    });
+    const hash = crypto.createHash('sha256').update('tok').digest('hex');
+    expect(invitationsRepo.findOne).toHaveBeenCalledWith({
+      where: { tokenHash: hash },
+      relations: ['company'],
+    });
+  });
+
+  it('returns expired status when invitation expired', async () => {
+    const invitation = Object.assign(new Invitation(), {
+      company: Object.assign(new Company(), { name: 'ACME' }),
+      email: 'a@b.com',
+      role: InvitationRole.ADMIN,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    invitationsRepo.findOne.mockResolvedValue(invitation);
+
+    const result = await service.previewInvitation('tok');
+    expect(result.status).toBe('expired');
+  });
+
+  it('returns revoked status when invitation revoked', async () => {
+    const invitation = Object.assign(new Invitation(), {
+      company: Object.assign(new Company(), { name: 'ACME' }),
+      email: 'a@b.com',
+      role: InvitationRole.ADMIN,
+      expiresAt: new Date(Date.now() + 1000),
+      revokedAt: new Date(),
+    });
+    invitationsRepo.findOne.mockResolvedValue(invitation);
+
+    const result = await service.previewInvitation('tok');
+    expect(result.status).toBe('revoked');
+  });
+
+  it('returns accepted status when invitation accepted', async () => {
+    const invitation = Object.assign(new Invitation(), {
+      company: Object.assign(new Company(), { name: 'ACME' }),
+      email: 'a@b.com',
+      role: InvitationRole.ADMIN,
+      expiresAt: new Date(Date.now() + 1000),
+      acceptedAt: new Date(),
+    });
+    invitationsRepo.findOne.mockResolvedValue(invitation);
+
+    const result = await service.previewInvitation('tok');
+    expect(result.status).toBe('accepted');
+  });
+
+  it('throws NotFoundException when invitation not found', async () => {
+    invitationsRepo.findOne.mockResolvedValue(null);
+    await expect(service.previewInvitation('tok')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});

--- a/backend/src/companies/companies.module.ts
+++ b/backend/src/companies/companies.module.ts
@@ -5,6 +5,7 @@ import { CompanyUser } from './entities/company-user.entity';
 import { Invitation } from './entities/invitation.entity';
 import { CompaniesService } from './companies.service';
 import { CompaniesController } from './companies.controller';
+import { InvitationsController } from './invitations.controller';
 import { User } from '../users/user.entity';
 import { UsersModule } from '../users/users.module';
 import { InvitationsService } from './invitations.service';
@@ -16,7 +17,7 @@ import { EmailService } from '../common/email.service';
     UsersModule,
   ],
   providers: [CompaniesService, InvitationsService, EmailService],
-  controllers: [CompaniesController],
+  controllers: [CompaniesController, InvitationsController],
   exports: [CompaniesService, InvitationsService],
 })
 export class CompaniesModule {}

--- a/backend/src/companies/invitations.controller.ts
+++ b/backend/src/companies/invitations.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { InvitationsService } from './invitations.service';
+import { InvitationRole } from './entities/invitation.entity';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('invitations')
+@Controller('invitations')
+export class InvitationsController {
+  constructor(private readonly invitationsService: InvitationsService) {}
+
+  @Get(':token')
+  async preview(
+    @Param('token') token: string,
+  ): Promise<{
+    companyName: string;
+    email: string;
+    role: InvitationRole;
+    status: 'valid' | 'expired' | 'revoked' | 'accepted';
+  }> {
+    return this.invitationsService.previewInvitation(token);
+  }
+}


### PR DESCRIPTION
## Summary
- add public `GET /invitations/:token` endpoint for previewing invites
- handle token hashing and status calculation in InvitationsService
- test invitation preview for valid, expired, revoked, accepted, and missing tokens

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1dac3255883259cad78049de49704