### PR TITLE
feat(models): add dashboard models for dashboard stats

### DIFF
--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -4,6 +4,7 @@ import { environment } from '../environments/environment';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { ErrorService } from './error.service';
+import { UpcomingJobSummary, EquipmentCount } from './models/dashboard.models';
 
 export interface Paginated<T> {
   items: T[];
@@ -356,14 +357,18 @@ export class ApiService {
     );
   }
 
-  getUpcomingJobs(): Observable<{ items: unknown[]; total: number }> {
-    return this.request<{ items: unknown[]; total: number }>('GET', `${environment.apiUrl}/jobs`, {
-      params: { completed: false, limit: 5 },
-    });
+  getUpcomingJobs(): Observable<{ items: UpcomingJobSummary[]; total: number }> {
+    return this.request<{ items: UpcomingJobSummary[]; total: number }>(
+      'GET',
+      `${environment.apiUrl}/jobs`,
+      {
+        params: { completed: false, limit: 5 },
+      },
+    );
   }
 
-  getEquipmentCount(status: string): Observable<{ items: unknown[]; total: number }> {
-    return this.request<{ items: unknown[]; total: number }>(
+  getEquipmentCount(status: string): Observable<{ items: EquipmentCount[]; total: number }> {
+    return this.request<{ items: EquipmentCount[]; total: number }>(
       'GET',
       `${environment.apiUrl}/equipment`,
       {

--- a/frontend/src/app/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/dashboard.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { ApiService } from '../api.service';
+import { ApiService, Paginated } from '../api.service';
+import { UpcomingJobSummary, EquipmentCount } from '../models/dashboard.models';
 
 @Component({
   selector: 'app-dashboard',
@@ -34,11 +35,15 @@ export class DashboardComponent implements OnInit {
   protected readonly activeUsers = signal(0);
 
   ngOnInit(): void {
-    this.api.getUpcomingJobs().subscribe((data) => this.upcomingJobs.set(data.total));
+    this.api
+      .getUpcomingJobs()
+      .subscribe((data: Paginated<UpcomingJobSummary>) => this.upcomingJobs.set(data.total));
     this.api
       .getEquipmentCount('available')
-      .subscribe((data) => this.equipmentAvailable.set(data.total));
-    this.api.getEquipmentCount('in_use').subscribe((data) => this.equipmentInUse.set(data.total));
+      .subscribe((data: Paginated<EquipmentCount>) => this.equipmentAvailable.set(data.total));
+    this.api
+      .getEquipmentCount('in_use')
+      .subscribe((data: Paginated<EquipmentCount>) => this.equipmentInUse.set(data.total));
     this.api.getUsers().subscribe((data) => this.activeUsers.set(data.length));
   }
 }

--- a/frontend/src/app/models/dashboard.models.ts
+++ b/frontend/src/app/models/dashboard.models.ts
@@ -1,0 +1,12 @@
+export interface UpcomingJobSummary {
+  id: number;
+  title: string;
+  completed: boolean;
+}
+
+export interface EquipmentCount {
+  id: number;
+  name: string;
+  status: string;
+  type: string;
+}


### PR DESCRIPTION
## Summary
- add `UpcomingJobSummary` and `EquipmentCount` interfaces in shared models folder
- update `ApiService` dashboard calls to use new interfaces
- type dashboard component requests with new models

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1f13886fc8325b47665b1ff0267ce