### PR TITLE
Handle existing user invitation acceptance

### DIFF
--- a/backend/src/common/guards/optional-jwt-auth.guard.ts
+++ b/backend/src/common/guards/optional-jwt-auth.guard.ts
@@ -1,0 +1,16 @@
+import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+@Injectable()
+export class OptionalJwtAuthGuard extends JwtAuthGuard {
+  handleRequest(err: unknown, user: any, info: unknown, context: ExecutionContext) {
+    try {
+      return super.handleRequest(err, user, info, context);
+    } catch (e) {
+      if (e instanceof UnauthorizedException) {
+        return null;
+      }
+      throw e;
+    }
+  }
+}

--- a/backend/src/companies/__tests__/invitations.accept-existing-user.spec.ts
+++ b/backend/src/companies/__tests__/invitations.accept-existing-user.spec.ts
@@ -1,0 +1,154 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */
+import * as crypto from 'crypto';
+import { Repository } from 'typeorm';
+import { InvitationsService } from '../invitations.service';
+import { Invitation, InvitationRole } from '../entities/invitation.entity';
+import { CompanyUser, CompanyUserRole } from '../entities/company-user.entity';
+import { User } from '../../users/user.entity';
+import { EmailService } from '../../common/email.service';
+
+describe('InvitationsService acceptExistingUser', () => {
+  let service: InvitationsService;
+  let invitationsRepo: jest.Mocked<Pick<Repository<Invitation>, 'findOne' | 'save'>>;
+  let companyUsersRepo: jest.Mocked<
+    Pick<Repository<CompanyUser>, 'create' | 'save'>
+  >;
+  let usersRepo: jest.Mocked<Pick<Repository<User>, 'findOne' | 'save'>>;
+  let emailService: EmailService;
+
+  beforeEach(() => {
+    invitationsRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(async (inv) => inv),
+    } as unknown as jest.Mocked<Pick<Repository<Invitation>, 'findOne' | 'save'>>;
+    companyUsersRepo = {
+      create: jest.fn((dto) => Object.assign(new CompanyUser(), dto)),
+      save: jest.fn(async (m) => m),
+    } as unknown as jest.Mocked<Pick<Repository<CompanyUser>, 'create' | 'save'>>;
+    usersRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(async (u) => u),
+    } as unknown as jest.Mocked<Pick<Repository<User>, 'findOne' | 'save'>>;
+    emailService = {} as EmailService;
+    service = new InvitationsService(
+      invitationsRepo as unknown as Repository<Invitation>,
+      companyUsersRepo as unknown as Repository<CompanyUser>,
+      usersRepo as unknown as Repository<User>,
+      emailService,
+    );
+  });
+
+  it('adds membership for existing user and marks invitation accepted', async () => {
+    const token = 'abc';
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const invitation = Object.assign(new Invitation(), {
+      companyId: 7,
+      email: 'existing@user.com',
+      role: InvitationRole.ADMIN,
+      tokenHash,
+      expiresAt: new Date(Date.now() + 10000),
+      invitedBy: 1,
+    });
+    invitationsRepo.findOne.mockResolvedValue(invitation);
+    usersRepo.findOne.mockResolvedValue(
+      Object.assign(new User(), { id: 5, email: 'existing@user.com' }),
+    );
+
+    const user = await service.acceptExistingUser(token, {
+      userId: 5,
+      email: 'existing@user.com',
+    });
+
+    expect(user.companyId).toBe(7);
+    expect(companyUsersRepo.create).toHaveBeenCalledWith({
+      companyId: 7,
+      userId: 5,
+      role: CompanyUserRole.ADMIN,
+      invitedBy: 1,
+    });
+    expect(invitation.acceptedAt).toBeInstanceOf(Date);
+  });
+
+  it('rejects when email mismatch', async () => {
+    const token = 'tok';
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const invitation = Object.assign(new Invitation(), {
+      companyId: 7,
+      email: 'invited@user.com',
+      role: InvitationRole.WORKER,
+      tokenHash,
+      expiresAt: new Date(Date.now() + 10000),
+    });
+    invitationsRepo.findOne.mockResolvedValue(invitation);
+    usersRepo.findOne.mockResolvedValue(
+      Object.assign(new User(), { id: 5, email: 'invited@user.com' }),
+    );
+    await expect(
+      service.acceptExistingUser(token, {
+        userId: 5,
+        email: 'other@user.com',
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('rejects expired token', async () => {
+    const token = 'expired';
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const invitation = Object.assign(new Invitation(), {
+      tokenHash,
+      companyId: 1,
+      email: 'a@b.com',
+      role: InvitationRole.WORKER,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    invitationsRepo.findOne.mockResolvedValue(invitation);
+    usersRepo.findOne.mockResolvedValue(
+      Object.assign(new User(), { id: 1, email: 'a@b.com' }),
+    );
+    await expect(
+      service.acceptExistingUser(token, {
+        userId: 1,
+        email: 'a@b.com',
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects revoked or used token', async () => {
+    const token = 'revoked';
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const invitation = Object.assign(new Invitation(), {
+      tokenHash,
+      companyId: 1,
+      email: 'a@b.com',
+      role: InvitationRole.WORKER,
+      expiresAt: new Date(Date.now() + 1000),
+      revokedAt: new Date(),
+    });
+    invitationsRepo.findOne.mockResolvedValueOnce(invitation);
+    usersRepo.findOne.mockResolvedValue(
+      Object.assign(new User(), { id: 1, email: 'a@b.com' }),
+    );
+    await expect(
+      service.acceptExistingUser(token, {
+        userId: 1,
+        email: 'a@b.com',
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    const used = Object.assign(new Invitation(), {
+      tokenHash,
+      companyId: 1,
+      email: 'a@b.com',
+      role: InvitationRole.WORKER,
+      expiresAt: new Date(Date.now() + 1000),
+      acceptedAt: new Date(),
+    });
+    invitationsRepo.findOne.mockResolvedValueOnce(used);
+    await expect(
+      service.acceptExistingUser(token, {
+        userId: 1,
+        email: 'a@b.com',
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/backend/src/companies/invitations.controller.ts
+++ b/backend/src/companies/invitations.controller.ts
@@ -1,10 +1,21 @@
-import { Controller, Get, Param, Post, Body } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Body,
+  Req,
+  BadRequestException,
+  UseGuards,
+  ValidationPipe,
+} from '@nestjs/common';
 import { InvitationsService } from './invitations.service';
 import { InvitationRole } from './entities/invitation.entity';
 import { ApiTags } from '@nestjs/swagger';
 import { AcceptInvitationDto } from './dto/accept-invitation.dto';
 import { Public } from '../common/decorators/public.decorator';
 import { AuthService } from '../auth/auth.service';
+import { OptionalJwtAuthGuard } from '../common/guards/optional-jwt-auth.guard';
 
 @ApiTags('invitations')
 @Controller('invitations')
@@ -27,11 +38,30 @@ export class InvitationsController {
   }
 
   @Public()
+  @UseGuards(OptionalJwtAuthGuard)
   @Post(':token/accept')
   async accept(
     @Param('token') token: string,
-    @Body() dto: AcceptInvitationDto,
+    @Body(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        skipMissingProperties: true,
+      }),
+    )
+    dto: AcceptInvitationDto,
+    @Req() req: { user?: { userId: number; email: string } },
   ) {
+    if (req.user) {
+      const user = await this.invitationsService.acceptExistingUser(
+        token,
+        req.user,
+      );
+      return this.authService.login(user);
+    }
+    if (!dto?.name || !dto?.password) {
+      throw new BadRequestException('Name and password are required');
+    }
     const user = await this.invitationsService.acceptInvitation(token, dto);
     return this.authService.login(user);
   }


### PR DESCRIPTION
## Summary
- Allow existing users to accept company invitations with matching email
- Add optional JWT guard and conditional invitation handling
- Cover email mismatch and token validity with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1df30a3248325ba4bef6ca7c0c6e7