### PR TITLE
feat(frontend): add team management page

### DIFF
--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -75,6 +75,21 @@ export interface Company {
 export type CreateCompany = Partial<Omit<Company, 'id'>>;
 export type UpdateCompany = Partial<CreateCompany>;
 
+export interface CompanyMember {
+  userId: number;
+  username: string;
+  email: string;
+  role: string;
+  status: string;
+}
+
+export interface CompanyInvitation {
+  id: number;
+  email: string;
+  role: string;
+  expiresAt: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class ApiService {
   private http = inject(HttpClient);
@@ -275,6 +290,70 @@ export class ApiService {
     return this.request<Company>('PATCH', `${environment.apiUrl}/companies/${id}`, {
       body: payload,
     });
+  }
+
+  // Company Members
+  getCompanyMembers(companyId: number): Observable<CompanyMember[]> {
+    return this.request<CompanyMember[]>(
+      'GET',
+      `${environment.apiUrl}/companies/${companyId}/members`,
+    );
+  }
+
+  updateCompanyMember(
+    companyId: number,
+    userId: number,
+    payload: Partial<Pick<CompanyMember, 'role' | 'status'>>,
+  ): Observable<CompanyMember> {
+    return this.request<CompanyMember>(
+      'PATCH',
+      `${environment.apiUrl}/companies/${companyId}/members/${userId}`,
+      {
+        body: payload,
+      },
+    );
+  }
+
+  removeCompanyMember(companyId: number, userId: number): Observable<void> {
+    return this.request<void>(
+      'DELETE',
+      `${environment.apiUrl}/companies/${companyId}/members/${userId}`,
+    );
+  }
+
+  // Company Invitations
+  getCompanyInvitations(companyId: number): Observable<CompanyInvitation[]> {
+    return this.request<CompanyInvitation[]>(
+      'GET',
+      `${environment.apiUrl}/companies/${companyId}/invitations`,
+    );
+  }
+
+  createCompanyInvitation(
+    companyId: number,
+    payload: { email: string; role: string },
+  ): Observable<CompanyInvitation> {
+    return this.request<CompanyInvitation>(
+      'POST',
+      `${environment.apiUrl}/companies/${companyId}/invitations`,
+      {
+        body: payload,
+      },
+    );
+  }
+
+  revokeCompanyInvitation(companyId: number, inviteId: number): Observable<void> {
+    return this.request<void>(
+      'POST',
+      `${environment.apiUrl}/companies/${companyId}/invitations/${inviteId}/revoke`,
+    );
+  }
+
+  resendCompanyInvitation(companyId: number, inviteId: number): Observable<CompanyInvitation> {
+    return this.request<CompanyInvitation>(
+      'POST',
+      `${environment.apiUrl}/companies/${companyId}/invitations/${inviteId}/resend`,
+    );
   }
 
   getUpcomingJobs(): Observable<{ items: unknown[]; total: number }> {

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { AuthGuard } from './auth/auth.guard';
 import { AdminGuard } from './auth/admin.guard';
 import { RootRedirectGuard } from './auth/root-redirect.guard';
+import { roleGuard } from './auth/role.guard';
 
 export const routes: Routes = [
   {
@@ -51,6 +52,12 @@ export const routes: Routes = [
     path: 'company',
     canActivate: [AuthGuard],
     loadChildren: () => import('./companies/companies.routes').then((m) => m.companiesRoutes),
+  },
+  {
+    path: 'team',
+    canActivate: [AuthGuard, roleGuard],
+    data: { roles: ['owner', 'admin'] },
+    loadChildren: () => import('./team/team.routes').then((m) => m.teamRoutes),
   },
   {
     path: 'admin',

--- a/frontend/src/app/layout/layout.component.html
+++ b/frontend/src/app/layout/layout.component.html
@@ -13,7 +13,11 @@
     <a routerLink="/equipment" routerLinkActive="active">Equipment</a>
     <a routerLink="/jobs" routerLinkActive="active">Jobs</a>
     <a routerLink="/company/profile" routerLinkActive="active">Company</a>
-    <a routerLink="/company/workers" routerLinkActive="active">Workers</a>
+    <a
+      *ngIf="auth.hasRole('owner') || auth.hasRole('admin')"
+      routerLink="/team"
+      routerLinkActive="active"
+      >Team</a>
   </nav>
   <main class="content">
     <router-outlet></router-outlet>

--- a/frontend/src/app/team/team.component.ts
+++ b/frontend/src/app/team/team.component.ts
@@ -1,0 +1,134 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TeamService } from './team.service';
+import { CompanyMember, CompanyInvitation } from '../api.service';
+
+@Component({
+  selector: 'app-team',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <h2>Members</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Role</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let m of members">
+          <td>{{ m.username }}</td>
+          <td>{{ m.email }}</td>
+          <td>
+            <select [(ngModel)]="m.role" (change)="updateMember(m)">
+              <option value="OWNER">Owner</option>
+              <option value="ADMIN">Admin</option>
+              <option value="WORKER">Worker</option>
+            </select>
+          </td>
+          <td>
+            <select [(ngModel)]="m.status" (change)="updateMember(m)">
+              <option value="ACTIVE">Active</option>
+              <option value="SUSPENDED">Suspended</option>
+            </select>
+          </td>
+          <td>
+            <button (click)="removeMember(m)">Remove</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Invite Member</h3>
+    <form (ngSubmit)="sendInvite()" #inviteForm="ngForm">
+      <input type="email" name="email" [(ngModel)]="invite.email" required placeholder="Email" />
+      <select name="role" [(ngModel)]="invite.role">
+        <option value="WORKER">Worker</option>
+        <option value="ADMIN">Admin</option>
+      </select>
+      <button type="submit" [disabled]="inviteForm.invalid">Invite</button>
+    </form>
+
+    <h2>Pending Invitations</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Email</th>
+          <th>Role</th>
+          <th>Expires</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let i of invitations">
+          <td>{{ i.email }}</td>
+          <td>{{ i.role }}</td>
+          <td>{{ i.expiresAt | date: 'short' }}</td>
+          <td>
+            <button (click)="resend(i)">Resend</button>
+            <button (click)="revoke(i)">Revoke</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  `,
+})
+export class TeamComponent implements OnInit {
+  private service = inject(TeamService);
+
+  members: CompanyMember[] = [];
+  invitations: CompanyInvitation[] = [];
+  invite = { email: '', role: 'WORKER' };
+
+  ngOnInit(): void {
+    this.loadMembers();
+    this.loadInvitations();
+  }
+
+  private loadMembers(): void {
+    this.service.getMembers().subscribe((m) => (this.members = m));
+  }
+
+  private loadInvitations(): void {
+    this.service.getInvitations().subscribe((i) => (this.invitations = i));
+  }
+
+  updateMember(m: CompanyMember): void {
+    this.service
+      .updateMember(m.userId, { role: m.role, status: m.status })
+      .subscribe((updated) => Object.assign(m, updated));
+  }
+
+  removeMember(m: CompanyMember): void {
+    if (!confirm('Remove this member?')) return;
+    this.service.removeMember(m.userId).subscribe(() => {
+      this.members = this.members.filter((x) => x.userId !== m.userId);
+    });
+  }
+
+  sendInvite(): void {
+    this.service.invite(this.invite).subscribe((inv) => {
+      this.invitations.push(inv);
+      this.invite = { email: '', role: 'WORKER' };
+    });
+  }
+
+  resend(inv: CompanyInvitation): void {
+    this.service.resendInvite(inv.id).subscribe((updated) => {
+      const idx = this.invitations.findIndex((x) => x.id === updated.id);
+      if (idx > -1) this.invitations[idx] = updated;
+    });
+  }
+
+  revoke(inv: CompanyInvitation): void {
+    if (!confirm('Revoke this invitation?')) return;
+    this.service.revokeInvite(inv.id).subscribe(() => {
+      this.invitations = this.invitations.filter((x) => x.id !== inv.id);
+    });
+  }
+}

--- a/frontend/src/app/team/team.routes.ts
+++ b/frontend/src/app/team/team.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const teamRoutes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./team.component').then((m) => m.TeamComponent),
+  },
+];

--- a/frontend/src/app/team/team.service.ts
+++ b/frontend/src/app/team/team.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService, CompanyMember, CompanyInvitation } from '../api.service';
+import { AuthService } from '../auth/auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class TeamService {
+  private api = inject(ApiService);
+  private auth = inject(AuthService);
+
+  private getCompanyId(): number {
+    const id = this.auth.getCompany();
+    return id ? Number(id) : 0;
+  }
+
+  getMembers(): Observable<CompanyMember[]> {
+    return this.api.getCompanyMembers(this.getCompanyId());
+  }
+
+  updateMember(
+    userId: number,
+    payload: Partial<Pick<CompanyMember, 'role' | 'status'>>,
+  ): Observable<CompanyMember> {
+    return this.api.updateCompanyMember(this.getCompanyId(), userId, payload);
+  }
+
+  removeMember(userId: number): Observable<void> {
+    return this.api.removeCompanyMember(this.getCompanyId(), userId);
+  }
+
+  getInvitations(): Observable<CompanyInvitation[]> {
+    return this.api.getCompanyInvitations(this.getCompanyId());
+  }
+
+  invite(data: { email: string; role: string }): Observable<CompanyInvitation> {
+    return this.api.createCompanyInvitation(this.getCompanyId(), data);
+  }
+
+  resendInvite(id: number): Observable<CompanyInvitation> {
+    return this.api.resendCompanyInvitation(this.getCompanyId(), id);
+  }
+
+  revokeInvite(id: number): Observable<void> {
+    return this.api.revokeCompanyInvitation(this.getCompanyId(), id);
+  }
+}


### PR DESCRIPTION
## Summary
- add team route with owner/admin guard
- implement team service and component for members and invitations
- extend API service with member and invitation endpoints

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e5f0033483259408b313136abfb0