### PR TITLE
Backend: Membership listing & company switch

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, Req } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
@@ -10,6 +10,7 @@ import { User } from '../users/user.entity';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { VerifyEmailDto } from './dto/verify-email.dto';
 import { SignupOwnerDto } from './dto/signup-owner.dto';
+import { SwitchCompanyDto } from './dto/switch-company.dto';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -35,6 +36,16 @@ export class AuthController {
       loginDto.company,
     );
     return this.authService.login(user);
+  }
+
+  @Post('switch-company')
+  @ApiOperation({ summary: 'Switch active company for user' })
+  @ApiResponse({ status: 200, description: 'New JWT for selected company' })
+  async switchCompany(
+    @Body() dto: SwitchCompanyDto,
+    @Req() req: { user: { userId: number; username: string; email: string } },
+  ) {
+    return this.authService.switchCompany(req.user, dto.companyId);
   }
 
   @Public()

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,73 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { RefreshToken } from './refresh-token.entity';
+import { VerificationToken } from './verification-token.entity';
+import { User, UserRole } from '../users/user.entity';
+import {
+  CompanyUser,
+  CompanyUserRole,
+  CompanyUserStatus,
+} from '../companies/entities/company-user.entity';
+import { EmailService } from '../common/email.service';
+
+describe('AuthService.switchCompany', () => {
+  let service: AuthService;
+  let repo: jest.Mocked<Pick<Repository<CompanyUser>, 'findOne'>>;
+  let jwt: { signAsync: jest.Mock };
+
+  beforeEach(() => {
+    repo = { findOne: jest.fn() } as any;
+    jwt = { signAsync: jest.fn() };
+    service = new AuthService(
+      {} as unknown as UsersService,
+      jwt as unknown as JwtService,
+      {} as ConfigService,
+      {} as unknown as Repository<RefreshToken>,
+      {} as unknown as Repository<VerificationToken>,
+      {} as unknown as Repository<User>,
+      {} as EmailService,
+      repo as unknown as Repository<CompanyUser>,
+    );
+  });
+
+  it('throws when membership is missing', async () => {
+    repo.findOne.mockResolvedValue(null);
+    await expect(
+      service.switchCompany(
+        { userId: 1, username: 'a', email: 'a@e.com' },
+        2,
+      ),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('returns token for valid membership', async () => {
+    repo.findOne.mockResolvedValue(
+      Object.assign(new CompanyUser(), {
+        userId: 1,
+        companyId: 2,
+        role: CompanyUserRole.ADMIN,
+        status: CompanyUserStatus.ACTIVE,
+      }),
+    );
+    jwt.signAsync.mockResolvedValue('jwt');
+
+    const result = await service.switchCompany(
+      { userId: 1, username: 'a', email: 'a@e.com' },
+      2,
+    );
+
+    expect(jwt.signAsync).toHaveBeenCalledWith({
+      username: 'a',
+      sub: 1,
+      email: 'a@e.com',
+      companyId: 2,
+      roles: [UserRole.Admin],
+      role: UserRole.Admin,
+    });
+    expect(result).toEqual({ access_token: 'jwt' });
+  });
+});

--- a/backend/src/auth/dto/switch-company.dto.ts
+++ b/backend/src/auth/dto/switch-company.dto.ts
@@ -1,0 +1,8 @@
+import { IsInt } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SwitchCompanyDto {
+  @ApiProperty()
+  @IsInt()
+  companyId!: number;
+}

--- a/backend/src/users/dto/company-membership-response.dto.ts
+++ b/backend/src/users/dto/company-membership-response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CompanyUserRole } from '../../companies/entities/company-user.entity';
+
+export class CompanyMembershipResponseDto {
+  @ApiProperty()
+  companyId!: number;
+
+  @ApiProperty()
+  companyName!: string;
+
+  @ApiProperty({ enum: CompanyUserRole })
+  role!: CompanyUserRole;
+}

--- a/backend/src/users/me.controller.spec.ts
+++ b/backend/src/users/me.controller.spec.ts
@@ -1,0 +1,40 @@
+import { MeController } from './me.controller';
+import { Repository } from 'typeorm';
+import {
+  CompanyUser,
+  CompanyUserRole,
+  CompanyUserStatus,
+} from '../companies/entities/company-user.entity';
+import { User } from './user.entity';
+
+describe('MeController', () => {
+  let controller: MeController;
+  let repo: jest.Mocked<Pick<Repository<CompanyUser>, 'find'>>;
+
+  beforeEach(() => {
+    repo = { find: jest.fn() } as any;
+    controller = new MeController(repo as unknown as Repository<CompanyUser>);
+  });
+
+  it('returns active memberships', async () => {
+    repo.find.mockResolvedValue([
+      Object.assign(new CompanyUser(), {
+        companyId: 1,
+        role: CompanyUserRole.ADMIN,
+        status: CompanyUserStatus.ACTIVE,
+        company: { name: 'Acme' },
+      }),
+    ]);
+
+    const user = Object.assign(new User(), { id: 1 });
+    const result = await controller.listCompanies(user);
+
+    expect(repo.find).toHaveBeenCalledWith({
+      where: { userId: 1, status: CompanyUserStatus.ACTIVE },
+      relations: ['company'],
+    });
+    expect(result).toEqual([
+      { companyId: 1, companyName: 'Acme', role: CompanyUserRole.ADMIN },
+    ]);
+  });
+});

--- a/backend/src/users/me.controller.ts
+++ b/backend/src/users/me.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  CompanyUser,
+  CompanyUserStatus,
+} from '../companies/entities/company-user.entity';
+import { AuthUser } from '../common/decorators/auth-user.decorator';
+import { User } from './user.entity';
+import { CompanyMembershipResponseDto } from './dto/company-membership-response.dto';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('me')
+@ApiBearerAuth()
+@Controller('me')
+export class MeController {
+  constructor(
+    @InjectRepository(CompanyUser)
+    private readonly companyUsersRepository: Repository<CompanyUser>,
+  ) {}
+
+  @Get('companies')
+  async listCompanies(
+    @AuthUser() user: User,
+  ): Promise<CompanyMembershipResponseDto[]> {
+    const memberships = await this.companyUsersRepository.find({
+      where: { userId: user.id, status: CompanyUserStatus.ACTIVE },
+      relations: ['company'],
+    });
+    return memberships.map((m) => ({
+      companyId: m.companyId,
+      companyName: m.company?.name ?? '',
+      role: m.role,
+    }));
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
+import { CompanyUser } from '../companies/entities/company-user.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { MeController } from './me.controller';
 import { EmailService } from '../common/email.service';
 import { UserCreationService } from './user-creation.service';
 import { CustomerRegistrationService } from './customer-registration.service';
@@ -18,7 +20,7 @@ const userRepositoryProvider = {
 };
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User, CompanyUser])],
   providers: [
     UsersService,
     EmailService,
@@ -27,7 +29,7 @@ const userRepositoryProvider = {
     CompanyOnboardingService,
     userRepositoryProvider,
   ],
-  controllers: [UsersController],
+  controllers: [UsersController, MeController],
   exports: [UsersService, userRepositoryProvider],
 })
 export class UsersModule {}


### PR DESCRIPTION
## Summary
- list a user's active company memberships
- allow switching active company by issuing new JWT
- test company membership validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e87b1b748325a8fbff109cf68ecd