### PR TITLE
Remove company selection remnants from login page

### DIFF
--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -2,7 +2,7 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
-import { finalize, switchMap } from 'rxjs';
+import { finalize } from 'rxjs';
 import { AuthService } from '../auth.service';
 import { ErrorService } from '../../error.service';
 
@@ -39,10 +39,7 @@ export class LoginComponent {
       this.loading = true;
       this.auth
         .login(this.form.getRawValue())
-        .pipe(
-          switchMap(() => this.auth.loadCompanies()),
-          finalize(() => (this.loading = false)),
-        )
+        .pipe(finalize(() => (this.loading = false)))
         .subscribe({
           next: () => {
             void this.router.navigate(['/dashboard']);


### PR DESCRIPTION
## Summary
- simplify login flow by removing company loading call

## Testing
- `npm run lint`
- `CHROME_BIN=chromium-browser npm test` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ecc394908325bce004bdfca4ebee