### PR TITLE
feat(companies): manage company members

### DIFF
--- a/backend/src/companies/__tests__/members.service.spec.ts
+++ b/backend/src/companies/__tests__/members.service.spec.ts
@@ -1,0 +1,98 @@
+import { Repository } from 'typeorm';
+import { MembersService } from '../members.service';
+import {
+  CompanyUser,
+  CompanyUserRole,
+  CompanyUserStatus,
+} from '../entities/company-user.entity';
+import { UpdateCompanyMemberDto } from '../dto/update-company-member.dto';
+
+describe('MembersService', () => {
+  let service: MembersService;
+  let repo: jest.Mocked<
+    Pick<
+      Repository<CompanyUser>,
+      'find' | 'findOne' | 'count' | 'save' | 'delete'
+    >
+  >;
+
+  beforeEach(() => {
+    repo = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      count: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<
+      Pick<
+        Repository<CompanyUser>,
+        'find' | 'findOne' | 'count' | 'save' | 'delete'
+      >
+    >;
+    service = new MembersService(repo as unknown as Repository<CompanyUser>);
+  });
+
+  it('updates role and status for a member', async () => {
+    const membership = Object.assign(new CompanyUser(), {
+      companyId: 1,
+      userId: 2,
+      role: CompanyUserRole.WORKER,
+      status: CompanyUserStatus.ACTIVE,
+      user: { id: 2, username: 'u', email: 'u@e.com' },
+    });
+    repo.findOne.mockResolvedValue(membership);
+    repo.save.mockImplementation(async (m) => m as CompanyUser);
+
+    const dto: UpdateCompanyMemberDto = {
+      role: CompanyUserRole.ADMIN,
+      status: CompanyUserStatus.SUSPENDED,
+    };
+    const updated = await service.updateMember(1, 2, dto);
+    expect(updated.role).toBe(CompanyUserRole.ADMIN);
+    expect(updated.status).toBe(CompanyUserStatus.SUSPENDED);
+  });
+
+  it('prevents demoting the last owner', async () => {
+    const membership = Object.assign(new CompanyUser(), {
+      companyId: 1,
+      userId: 1,
+      role: CompanyUserRole.OWNER,
+      status: CompanyUserStatus.ACTIVE,
+      user: { id: 1, username: 'o', email: 'o@e.com' },
+    });
+    repo.findOne.mockResolvedValue(membership);
+    repo.count.mockResolvedValue(1);
+
+    await expect(
+      service.updateMember(1, 1, { role: CompanyUserRole.ADMIN }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('prevents removing the last owner', async () => {
+    const membership = Object.assign(new CompanyUser(), {
+      companyId: 1,
+      userId: 1,
+      role: CompanyUserRole.OWNER,
+      status: CompanyUserStatus.ACTIVE,
+    });
+    repo.findOne.mockResolvedValue(membership);
+    repo.count.mockResolvedValue(1);
+
+    await expect(service.removeMember(1, 1)).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it('removes a member', async () => {
+    const membership = Object.assign(new CompanyUser(), {
+      companyId: 1,
+      userId: 2,
+      role: CompanyUserRole.ADMIN,
+      status: CompanyUserStatus.ACTIVE,
+    });
+    repo.findOne.mockResolvedValue(membership);
+
+    await service.removeMember(1, 2);
+    expect(repo.delete).toHaveBeenCalledWith({ companyId: 1, userId: 2 });
+  });
+});

--- a/backend/src/companies/companies.module.ts
+++ b/backend/src/companies/companies.module.ts
@@ -6,11 +6,13 @@ import { Invitation } from './entities/invitation.entity';
 import { CompaniesService } from './companies.service';
 import { CompaniesController } from './companies.controller';
 import { InvitationsController } from './invitations.controller';
+import { MembersController } from './members.controller';
 import { User } from '../users/user.entity';
 import { UsersModule } from '../users/users.module';
 import { InvitationsService } from './invitations.service';
 import { EmailService } from '../common/email.service';
 import { AuthModule } from '../auth/auth.module';
+import { MembersService } from './members.service';
 
 @Module({
   imports: [
@@ -18,8 +20,13 @@ import { AuthModule } from '../auth/auth.module';
     UsersModule,
     AuthModule,
   ],
-  providers: [CompaniesService, InvitationsService, EmailService],
-  controllers: [CompaniesController, InvitationsController],
-  exports: [CompaniesService, InvitationsService],
+  providers: [
+    CompaniesService,
+    InvitationsService,
+    MembersService,
+    EmailService,
+  ],
+  controllers: [CompaniesController, InvitationsController, MembersController],
+  exports: [CompaniesService, InvitationsService, MembersService],
 })
 export class CompaniesModule {}

--- a/backend/src/companies/dto/company-member-response.dto.ts
+++ b/backend/src/companies/dto/company-member-response.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  CompanyUserRole,
+  CompanyUserStatus,
+} from '../entities/company-user.entity';
+
+export class CompanyMemberResponseDto {
+  @ApiProperty()
+  userId!: number;
+
+  @ApiProperty()
+  username!: string;
+
+  @ApiProperty()
+  email!: string;
+
+  @ApiProperty({ enum: CompanyUserRole })
+  role!: CompanyUserRole;
+
+  @ApiProperty({ enum: CompanyUserStatus })
+  status!: CompanyUserStatus;
+}

--- a/backend/src/companies/dto/update-company-member.dto.ts
+++ b/backend/src/companies/dto/update-company-member.dto.ts
@@ -1,0 +1,18 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import {
+  CompanyUserRole,
+  CompanyUserStatus,
+} from '../entities/company-user.entity';
+
+export class UpdateCompanyMemberDto {
+  @ApiPropertyOptional({ enum: CompanyUserRole })
+  @IsEnum(CompanyUserRole)
+  @IsOptional()
+  role?: CompanyUserRole;
+
+  @ApiPropertyOptional({ enum: CompanyUserStatus })
+  @IsEnum(CompanyUserStatus)
+  @IsOptional()
+  status?: CompanyUserStatus;
+}

--- a/backend/src/companies/members.controller.ts
+++ b/backend/src/companies/members.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  NotFoundException,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Roles } from '../common/decorators/roles.decorator';
+import { User, UserRole } from '../users/user.entity';
+import { AuthUser } from '../common/decorators/auth-user.decorator';
+import { MembersService } from './members.service';
+import { CompanyMemberResponseDto } from './dto/company-member-response.dto';
+import { UpdateCompanyMemberDto } from './dto/update-company-member.dto';
+
+@ApiTags('companies')
+@ApiBearerAuth()
+@Roles(UserRole.Owner, UserRole.Admin)
+@Controller('companies/:companyId/members')
+export class MembersController {
+  constructor(private readonly membersService: MembersService) {}
+
+  @Get()
+  async list(
+    @Param('companyId', ParseIntPipe) companyId: number,
+    @AuthUser() user: User,
+  ): Promise<CompanyMemberResponseDto[]> {
+    if (user.companyId !== companyId)
+      throw new NotFoundException('Company not found');
+    return this.membersService.findMembers(companyId);
+  }
+
+  @Patch(':userId')
+  async update(
+    @Param('companyId', ParseIntPipe) companyId: number,
+    @Param('userId', ParseIntPipe) userId: number,
+    @Body() dto: UpdateCompanyMemberDto,
+    @AuthUser() user: User,
+  ): Promise<CompanyMemberResponseDto> {
+    if (user.companyId !== companyId)
+      throw new NotFoundException('Company not found');
+    return this.membersService.updateMember(companyId, userId, dto);
+  }
+
+  @Delete(':userId')
+  async remove(
+    @Param('companyId', ParseIntPipe) companyId: number,
+    @Param('userId', ParseIntPipe) userId: number,
+    @AuthUser() user: User,
+  ): Promise<void> {
+    if (user.companyId !== companyId)
+      throw new NotFoundException('Company not found');
+    await this.membersService.removeMember(companyId, userId);
+  }
+}

--- a/backend/src/companies/members.service.ts
+++ b/backend/src/companies/members.service.ts
@@ -1,0 +1,93 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  CompanyUser,
+  CompanyUserRole,
+  CompanyUserStatus,
+} from './entities/company-user.entity';
+import { CompanyMemberResponseDto } from './dto/company-member-response.dto';
+import { UpdateCompanyMemberDto } from './dto/update-company-member.dto';
+
+@Injectable()
+export class MembersService {
+  constructor(
+    @InjectRepository(CompanyUser)
+    private readonly companyUsersRepository: Repository<CompanyUser>,
+  ) {}
+
+  async findMembers(companyId: number): Promise<CompanyMemberResponseDto[]> {
+    const members = await this.companyUsersRepository.find({
+      where: { companyId },
+      relations: ['user'],
+    });
+    return members.map((m) => this.toResponseDto(m));
+  }
+
+  async updateMember(
+    companyId: number,
+    userId: number,
+    dto: UpdateCompanyMemberDto,
+  ): Promise<CompanyMemberResponseDto> {
+    const membership = await this.companyUsersRepository.findOne({
+      where: { companyId, userId },
+      relations: ['user'],
+    });
+    if (!membership) throw new NotFoundException('Member not found');
+
+    if (membership.role === CompanyUserRole.OWNER) {
+      const ownerCount = await this.companyUsersRepository.count({
+        where: {
+          companyId,
+          role: CompanyUserRole.OWNER,
+          status: CompanyUserStatus.ACTIVE,
+        },
+      });
+      if (
+        ownerCount === 1 &&
+        ((dto.role && dto.role !== CompanyUserRole.OWNER) ||
+          (dto.status && dto.status !== CompanyUserStatus.ACTIVE))
+      ) {
+        throw new BadRequestException('Cannot demote the last owner');
+      }
+    }
+
+    if (dto.role) membership.role = dto.role;
+    if (dto.status) membership.status = dto.status;
+    const saved = await this.companyUsersRepository.save(membership);
+    return this.toResponseDto(saved);
+  }
+
+  async removeMember(companyId: number, userId: number): Promise<void> {
+    const membership = await this.companyUsersRepository.findOne({
+      where: { companyId, userId },
+    });
+    if (!membership) throw new NotFoundException('Member not found');
+    if (membership.role === CompanyUserRole.OWNER) {
+      const ownerCount = await this.companyUsersRepository.count({
+        where: {
+          companyId,
+          role: CompanyUserRole.OWNER,
+          status: CompanyUserStatus.ACTIVE,
+        },
+      });
+      if (ownerCount === 1)
+        throw new BadRequestException('Cannot remove the last owner');
+    }
+    await this.companyUsersRepository.delete({ companyId, userId });
+  }
+
+  private toResponseDto(m: CompanyUser): CompanyMemberResponseDto {
+    return {
+      userId: m.userId,
+      username: m.user?.username ?? '',
+      email: m.user?.email ?? '',
+      role: m.role,
+      status: m.status,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add endpoints to list, update and remove company members
- prevent demoting or deleting the last owner
- cover role changes and last-owner protection with unit tests

## Testing
- `npm test`
- `npm run lint` *(fails: Async arrow function has no 'await' expression, Unsafe member access)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e10150c8832591790b16815498d9