### PR TITLE
refactor: use shared job mapper in service

### DIFF
--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -3,7 +3,6 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { Job } from './entities/job.entity';
 import { JobResponseDto } from './dto/job-response.dto';
 import { CreateJobDto } from './dto/create-job.dto';
 import { UpdateJobDto } from './dto/update-job.dto';
@@ -146,37 +145,6 @@ export class JobsService {
       throw new NotFoundException(`Job with ID ${id} not found.`);
     }
     await this.jobRepository.remove(job);
-  }
-
-  private toJobResponseDto(job: Job): JobResponseDto {
-    return {
-      id: job.id,
-      title: job.title,
-      description: job.description,
-      scheduledDate: job.scheduledDate,
-      completed: job.completed,
-      estimatedHours: job.estimatedHours,
-      actualHours: job.actualHours,
-      notes: job.notes,
-      customer: {
-        id: job.customer.id,
-        name: job.customer.name,
-        email: job.customer.email,
-      },
-      assignments: job.assignments?.map((assignment) => ({
-        id: assignment.id,
-        user: { id: assignment.user.id, username: assignment.user.username },
-        equipment: {
-          id: assignment.equipment.id,
-          name: assignment.equipment.name,
-        },
-        startTime: assignment.startTime,
-        endTime: assignment.endTime,
-        notes: assignment.notes,
-      })),
-      createdAt: job.createdAt,
-      updatedAt: job.updatedAt,
-    };
   }
 
   private checkResourceConflicts(


### PR DESCRIPTION
## Summary
- remove private `toJobResponseDto` method from jobs service
- rely on shared mapper `toJobResponseDto`
- drop unused `Job` entity import

## Testing
- `npm test`
- `npm run build` *(fails: Property 'handleRequest' in type 'OptionalJwtAuthGuard' is not assignable to base type 'JwtAuthGuard'; 'user.roles' is possibly 'undefined')*


------
https://chatgpt.com/codex/tasks/task_e_68b1fd6ea61883258892ed6880a133ef