### PR TITLE
refactor: drop company from login

### DIFF
--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -17,18 +17,16 @@ export class AuthService {
     return this.roles().includes(role);
   }
 
-  login(data: {
-    email: string;
-    password: string;
-    company: string;
-  }): Observable<{ access_token: string }> {
+  login(data: { email: string; password: string }): Observable<{ access_token: string }> {
     return this.http.post<{ access_token: string }>(`${environment.apiUrl}/auth/login`, data).pipe(
       tap((res) => {
         if (this.hasLocalStorage()) {
           localStorage.setItem('token', res.access_token);
           this.roles.set(this.getRolesFromToken());
-          const company = this.getCompanyFromToken(res.access_token) ?? data.company;
-          this.setCompany(company);
+          const company = this.getCompanyFromToken(res.access_token);
+          if (company) {
+            this.setCompany(company);
+          }
         }
       }),
     );

--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -12,7 +12,6 @@ import { ErrorService } from '../../error.service';
   imports: [CommonModule, ReactiveFormsModule, RouterLink],
   template: `
     <form [formGroup]="form" (ngSubmit)="submit()">
-      <input type="text" formControlName="company" placeholder="Company" />
       <input type="email" formControlName="email" placeholder="Email" />
       <input type="password" formControlName="password" placeholder="Password" />
       <button type="submit" [disabled]="loading">Login</button>
@@ -29,7 +28,6 @@ export class LoginComponent {
   private errorService = inject(ErrorService);
 
   form = this.fb.nonNullable.group({
-    company: ['', Validators.required.bind(Validators)],
     email: ['', [Validators.required.bind(Validators), Validators.email.bind(Validators)]],
     password: ['', Validators.required.bind(Validators)],
   });

--- a/frontend/src/app/invitations/accept-invitation.component.ts
+++ b/frontend/src/app/invitations/accept-invitation.component.ts
@@ -24,7 +24,6 @@ import { ErrorService } from '../error.service';
         </p>
         <div *ngIf="mode === 'login'">
           <form [formGroup]="loginForm" (ngSubmit)="login()">
-            <input type="text" formControlName="company" placeholder="Company" />
             <input type="email" formControlName="email" placeholder="Email" />
             <input type="password" formControlName="password" placeholder="Password" />
             <button type="submit" [disabled]="loginLoading">Login</button>
@@ -57,7 +56,6 @@ export class AcceptInvitationComponent implements OnInit {
   mode: 'login' | 'create' = 'login';
 
   loginForm = this.fb.nonNullable.group({
-    company: ['', Validators.required.bind(Validators)],
     email: ['', [Validators.required.bind(Validators), Validators.email.bind(Validators)]],
     password: ['', Validators.required.bind(Validators)],
   });


### PR DESCRIPTION
## Summary
- remove company field from login and invitation flows
- simplify `AuthService.login` to only require email and password
- adjust related components to call new login signature

## Testing
- `npm test` *(fails: No binary for ChromeHeadless)*
- `npm run build` *(fails: missing getPrerenderParams for prerender routes)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1eb375ad0832594707bad8f5a9fbf