### PR TITLE
Backend: revoke and resend invitations

### DIFF
--- a/backend/src/companies/__tests__/invitations.revoke-resend.spec.ts
+++ b/backend/src/companies/__tests__/invitations.revoke-resend.spec.ts
@@ -1,0 +1,84 @@
+import * as crypto from 'crypto';
+import { Repository } from 'typeorm';
+import { InvitationsService } from '../invitations.service';
+import { Invitation, InvitationRole } from '../entities/invitation.entity';
+import { CompanyUser } from '../entities/company-user.entity';
+import { User } from '../../users/user.entity';
+import { EmailService } from '../../common/email.service';
+
+describe('InvitationsService revoke and resend', () => {
+  let invitationsRepo: jest.Mocked<Pick<Repository<Invitation>, 'findOne' | 'save'>>;
+  let service: InvitationsService;
+  let emailService: { sendCompanyInvitationEmail: jest.Mock<void, [string, string]> };
+
+  beforeEach(() => {
+    invitationsRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(async (inv) => inv),
+    } as unknown as jest.Mocked<Pick<Repository<Invitation>, 'findOne' | 'save'>>;
+    emailService = { sendCompanyInvitationEmail: jest.fn() };
+    service = new InvitationsService(
+      invitationsRepo as unknown as Repository<Invitation>,
+      {} as unknown as Repository<CompanyUser>,
+      {} as unknown as Repository<User>,
+      emailService as unknown as EmailService,
+    );
+  });
+
+  it('revoked tokens cannot be accepted', async () => {
+    const token = 'abc';
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const invitation = Object.assign(new Invitation(), {
+      id: 1,
+      companyId: 2,
+      email: 'a@b.com',
+      role: InvitationRole.WORKER,
+      tokenHash,
+      expiresAt: new Date(Date.now() + 1000),
+    });
+    invitationsRepo.findOne.mockImplementation(async (opts: any) => {
+      const where = opts.where ?? opts;
+      if (where.id === 1 && where.companyId === 2) return invitation;
+      if (where.tokenHash === invitation.tokenHash) return invitation;
+      return null;
+    });
+
+    await service.revokeInvitation(2, 1);
+
+    await expect(
+      service.acceptExistingUser(token, { userId: 5, email: 'a@b.com' }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('resend rotates token and expiry', async () => {
+    const token = 'old';
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const invitation = Object.assign(new Invitation(), {
+      id: 3,
+      companyId: 4,
+      email: 'resend@ex.com',
+      role: InvitationRole.ADMIN,
+      tokenHash,
+      expiresAt: new Date(Date.now() - 1000),
+      company: { name: 'Co' } as any,
+    });
+    invitationsRepo.findOne.mockImplementation(async (opts: any) => {
+      const where = opts.where ?? opts;
+      if (where.id === 3 && where.companyId === 4) return invitation;
+      if (where.tokenHash === invitation.tokenHash) return invitation;
+      return null;
+    });
+
+    await service.resendInvitation(4, 3);
+    const [[email, newToken]] = emailService.sendCompanyInvitationEmail.mock.calls;
+    expect(email).toBe('resend@ex.com');
+    const newHash = crypto.createHash('sha256').update(newToken).digest('hex');
+    expect(invitation.tokenHash).toBe(newHash);
+    expect(invitation.expiresAt.getTime()).toBeGreaterThan(Date.now());
+
+    await expect(service.previewInvitation(token)).rejects.toMatchObject({ status: 404 });
+    const preview = await service.previewInvitation(newToken);
+    expect(preview.status).toBe('valid');
+  });
+});
+

--- a/backend/src/companies/companies.controller.ts
+++ b/backend/src/companies/companies.controller.ts
@@ -98,4 +98,43 @@ export class CompaniesController {
       expiresAt: invitation.expiresAt,
     };
   }
+
+  @Roles(UserRole.Owner, UserRole.Admin)
+  @Post(':companyId/invitations/:inviteId/revoke')
+  async revokeInvitation(
+    @Param('companyId', ParseIntPipe) companyId: number,
+    @Param('inviteId', ParseIntPipe) inviteId: number,
+    @AuthUser() user: User,
+  ): Promise<{ success: true }> {
+    if (user.companyId !== companyId)
+      throw new NotFoundException('Company not found');
+    await this.invitationsService.revokeInvitation(companyId, inviteId);
+    return { success: true };
+  }
+
+  @Roles(UserRole.Owner, UserRole.Admin)
+  @Post(':companyId/invitations/:inviteId/resend')
+  async resendInvitation(
+    @Param('companyId', ParseIntPipe) companyId: number,
+    @Param('inviteId', ParseIntPipe) inviteId: number,
+    @AuthUser() user: User,
+  ): Promise<{
+    id: number;
+    email: string;
+    role: InvitationRole;
+    expiresAt: Date;
+  }> {
+    if (user.companyId !== companyId)
+      throw new NotFoundException('Company not found');
+    const invitation = await this.invitationsService.resendInvitation(
+      companyId,
+      inviteId,
+    );
+    return {
+      id: invitation.id,
+      email: invitation.email,
+      role: invitation.role,
+      expiresAt: invitation.expiresAt,
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- add endpoints to revoke and resend company invitations
- rotate invitation tokens and expiry when resending
- cover revoke/resend behaviors with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e0ffb6f483259af6f795e762c770