### PR TITLE
feat: add owner signup page

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -14,6 +14,11 @@ export const routes: Routes = [
       import('./auth/register/register.component').then((m) => m.RegisterComponent),
   },
   {
+    path: 'signup/company',
+    loadComponent: () =>
+      import('./auth/signup-owner/signup-owner.component').then((m) => m.SignupOwnerComponent),
+  },
+  {
     path: 'verify',
     loadComponent: () => import('./auth/verify/verify.component').then((m) => m.VerifyComponent),
   },

--- a/frontend/src/app/auth/signup-owner/signup-owner.component.ts
+++ b/frontend/src/app/auth/signup-owner/signup-owner.component.ts
@@ -1,0 +1,54 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { finalize } from 'rxjs';
+import { AuthService } from '../auth.service';
+import { ErrorService } from '../../error.service';
+
+@Component({
+  selector: 'app-signup-owner',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="submit()">
+      <input type="text" formControlName="name" placeholder="Name" />
+      <input type="email" formControlName="email" placeholder="Email" />
+      <input type="password" formControlName="password" placeholder="Password" />
+      <input type="text" formControlName="companyName" placeholder="Company Name" />
+      <button type="submit" [disabled]="loading">Sign Up</button>
+    </form>
+  `,
+})
+export class SignupOwnerComponent {
+  private auth = inject(AuthService);
+  private router = inject(Router);
+  private fb = inject(FormBuilder);
+  private errorService = inject(ErrorService);
+
+  form = this.fb.nonNullable.group({
+    name: ['', Validators.required.bind(Validators)],
+    email: ['', [Validators.required.bind(Validators), Validators.email.bind(Validators)]],
+    password: ['', Validators.required.bind(Validators)],
+    companyName: ['', Validators.required.bind(Validators)],
+  });
+
+  loading = false;
+
+  submit(): void {
+    if (this.form.valid && !this.loading) {
+      this.loading = true;
+      this.auth
+        .signupOwner(this.form.getRawValue())
+        .pipe(finalize(() => (this.loading = false)))
+        .subscribe({
+          next: () => void this.router.navigate(['/dashboard']),
+          error: (err: unknown) => {
+            const status = (err as { status?: number }).status;
+            const message = status === 409 ? 'Email already exists' : (err as Error).message;
+            this.errorService.show(message);
+          },
+        });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `/signup/company` route and standalone owner signup component
- post to `/auth/signup-owner`, storing JWT and redirecting to dashboard
- derive company context from JWT in AuthService and support owner signup flow

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e16f5d8c83258ea9d8b3d80676b6