### PR TITLE
feat: add RequestUser interface

### DIFF
--- a/backend/src/auth/interfaces/request-user.interface.ts
+++ b/backend/src/auth/interfaces/request-user.interface.ts
@@ -1,0 +1,8 @@
+import { UserRole } from '../../users/user.entity';
+
+export interface RequestUser {
+  id: number;
+  companyId?: number | null;
+  role: UserRole;
+}
+

--- a/backend/src/common/guards/jwt-auth.guard.spec.ts
+++ b/backend/src/common/guards/jwt-auth.guard.spec.ts
@@ -1,5 +1,6 @@
 import { ExecutionContext, ForbiddenException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { UserRole } from '../../users/user.entity';
 import { JwtAuthGuard } from './jwt-auth.guard';
 
 describe('JwtAuthGuard', () => {
@@ -25,7 +26,12 @@ describe('JwtAuthGuard', () => {
     } as unknown as ExecutionContext;
 
     expect(() =>
-      guard.handleRequest(null, { companyId: 1 }, null, context),
+      guard.handleRequest(
+        null,
+        { id: 1, companyId: 1, role: UserRole.Admin },
+        null,
+        context,
+      ),
     ).toThrow(ForbiddenException);
   });
 });

--- a/backend/src/common/guards/jwt-auth.guard.ts
+++ b/backend/src/common/guards/jwt-auth.guard.ts
@@ -8,6 +8,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { RequestUser } from '../../auth/interfaces/request-user.interface';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
@@ -32,7 +33,12 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     return super.canActivate(context);
   }
 
-  handleRequest(err: unknown, user: any, _info: unknown, context: ExecutionContext) {
+  handleRequest<TUser extends RequestUser = RequestUser>(
+    err: unknown,
+    user: TUser,
+    _info: unknown,
+    context: ExecutionContext,
+  ): TUser {
     if (err || !user) {
       throw err || new UnauthorizedException();
     }

--- a/backend/src/common/guards/optional-jwt-auth.guard.ts
+++ b/backend/src/common/guards/optional-jwt-auth.guard.ts
@@ -1,9 +1,19 @@
-import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { RequestUser } from '../../auth/interfaces/request-user.interface';
 import { JwtAuthGuard } from './jwt-auth.guard';
 
 @Injectable()
 export class OptionalJwtAuthGuard extends JwtAuthGuard {
-  handleRequest(err: unknown, user: any, info: unknown, context: ExecutionContext) {
+  handleRequest<TUser extends RequestUser = RequestUser>(
+    err: unknown,
+    user: TUser,
+    info: unknown,
+    context: ExecutionContext,
+  ): TUser | null {
     try {
       return super.handleRequest(err, user, info, context);
     } catch (e) {


### PR DESCRIPTION
## Summary
- add RequestUser interface for authenticated user data
- type JWT guards with RequestUser
- update guard tests for the new interface

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f0b31cf88325a9330cde5100fc3a