### PR TITLE
refactor(auth): add JwtUserPayload interface

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -11,6 +11,7 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { VerifyEmailDto } from './dto/verify-email.dto';
 import { SignupOwnerDto } from './dto/signup-owner.dto';
 import { SwitchCompanyDto } from './dto/switch-company.dto';
+import { JwtUserPayload } from './interfaces/jwt-user-payload.interface';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -51,7 +52,7 @@ export class AuthController {
   @ApiResponse({ status: 200, description: 'New JWT for selected company' })
   async switchCompany(
     @Body() dto: SwitchCompanyDto,
-    @Req() req: { user: { userId: number; username: string; email: string } },
+    @Req() req: { user: JwtUserPayload },
   ) {
     return this.authService.switchCompany(req.user, dto.companyId);
   }

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -13,6 +13,7 @@ import {
   CompanyUserStatus,
 } from '../companies/entities/company-user.entity';
 import { EmailService } from '../common/email.service';
+import { JwtUserPayload } from './interfaces/jwt-user-payload.interface';
 
 describe('AuthService.switchCompany', () => {
   let service: AuthService;
@@ -36,12 +37,14 @@ describe('AuthService.switchCompany', () => {
 
   it('throws when membership is missing', async () => {
     repo.findOne.mockResolvedValue(null);
-    await expect(
-      service.switchCompany(
-        { userId: 1, username: 'a', email: 'a@e.com' },
-        2,
-      ),
-    ).rejects.toBeInstanceOf(UnauthorizedException);
+    const user: JwtUserPayload = {
+      userId: 1,
+      username: 'a',
+      email: 'a@e.com',
+    };
+    await expect(service.switchCompany(user, 2)).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
   });
 
   it('returns token for valid membership', async () => {
@@ -55,10 +58,12 @@ describe('AuthService.switchCompany', () => {
     );
     jwt.signAsync.mockResolvedValue('jwt');
 
-    const result = await service.switchCompany(
-      { userId: 1, username: 'a', email: 'a@e.com' },
-      2,
-    );
+    const user: JwtUserPayload = {
+      userId: 1,
+      username: 'a',
+      email: 'a@e.com',
+    };
+    const result = await service.switchCompany(user, 2);
 
     expect(jwt.signAsync).toHaveBeenCalledWith({
       username: 'a',

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -22,6 +22,7 @@ import {
   CompanyUserRole,
   CompanyUserStatus,
 } from '../companies/entities/company-user.entity';
+import { JwtUserPayload } from './interfaces/jwt-user-payload.interface';
 
 @Injectable()
 export class AuthService {
@@ -159,7 +160,7 @@ export class AuthService {
   }
 
   async switchCompany(
-    user: { userId: number; username: string; email: string },
+    user: JwtUserPayload,
     companyId: number,
   ): Promise<{ access_token: string }> {
     const membership = await this.companyUsersRepository.findOne({

--- a/backend/src/auth/interfaces/jwt-user-payload.interface.ts
+++ b/backend/src/auth/interfaces/jwt-user-payload.interface.ts
@@ -1,0 +1,10 @@
+import { UserRole } from '../../users/user.entity';
+
+export interface JwtUserPayload {
+  userId: number;
+  username: string;
+  email: string;
+  roles?: UserRole[];
+  role?: UserRole;
+  companyId?: number | null;
+}


### PR DESCRIPTION
## Summary
- add `JwtUserPayload` interface for user info carried in JWT
- update AuthService and controller to use new interface
- adjust related tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f145254083258398a05916b05857