### PR TITLE
feat: add email templates and sender config

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -56,7 +56,12 @@ SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USER=your_email@example.com
 SMTP_PASS=your_email_password
-SMTP_FROM=noreply@example.com
+
+# The address emails will be sent from, e.g. "RF Landscaper Pro <no-reply@rflandscaperpro.com>"
+EMAIL_FROM=noreply@example.com
+
+# Base URL for links in emails
+APP_BASE_URL=https://app.example.com
 
 # File Upload (for future use)
 MAX_FILE_SIZE=10485760

--- a/backend/src/companies/__tests__/invitations.accept-existing-user.spec.ts
+++ b/backend/src/companies/__tests__/invitations.accept-existing-user.spec.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { InvitationsService } from '../invitations.service';
 import { Invitation, InvitationRole } from '../entities/invitation.entity';
 import { CompanyUser, CompanyUserRole } from '../entities/company-user.entity';
+import { Company } from '../entities/company.entity';
 import { User } from '../../users/user.entity';
 import { EmailService } from '../../common/email.service';
 
@@ -14,7 +15,13 @@ describe('InvitationsService acceptExistingUser', () => {
     Pick<Repository<CompanyUser>, 'create' | 'save'>
   >;
   let usersRepo: jest.Mocked<Pick<Repository<User>, 'findOne' | 'save'>>;
-  let emailService: EmailService;
+  let companiesRepo: jest.Mocked<Pick<Repository<Company>, 'findOne'>>;
+  let emailService: {
+    sendAddedToCompanyEmail: jest.Mock<
+      void,
+      [string, string, InvitationRole]
+    >;
+  };
 
   beforeEach(() => {
     invitationsRepo = {
@@ -29,12 +36,23 @@ describe('InvitationsService acceptExistingUser', () => {
       findOne: jest.fn(),
       save: jest.fn(async (u) => u),
     } as unknown as jest.Mocked<Pick<Repository<User>, 'findOne' | 'save'>>;
-    emailService = {} as EmailService;
+    companiesRepo = {
+      findOne: jest.fn(async () => Object.assign(new Company(), { id: 7, name: 'Co' })),
+    } as unknown as jest.Mocked<Pick<Repository<Company>, 'findOne'>>;
+    emailService = {
+      sendAddedToCompanyEmail: jest.fn(),
+    } as {
+      sendAddedToCompanyEmail: jest.Mock<
+        void,
+        [string, string, InvitationRole]
+      >;
+    };
     service = new InvitationsService(
       invitationsRepo as unknown as Repository<Invitation>,
       companyUsersRepo as unknown as Repository<CompanyUser>,
       usersRepo as unknown as Repository<User>,
-      emailService,
+      companiesRepo as unknown as Repository<Company>,
+      emailService as unknown as EmailService,
     );
   });
 
@@ -67,6 +85,11 @@ describe('InvitationsService acceptExistingUser', () => {
       invitedBy: 1,
     });
     expect(invitation.acceptedAt).toBeInstanceOf(Date);
+    expect(emailService.sendAddedToCompanyEmail).toHaveBeenCalledWith(
+      'existing@user.com',
+      'Co',
+      InvitationRole.ADMIN,
+    );
   });
 
   it('rejects when email mismatch', async () => {

--- a/backend/src/companies/__tests__/invitations.preview.spec.ts
+++ b/backend/src/companies/__tests__/invitations.preview.spec.ts
@@ -21,6 +21,7 @@ describe('InvitationsService previewInvitation', () => {
       invitationsRepo as unknown as Repository<Invitation>,
       {} as unknown as Repository<CompanyUser>,
       {} as unknown as Repository<User>,
+      {} as unknown as Repository<Company>,
       {} as unknown as EmailService,
     );
   });


### PR DESCRIPTION
## Summary
- add EMAIL_FROM and APP_BASE_URL env vars
- template company invitation emails and send added-to-company notice
- support configurable nodemailer sender

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e87d54308325aea2087c7f5c2903