### PR TITLE
refactor: simplify validators

### DIFF
--- a/frontend/src/app/users/user-detail.component.ts
+++ b/frontend/src/app/users/user-detail.component.ts
@@ -99,14 +99,16 @@ export class UserDetailComponent implements OnInit {
   private fb = inject(FormBuilder);
   user?: User;
 
+  /* eslint-disable @typescript-eslint/unbound-method */
   form = this.fb.nonNullable.group({
-    username: ['', Validators.required.bind(Validators)],
-    email: ['', [Validators.required.bind(Validators), Validators.email.bind(Validators)]],
-    firstName: ['', Validators.required.bind(Validators)],
-    lastName: ['', Validators.required.bind(Validators)],
-    phone: ['', [Validators.required.bind(Validators), Validators.pattern(/^\d{10}$/)]],
+    username: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    firstName: ['', Validators.required],
+    lastName: ['', Validators.required],
+    phone: ['', [Validators.required, Validators.pattern(/^\d{10}$/)]],
     role: [''],
   });
+  /* eslint-enable @typescript-eslint/unbound-method */
 
   ngOnInit(): void {
     const id = Number(this.route.snapshot.paramMap.get('id'));

--- a/frontend/src/app/users/user-form.component.ts
+++ b/frontend/src/app/users/user-form.component.ts
@@ -72,10 +72,11 @@ export class UserFormComponent {
   private router = inject(Router);
   private errorService = inject(ErrorService);
 
+  /* eslint-disable @typescript-eslint/unbound-method */
   form = this.fb.nonNullable.group({
-    username: ['', Validators.required.bind(Validators)],
-    email: ['', [Validators.required.bind(Validators), Validators.email.bind(Validators)]],
-    password: ['', Validators.required.bind(Validators)],
+    username: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', Validators.required],
     firstName: [''],
     lastName: [''],
     phone: [''],
@@ -87,6 +88,7 @@ export class UserFormComponent {
       email: [''],
     }),
   });
+  /* eslint-enable @typescript-eslint/unbound-method */
 
   onSubmit(): void {
     if (this.form.valid) {


### PR DESCRIPTION
## Summary
- replace `Validators.*.bind(Validators)` with direct validators in user detail and user form components
- disable `@typescript-eslint/unbound-method` around new validator usage to satisfy lint rules

## Testing
- `npx eslint src/app/users/user-detail.component.ts src/app/users/user-form.component.ts`
- `npm test` *(frontend: fails, TS2304 Cannot find name 'Equipment')*
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68b1fd761bdc8325b1f36c00a39ba98a