### PR TITLE
feat: add invitation acceptance flow

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -23,6 +23,11 @@ export const routes: Routes = [
     loadComponent: () => import('./auth/verify/verify.component').then((m) => m.VerifyComponent),
   },
   {
+    path: 'invite/accept',
+    loadComponent: () =>
+      import('./invitations/accept-invitation.component').then((m) => m.AcceptInvitationComponent),
+  },
+  {
     path: 'customers',
     canActivate: [AuthGuard],
     loadChildren: () => import('./customers/customers.routes').then((m) => m.customersRoutes),

--- a/frontend/src/app/invitations/accept-invitation.component.ts
+++ b/frontend/src/app/invitations/accept-invitation.component.ts
@@ -1,0 +1,130 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { finalize, switchMap } from 'rxjs';
+import { InvitationsService, InvitationPreview } from './invitations.service';
+import { AuthService } from '../auth/auth.service';
+import { ErrorService } from '../error.service';
+
+@Component({
+  selector: 'app-accept-invitation',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <ng-container *ngIf="loading">Loading...</ng-container>
+    <ng-container *ngIf="!loading && preview">
+      <div *ngIf="preview.status !== 'valid'">
+        <p>Invitation {{ preview.status }}</p>
+      </div>
+      <div *ngIf="preview.status === 'valid'">
+        <p>
+          You have been invited to {{ preview.companyName }} as {{ preview.role }} using
+          {{ preview.email }}
+        </p>
+        <div *ngIf="mode === 'login'">
+          <form [formGroup]="loginForm" (ngSubmit)="login()">
+            <input type="text" formControlName="company" placeholder="Company" />
+            <input type="email" formControlName="email" placeholder="Email" />
+            <input type="password" formControlName="password" placeholder="Password" />
+            <button type="submit" [disabled]="loginLoading">Login</button>
+          </form>
+          <button type="button" (click)="mode = 'create'">Create account</button>
+        </div>
+        <div *ngIf="mode === 'create'">
+          <form [formGroup]="createForm" (ngSubmit)="create()">
+            <input type="text" formControlName="name" placeholder="Name" />
+            <input type="password" formControlName="password" placeholder="Password" />
+            <button type="submit" [disabled]="createLoading">Create Account</button>
+          </form>
+          <button type="button" (click)="mode = 'login'">I have an account</button>
+        </div>
+      </div>
+    </ng-container>
+  `,
+})
+export class AcceptInvitationComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private invitations = inject(InvitationsService);
+  private auth = inject(AuthService);
+  private router = inject(Router);
+  private fb = inject(FormBuilder);
+  private errorService = inject(ErrorService);
+
+  preview?: InvitationPreview;
+  loading = true;
+  token = '';
+  mode: 'login' | 'create' = 'login';
+
+  loginForm = this.fb.nonNullable.group({
+    company: ['', Validators.required.bind(Validators)],
+    email: ['', [Validators.required.bind(Validators), Validators.email.bind(Validators)]],
+    password: ['', Validators.required.bind(Validators)],
+  });
+
+  createForm = this.fb.nonNullable.group({
+    name: ['', Validators.required.bind(Validators)],
+    password: ['', Validators.required.bind(Validators)],
+  });
+
+  loginLoading = false;
+  createLoading = false;
+
+  ngOnInit(): void {
+    this.token = this.route.snapshot.queryParamMap.get('token') ?? '';
+    if (this.token) {
+      this.invitations
+        .preview(this.token)
+        .pipe(finalize(() => (this.loading = false)))
+        .subscribe({
+          next: (res) => {
+            this.preview = res;
+            if (res.status === 'valid') {
+              this.loginForm.patchValue({ email: res.email });
+            }
+          },
+          error: (err: unknown) => {
+            this.errorService.show((err as Error).message);
+          },
+        });
+    } else {
+      this.loading = false;
+      this.errorService.show('Invalid invitation token');
+    }
+  }
+
+  login(): void {
+    if (this.loginForm.valid && !this.loginLoading) {
+      this.loginLoading = true;
+      this.auth
+        .login(this.loginForm.getRawValue())
+        .pipe(
+          switchMap(() => this.invitations.accept(this.token)),
+          finalize(() => (this.loginLoading = false)),
+        )
+        .subscribe({
+          next: (res) => {
+            this.auth.handleAuth(res);
+            void this.router.navigate(['/dashboard']);
+          },
+          error: (err: unknown) => this.errorService.show((err as Error).message),
+        });
+    }
+  }
+
+  create(): void {
+    if (this.createForm.valid && !this.createLoading) {
+      this.createLoading = true;
+      this.invitations
+        .accept(this.token, this.createForm.getRawValue())
+        .pipe(finalize(() => (this.createLoading = false)))
+        .subscribe({
+          next: (res) => {
+            this.auth.handleAuth(res);
+            void this.router.navigate(['/dashboard']);
+          },
+          error: (err: unknown) => this.errorService.show((err as Error).message),
+        });
+    }
+  }
+}

--- a/frontend/src/app/invitations/invitations.service.ts
+++ b/frontend/src/app/invitations/invitations.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface InvitationPreview {
+  companyName: string;
+  email: string;
+  role: string;
+  status: 'valid' | 'expired' | 'revoked' | 'accepted';
+}
+
+@Injectable({ providedIn: 'root' })
+export class InvitationsService {
+  private http = inject(HttpClient);
+
+  preview(token: string): Observable<InvitationPreview> {
+    return this.http.get<InvitationPreview>(`${environment.apiUrl}/invitations/${token}`);
+  }
+
+  accept(
+    token: string,
+    data?: { name: string; password: string },
+  ): Observable<{ access_token: string; companies?: string[] }> {
+    return this.http.post<{ access_token: string; companies?: string[] }>(
+      `${environment.apiUrl}/invitations/${token}/accept`,
+      data ?? {},
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `/invite/accept` page for invitation preview and acceptance
- allow existing or new users to accept company invites
- centralize auth token handling

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1e62bb3ec832590f523c7acb564bc