### PR TITLE
refactor auth repositories

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -12,12 +12,30 @@ import { User } from '../users/user.entity';
 import { EmailService } from '../common/email.service';
 import { Company } from '../companies/entities/company.entity';
 import { CompanyUser } from '../companies/entities/company-user.entity';
+import {
+  REFRESH_TOKEN_REPOSITORY,
+  TypeOrmRefreshTokenRepository,
+} from './repositories/refresh-token.repository';
+import {
+  VERIFICATION_TOKEN_REPOSITORY,
+  TypeOrmVerificationTokenRepository,
+} from './repositories/verification-token.repository';
+import {
+  COMPANY_MEMBERSHIP_REPOSITORY,
+  TypeOrmCompanyMembershipRepository,
+} from './repositories/company-membership.repository';
 
 @Module({
   imports: [
     UsersModule,
     ConfigModule,
-    TypeOrmModule.forFeature([RefreshToken, VerificationToken, User, Company, CompanyUser]),
+    TypeOrmModule.forFeature([
+      RefreshToken,
+      VerificationToken,
+      User,
+      Company,
+      CompanyUser,
+    ]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -35,7 +53,23 @@ import { CompanyUser } from '../companies/entities/company-user.entity';
       },
     }),
   ],
-  providers: [AuthService, JwtStrategy, EmailService],
+  providers: [
+    AuthService,
+    JwtStrategy,
+    EmailService,
+    {
+      provide: REFRESH_TOKEN_REPOSITORY,
+      useClass: TypeOrmRefreshTokenRepository,
+    },
+    {
+      provide: VERIFICATION_TOKEN_REPOSITORY,
+      useClass: TypeOrmVerificationTokenRepository,
+    },
+    {
+      provide: COMPANY_MEMBERSHIP_REPOSITORY,
+      useClass: TypeOrmCompanyMembershipRepository,
+    },
+  ],
   controllers: [AuthController],
   exports: [AuthService],
 })

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,22 +1,22 @@
 import { UnauthorizedException } from '@nestjs/common';
-import { Repository } from 'typeorm';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
-import { RefreshToken } from './refresh-token.entity';
-import { VerificationToken } from './verification-token.entity';
-import { User, UserRole } from '../users/user.entity';
+import { UserRole } from '../users/user.entity';
 import {
   CompanyUser,
   CompanyUserRole,
   CompanyUserStatus,
 } from '../companies/entities/company-user.entity';
 import { EmailService } from '../common/email.service';
+import { RefreshTokenRepository } from './repositories/refresh-token.repository';
+import { VerificationTokenRepository } from './repositories/verification-token.repository';
+import { CompanyMembershipRepository } from './repositories/company-membership.repository';
 
 describe('AuthService.switchCompany', () => {
   let service: AuthService;
-  let repo: jest.Mocked<Pick<Repository<CompanyUser>, 'findOne'>>;
+  let repo: jest.Mocked<CompanyMembershipRepository>;
   let jwt: { signAsync: jest.Mock };
 
   beforeEach(() => {
@@ -26,21 +26,18 @@ describe('AuthService.switchCompany', () => {
       {} as unknown as UsersService,
       jwt as unknown as JwtService,
       {} as ConfigService,
-      {} as unknown as Repository<RefreshToken>,
-      {} as unknown as Repository<VerificationToken>,
-      {} as unknown as Repository<User>,
+      {} as RefreshTokenRepository,
+      {} as VerificationTokenRepository,
+      {} as unknown as any, // Repository<User>
       {} as EmailService,
-      repo as unknown as Repository<CompanyUser>,
+      repo as CompanyMembershipRepository,
     );
   });
 
   it('throws when membership is missing', async () => {
     repo.findOne.mockResolvedValue(null);
     await expect(
-      service.switchCompany(
-        { userId: 1, username: 'a', email: 'a@e.com' },
-        2,
-      ),
+      service.switchCompany({ userId: 1, username: 'a', email: 'a@e.com' }, 2),
     ).rejects.toBeInstanceOf(UnauthorizedException);
   });
 

--- a/backend/src/auth/repositories/company-membership.repository.ts
+++ b/backend/src/auth/repositories/company-membership.repository.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, FindOneOptions } from 'typeorm';
+import { CompanyUser } from '../../companies/entities/company-user.entity';
+
+export interface CompanyMembershipRepository {
+  findOne(options: FindOneOptions<CompanyUser>): Promise<CompanyUser | null>;
+}
+
+export const COMPANY_MEMBERSHIP_REPOSITORY = Symbol(
+  'CompanyMembershipRepository',
+);
+
+@Injectable()
+export class TypeOrmCompanyMembershipRepository
+  implements CompanyMembershipRepository
+{
+  constructor(
+    @InjectRepository(CompanyUser)
+    private readonly repository: Repository<CompanyUser>,
+  ) {}
+
+  findOne(options: FindOneOptions<CompanyUser>): Promise<CompanyUser | null> {
+    return this.repository.findOne(options);
+  }
+}

--- a/backend/src/auth/repositories/refresh-token.repository.ts
+++ b/backend/src/auth/repositories/refresh-token.repository.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, FindOneOptions, FindOptionsWhere } from 'typeorm';
+import { RefreshToken } from '../refresh-token.entity';
+
+export interface RefreshTokenRepository {
+  findOne(options: FindOneOptions<RefreshToken>): Promise<RefreshToken | null>;
+  create(data: Partial<RefreshToken>): RefreshToken;
+  save(token: RefreshToken): Promise<RefreshToken>;
+  update(
+    criteria: FindOptionsWhere<RefreshToken>,
+    partialEntity: Partial<RefreshToken>,
+  ): Promise<void>;
+}
+
+export const REFRESH_TOKEN_REPOSITORY = Symbol('RefreshTokenRepository');
+
+@Injectable()
+export class TypeOrmRefreshTokenRepository implements RefreshTokenRepository {
+  constructor(
+    @InjectRepository(RefreshToken)
+    private readonly repository: Repository<RefreshToken>,
+  ) {}
+
+  findOne(options: FindOneOptions<RefreshToken>): Promise<RefreshToken | null> {
+    return this.repository.findOne(options);
+  }
+
+  create(data: Partial<RefreshToken>): RefreshToken {
+    return this.repository.create(data);
+  }
+
+  save(token: RefreshToken): Promise<RefreshToken> {
+    return this.repository.save(token);
+  }
+
+  async update(
+    criteria: FindOptionsWhere<RefreshToken>,
+    partialEntity: Partial<RefreshToken>,
+  ): Promise<void> {
+    await this.repository.update(criteria, partialEntity);
+  }
+}

--- a/backend/src/auth/repositories/verification-token.repository.ts
+++ b/backend/src/auth/repositories/verification-token.repository.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, FindOneOptions, FindOptionsWhere } from 'typeorm';
+import { VerificationToken } from '../verification-token.entity';
+
+export interface VerificationTokenRepository {
+  findOne(
+    options: FindOneOptions<VerificationToken>,
+  ): Promise<VerificationToken | null>;
+  create(data: Partial<VerificationToken>): VerificationToken;
+  save(entity: VerificationToken): Promise<VerificationToken>;
+  delete(criteria: FindOptionsWhere<VerificationToken>): Promise<void>;
+}
+
+export const VERIFICATION_TOKEN_REPOSITORY = Symbol(
+  'VerificationTokenRepository',
+);
+
+@Injectable()
+export class TypeOrmVerificationTokenRepository
+  implements VerificationTokenRepository
+{
+  constructor(
+    @InjectRepository(VerificationToken)
+    private readonly repository: Repository<VerificationToken>,
+  ) {}
+
+  findOne(
+    options: FindOneOptions<VerificationToken>,
+  ): Promise<VerificationToken | null> {
+    return this.repository.findOne(options);
+  }
+
+  create(data: Partial<VerificationToken>): VerificationToken {
+    return this.repository.create(data);
+  }
+
+  save(entity: VerificationToken): Promise<VerificationToken> {
+    return this.repository.save(entity);
+  }
+
+  async delete(criteria: FindOptionsWhere<VerificationToken>): Promise<void> {
+    await this.repository.delete(criteria);
+  }
+}


### PR DESCRIPTION
## Summary
- add repository interfaces for refresh tokens, verification tokens, and company memberships
- use repository interfaces in AuthService
- register repository implementations in AuthModule

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access .companyId on an `any` value ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f0d4cd588325a8f0ed7b3fd3cd56