### PR TITLE
Fix email handling and auth signupOwner test

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -3,7 +3,8 @@ import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
-import { UserRole } from '../users/user.entity';
+import { User, UserRole } from '../users/user.entity';
+import { Email } from '../users/value-objects/email.vo';
 import {
   CompanyUser,
   CompanyUserRole,
@@ -99,10 +100,11 @@ describe('AuthService.signupOwner', () => {
       userCreationService as unknown as UserCreationService,
       { signAsync: jest.fn() } as unknown as JwtService,
       {} as ConfigService,
-      {} as unknown as Repository<RefreshToken>,
-      {} as unknown as Repository<VerificationToken>,
+      {} as RefreshTokenRepository,
+      {} as VerificationTokenRepository,
+      {} as unknown as any, // Repository<User>
       {} as EmailService,
-      { findOne: jest.fn() } as unknown as Repository<CompanyUser>,
+      { findOne: jest.fn() } as unknown as CompanyMembershipRepository,
     );
     jest.spyOn(service, 'login').mockResolvedValue({} as any);
   });
@@ -125,7 +127,7 @@ describe('AuthService.signupOwner', () => {
 
     expect(userCreationService.createUser).toHaveBeenCalledWith({
       username: 'owner',
-      email: 'owner@example.com',
+      email: new Email('owner@example.com'),
       password: 'Password123!',
       role: UserRole.Owner,
       company: { name: 'ACME' },

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,5 +1,4 @@
 import {
-  ConflictException,
   Injectable,
   UnauthorizedException,
   Inject,
@@ -118,48 +117,21 @@ export class AuthService {
     });
 
     const token = await this.createVerificationToken(user.id);
-    await this.emailService.send(verificationMail(user.email, token));
+    await this.emailService.send(verificationMail(user.email.value, token));
     return { message: 'Verification email sent' };
   }
 
   async signupOwner(dto: SignupOwnerDto) {
     validatePasswordStrength(dto.password);
 
-    const user = await this.userCreationService.createUser({
-      username: dto.name,
-      email: dto.email,
-      password: dto.password,
-      role: UserRole.Owner,
-      company: { name: dto.companyName },
-      isVerified: true,
-    });
-
-    if (existing) {
-      throw new ConflictException('Email already exists');
-    }
-
-    try {
-      const user = await this.usersRepository.manager.transaction(
-        async (manager) => {
-          const userRepo = manager.getRepository(User);
-          const companyRepo = manager.getRepository(Company);
-          const membershipRepo = manager.getRepository(CompanyUser);
-
-          const newUser = userRepo.create({
-            username: dto.name,
-            email: new Email(dto.email),
-            password: dto.password,
-            role: UserRole.Owner,
-            isVerified: true,
-          });
-          const savedUser = await userRepo.save(newUser);
-
-          const company = companyRepo.create({
-            name: dto.companyName,
-            ownerId: savedUser.id,
-          });
-          const savedCompany = await companyRepo.save(company);
-
+      const user = await this.userCreationService.createUser({
+        username: dto.name,
+        email: new Email(dto.email),
+        password: dto.password,
+        role: UserRole.Owner,
+        company: { name: dto.companyName },
+        isVerified: true,
+      });
 
     return this.login(user);
   }

--- a/backend/src/companies/invitations.service.ts
+++ b/backend/src/companies/invitations.service.ts
@@ -364,7 +364,7 @@ export class InvitationsService {
 
     await this.emailService.send(
       addedToCompanyMail(
-        savedUser.email,
+        savedUser.email.value,
         company?.name ?? 'Your company',
         invitation.role,
       ),


### PR DESCRIPTION
## Summary
- use raw email string when sending invitation acceptance mail
- simplify signupOwner logic and use Email value object correctly
- update AuthService tests for email value objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1fb5c39f483258ca513f9b0865428