### PR TITLE
Refactor owner signup to use centralized user creation

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,16 +8,14 @@ import { UsersModule } from '../users/users.module';
 import { JwtStrategy } from './jwt.strategy';
 import { RefreshToken } from './refresh-token.entity';
 import { VerificationToken } from './verification-token.entity';
-import { User } from '../users/user.entity';
 import { EmailService } from '../common/email.service';
-import { Company } from '../companies/entities/company.entity';
 import { CompanyUser } from '../companies/entities/company-user.entity';
 
 @Module({
   imports: [
     UsersModule,
     ConfigModule,
-    TypeOrmModule.forFeature([RefreshToken, VerificationToken, User, Company, CompanyUser]),
+    TypeOrmModule.forFeature([RefreshToken, VerificationToken, CompanyUser]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -13,22 +13,27 @@ import {
   CompanyUserStatus,
 } from '../companies/entities/company-user.entity';
 import { EmailService } from '../common/email.service';
+import { UserCreationService } from '../users/user-creation.service';
 
 describe('AuthService.switchCompany', () => {
   let service: AuthService;
   let repo: jest.Mocked<Pick<Repository<CompanyUser>, 'findOne'>>;
   let jwt: { signAsync: jest.Mock };
+  let userCreationService: jest.Mocked<Pick<UserCreationService, 'createUser'>>;
 
   beforeEach(() => {
     repo = { findOne: jest.fn() } as any;
     jwt = { signAsync: jest.fn() };
+    userCreationService = {
+      createUser: jest.fn(),
+    } as jest.Mocked<Pick<UserCreationService, 'createUser'>>;
     service = new AuthService(
       {} as unknown as UsersService,
+      userCreationService as unknown as UserCreationService,
       jwt as unknown as JwtService,
       {} as ConfigService,
       {} as unknown as Repository<RefreshToken>,
       {} as unknown as Repository<VerificationToken>,
-      {} as unknown as Repository<User>,
       {} as EmailService,
       repo as unknown as Repository<CompanyUser>,
     );
@@ -69,5 +74,54 @@ describe('AuthService.switchCompany', () => {
       role: UserRole.Admin,
     });
     expect(result).toEqual({ access_token: 'jwt' });
+  });
+});
+
+describe('AuthService.signupOwner', () => {
+  let service: AuthService;
+  let userCreationService: jest.Mocked<Pick<UserCreationService, 'createUser'>>;
+
+  beforeEach(() => {
+    userCreationService = {
+      createUser: jest.fn(),
+    } as jest.Mocked<Pick<UserCreationService, 'createUser'>>;
+    service = new AuthService(
+      {} as unknown as UsersService,
+      userCreationService as unknown as UserCreationService,
+      { signAsync: jest.fn() } as unknown as JwtService,
+      {} as ConfigService,
+      {} as unknown as Repository<RefreshToken>,
+      {} as unknown as Repository<VerificationToken>,
+      {} as EmailService,
+      { findOne: jest.fn() } as unknown as Repository<CompanyUser>,
+    );
+    jest.spyOn(service, 'login').mockResolvedValue({} as any);
+  });
+
+  it('delegates to UserCreationService.createUser', async () => {
+    const user = Object.assign(new User(), {
+      id: 1,
+      username: 'owner',
+      email: 'owner@example.com',
+      role: UserRole.Owner,
+    });
+    userCreationService.createUser.mockResolvedValue(user);
+
+    await service.signupOwner({
+      name: 'owner',
+      email: 'owner@example.com',
+      password: 'Password123!',
+      companyName: 'ACME',
+    });
+
+    expect(userCreationService.createUser).toHaveBeenCalledWith({
+      username: 'owner',
+      email: 'owner@example.com',
+      password: 'Password123!',
+      role: UserRole.Owner,
+      company: { name: 'ACME' },
+      isVerified: true,
+    });
+    expect(service.login).toHaveBeenCalledWith(user);
   });
 });

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -6,6 +6,7 @@ import {
   Matches,
   IsEmail,
   ValidateNested,
+  IsBoolean,
 } from 'class-validator';
 import { UserRole } from '../user.entity';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -55,4 +56,9 @@ export class CreateUserDto {
   @IsString()
   @IsOptional()
   phone?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  isVerified?: boolean;
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -30,6 +30,6 @@ const userRepositoryProvider = {
     userRepositoryProvider,
   ],
   controllers: [UsersController, MeController],
-  exports: [UsersService, userRepositoryProvider],
+  exports: [UsersService, userRepositoryProvider, UserCreationService],
 })
 export class UsersModule {}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -49,6 +49,10 @@ export class UsersService {
     return this.usersRepository.find({ where });
   }
 
+  async markEmailVerified(userId: number): Promise<void> {
+    await this.usersRepository.update(userId, { isVerified: true });
+  }
+
   async create(createUserDto: CreateUserDto): Promise<User> {
     return this.userCreationService.createUser(createUserDto);
   }


### PR DESCRIPTION
## Summary
- Delegate owner signup to `UserCreationService.createUser` and remove manual transaction logic
- Extend `CreateUserDto` with `isVerified` flag and export `UserCreationService`
- Clean up auth module repository injections and add tests for delegation

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1f0c9f7a0832590482e2c0e0784af