### PR TITLE
feat(frontend): add company switcher

### DIFF
--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -2,7 +2,7 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
-import { finalize } from 'rxjs';
+import { finalize, switchMap } from 'rxjs';
 import { AuthService } from '../auth.service';
 import { ErrorService } from '../../error.service';
 
@@ -41,7 +41,10 @@ export class LoginComponent {
       this.loading = true;
       this.auth
         .login(this.form.getRawValue())
-        .pipe(finalize(() => (this.loading = false)))
+        .pipe(
+          switchMap(() => this.auth.loadCompanies()),
+          finalize(() => (this.loading = false)),
+        )
         .subscribe({
           next: () => {
             void this.router.navigate(['/dashboard']);

--- a/frontend/src/app/company-switcher/company-switcher.component.ts
+++ b/frontend/src/app/company-switcher/company-switcher.component.ts
@@ -19,7 +19,12 @@ export class CompanySwitcherComponent {
 
   onChange(company: string): void {
     if (company) {
-      this.auth.setCompany(company);
+      this.auth.switchCompany(company).subscribe(() => {
+        this.selected = company;
+        if (typeof window !== 'undefined') {
+          window.location.reload();
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- add login call to fetch companies and switch company endpoint
- update header switcher to re-mint JWT and refresh app

## Testing
- `npm test --prefix frontend` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b1e6d2a0548325a204d52bbc0ae52f