### PR TITLE
feat: avoid company header before selection

### DIFF
--- a/frontend/src/app/api.service.spec.ts
+++ b/frontend/src/app/api.service.spec.ts
@@ -5,6 +5,7 @@ import { ErrorService } from './error.service';
 import { environment } from '../environments/environment';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { authInterceptor } from './auth.interceptor';
+import { HttpClient } from '@angular/common/http';
 
 describe('ApiService auth interceptor', () => {
   let service: ApiService;
@@ -37,5 +38,16 @@ describe('ApiService auth interceptor', () => {
     expect(req.request.headers.get('Authorization')).toBe('Bearer abc');
     expect(req.request.headers.get('X-Company-ID')).toBe('1');
     req.flush({ status: 'ok' });
+  });
+
+  it('should not attach auth token or company header on login', () => {
+    localStorage.setItem('token', 'abc');
+    localStorage.setItem('companyId', '1');
+    const http = TestBed.inject(HttpClient);
+    http.post(`${environment.apiUrl}/auth/login`, { email: 'a', password: 'b' }).subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/auth/login`);
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    expect(req.request.headers.has('X-Company-ID')).toBeFalse();
+    req.flush({ access_token: 'xyz' });
   });
 });

--- a/frontend/src/app/auth.interceptor.ts
+++ b/frontend/src/app/auth.interceptor.ts
@@ -6,13 +6,23 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const auth = inject(AuthService);
   const token = auth.getToken();
   const company = auth.getCompany();
-  if (token || company) {
-    req = req.clone({
-      setHeaders: {
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        ...(company ? { 'X-Company-ID': company } : {}),
-      },
-    });
+
+  const isLogin = req.url.includes('/auth/login');
+  const isSwitchCompany = req.url.includes('/auth/switch-company');
+
+  const headers: Record<string, string> = {};
+
+  if (token && !isLogin) {
+    headers['Authorization'] = `Bearer ${token}`;
   }
+
+  if (company && !isLogin && !isSwitchCompany) {
+    headers['X-Company-ID'] = company;
+  }
+
+  if (Object.keys(headers).length) {
+    req = req.clone({ setHeaders: headers });
+  }
+
   return next(req);
 };

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -22,11 +22,10 @@ export class AuthService {
       tap((res) => {
         if (this.hasLocalStorage()) {
           localStorage.setItem('token', res.access_token);
-          this.roles.set(this.getRolesFromToken());
+          this.roles.set(this.getRolesFromToken(res.access_token));
           const company = this.getCompanyFromToken(res.access_token);
-          if (company) {
-            this.setCompany(company);
-          }
+          this.setCompany(company ?? null);
+          this.setCompanies([]);
         }
       }),
     );
@@ -45,7 +44,7 @@ export class AuthService {
         tap((res) => {
           if (this.hasLocalStorage()) {
             localStorage.setItem('token', res.access_token);
-            this.roles.set(this.getRolesFromToken());
+            this.roles.set(this.getRolesFromToken(res.access_token));
             this.setCompany(companyId);
           }
         }),
@@ -105,14 +104,10 @@ export class AuthService {
     if (this.hasLocalStorage()) {
       localStorage.setItem('token', res.access_token);
       this.roles.set(this.getRolesFromToken(res.access_token));
-      const company = this.getCompanyFromToken(res.access_token) ?? companyHint;
+      const company = this.getCompanyFromToken(res.access_token) ?? companyHint ?? null;
       const companies = res.companies ?? (company ? [company] : []);
-      if (company) {
-        this.setCompany(company);
-      }
-      if (companies.length) {
-        this.setCompanies(companies);
-      }
+      this.setCompany(company);
+      this.setCompanies(companies);
     }
   }
 
@@ -150,9 +145,13 @@ export class AuthService {
     return this.companies();
   }
 
-  setCompany(company: string): void {
+  setCompany(company: string | null): void {
     if (this.hasLocalStorage()) {
-      localStorage.setItem('companyId', company);
+      if (company) {
+        localStorage.setItem('companyId', company);
+      } else {
+        localStorage.removeItem('companyId');
+      }
     }
     this.company.set(company);
   }


### PR DESCRIPTION
## Summary
- prevent auth interceptor from sending X-Company-ID on login or switch-company requests
- reset stored company after login unless token includes one and always sync companies list
- add regression test ensuring login requests omit auth and company headers

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `apt-get update` *(fails: repository not signed / missing gpg)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ee8cdf4483259467f2adfb1de2af