### PR TITLE
refactor: remove company from login payload

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -53,29 +53,6 @@ describe('AuthController', () => {
     expect(authService.validateUser).toHaveBeenCalledWith(
       'user@example.com',
       'pass',
-      undefined,
-    );
-    expect(authService.login).toHaveBeenCalledWith(user);
-    expect(result).toEqual(resultPayload);
-  });
-
-  it('logs in with company', async () => {
-    const dto: LoginDto = {
-      email: 'user@example.com',
-      password: 'pass',
-      company: 'Acme',
-    };
-    const user = { id: 1 } as any;
-    const resultPayload = { access_token: 'token' };
-    authService.validateUser.mockResolvedValue(user);
-    authService.login.mockResolvedValue(resultPayload);
-
-    const result = await controller.login(dto);
-
-    expect(authService.validateUser).toHaveBeenCalledWith(
-      'user@example.com',
-      'pass',
-      'Acme',
     );
     expect(authService.login).toHaveBeenCalledWith(user);
     expect(result).toEqual(resultPayload);

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Req } from '@nestjs/common';
+import { Controller, Post, Body, Req, UsePipes, ValidationPipe } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
@@ -27,13 +27,21 @@ export class AuthController {
 
   @Public()
   @Post('login')
+  @UsePipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+      transformOptions: { enableImplicitConversion: true },
+      errorHttpStatusCode: 400,
+    }),
+  )
   @ApiOperation({ summary: 'Authenticate user and return JWT' })
   @ApiResponse({ status: 200, description: 'JWT token payload' })
   async login(@Body() loginDto: LoginDto) {
     const user: User = await this.authService.validateUser(
       loginDto.email,
       loginDto.password,
-      loginDto.company,
     );
     return this.authService.login(user);
   }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -40,15 +40,8 @@ export class AuthService {
     private readonly companyUsersRepository: Repository<CompanyUser>,
   ) {}
 
-  async validateUser(
-    email: string,
-    pass: string,
-    company?: string,
-  ): Promise<User> {
-    const user = await this.usersRepository.findOne({
-      where: { email },
-      relations: ['company'],
-    });
+  async validateUser(email: string, pass: string): Promise<User> {
+    const user = await this.usersRepository.findOne({ where: { email } });
     if (!user) {
       throw new UnauthorizedException('Invalid credentials');
     }
@@ -62,12 +55,6 @@ export class AuthService {
       throw new UnauthorizedException('Email not verified');
     }
 
-    if (company !== undefined) {
-      if (!user.company || user.company.name !== company) {
-        throw new UnauthorizedException('Invalid company');
-      }
-    }
-
     return user;
   }
 
@@ -76,7 +63,7 @@ export class AuthService {
       username: user.username,
       sub: user.id,
       email: user.email,
-      companyId: user.companyId,
+      companyId: null as number | null,
       roles: [user.role],
       role: user.role,
     };
@@ -249,7 +236,7 @@ export class AuthService {
         email: string;
         roles?: UserRole[];
         role?: UserRole;
-        companyId: number;
+        companyId: number | null;
       }>(token);
       const hashed = this.hashToken(token);
       const tokenEntity = await this.refreshTokenRepository.findOne({

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,5 +1,5 @@
-import { IsEmail, IsOptional, IsString } from 'class-validator';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
   @ApiProperty()
@@ -9,9 +9,4 @@ export class LoginDto {
   @ApiProperty()
   @IsString()
   password: string;
-
-  @ApiPropertyOptional()
-  @IsString()
-  @IsOptional()
-  company?: string;
 }

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -10,7 +10,7 @@ interface JwtPayload {
   email: string;
   roles: UserRole[];
   role?: UserRole;
-  companyId: number;
+  companyId: number | null;
 }
 
 @Injectable()


### PR DESCRIPTION
## Summary
- simplify login DTO to only require email and password
- return 400 on unexpected company field
- issue login JWTs without a company claim

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1eb21ae14832587021bb098dc6020