### PR TITLE
feat: allow optional auth user

### DIFF
--- a/backend/src/common/decorators/auth-user.decorator.spec.ts
+++ b/backend/src/common/decorators/auth-user.decorator.spec.ts
@@ -8,7 +8,7 @@ describe('AuthUser Decorator', () => {
   it('should return the user from the request', () => {
     class TestController {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      test(@AuthUser() _user: User) {}
+      test(@AuthUser() _user: User | undefined) {}
     }
     const metadata = Reflect.getMetadata(
       ROUTE_ARGS_METADATA,

--- a/backend/src/common/decorators/auth-user.decorator.ts
+++ b/backend/src/common/decorators/auth-user.decorator.ts
@@ -9,11 +9,11 @@ interface RequestUser {
 }
 
 export const AuthUser = createParamDecorator(
-  (_data: unknown, ctx: ExecutionContext): User => {
+  (_data: unknown, ctx: ExecutionContext): User | undefined => {
     const request = ctx.switchToHttp().getRequest<{ user?: RequestUser }>();
     const { user } = request;
     if (!user) {
-      return undefined as unknown as User;
+      return undefined;
     }
     return Object.assign(new User(), {
       id: user.userId,

--- a/backend/src/companies/companies.controller.ts
+++ b/backend/src/companies/companies.controller.ts
@@ -34,8 +34,8 @@ export class CompaniesController {
   ) {}
 
   @Get('profile')
-  async getProfile(@AuthUser() user: User): Promise<CompanyResponseDto> {
-    const company = await this.companiesService.findByUserId(user.id);
+  async getProfile(@AuthUser() user: User | undefined): Promise<CompanyResponseDto> {
+    const company = await this.companiesService.findByUserId(user!.id);
     if (!company) {
       throw new NotFoundException('Company not found');
     }
@@ -44,8 +44,8 @@ export class CompaniesController {
 
   @Roles(UserRole.Owner)
   @Get('workers')
-  async getWorkers(@AuthUser() user: User): Promise<UserResponseDto[]> {
-    const owner = await this.usersService.findById(user.id);
+  async getWorkers(@AuthUser() user: User | undefined): Promise<UserResponseDto[]> {
+    const owner = await this.usersService.findById(user!.id);
     if (!owner?.companyId)
       throw new NotFoundException('Owner company not found');
     const workers = await this.companiesService.findWorkers(owner.companyId);
@@ -56,9 +56,9 @@ export class CompaniesController {
   @Post()
   async create(
     @Body() dto: CreateCompanyDto,
-    @AuthUser() user: User,
+    @AuthUser() user: User | undefined,
   ): Promise<CompanyResponseDto> {
-    return this.companiesService.create(dto, user.id);
+    return this.companiesService.create(dto, user!.id);
   }
 
   @Roles(UserRole.Owner, UserRole.Admin)
@@ -66,9 +66,9 @@ export class CompaniesController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() dto: UpdateCompanyDto,
-    @AuthUser() user: User,
+    @AuthUser() user: User | undefined,
   ): Promise<CompanyResponseDto> {
-    if (user.companyId !== id) throw new NotFoundException('Company not found');
+    if (user!.companyId !== id) throw new NotFoundException('Company not found');
     return this.companiesService.update(id, dto);
   }
 
@@ -77,19 +77,19 @@ export class CompaniesController {
   async invite(
     @Param('companyId', ParseIntPipe) companyId: number,
     @Body() dto: CreateInvitationDto,
-    @AuthUser() user: User,
+    @AuthUser() user: User | undefined,
   ): Promise<{
     id: number;
     email: string;
     role: InvitationRole;
     expiresAt: Date;
   }> {
-    if (user.companyId !== companyId)
+    if (user!.companyId !== companyId)
       throw new NotFoundException('Company not found');
     const invitation = await this.invitationsService.createInvitation(
       companyId,
       dto,
-      user,
+      user!,
     );
     return {
       id: invitation.id,
@@ -104,9 +104,9 @@ export class CompaniesController {
   async revokeInvitation(
     @Param('companyId', ParseIntPipe) companyId: number,
     @Param('inviteId', ParseIntPipe) inviteId: number,
-    @AuthUser() user: User,
+    @AuthUser() user: User | undefined,
   ): Promise<{ success: true }> {
-    if (user.companyId !== companyId)
+    if (user!.companyId !== companyId)
       throw new NotFoundException('Company not found');
     await this.invitationsService.revokeInvitation(companyId, inviteId);
     return { success: true };
@@ -117,14 +117,14 @@ export class CompaniesController {
   async resendInvitation(
     @Param('companyId', ParseIntPipe) companyId: number,
     @Param('inviteId', ParseIntPipe) inviteId: number,
-    @AuthUser() user: User,
+    @AuthUser() user: User | undefined,
   ): Promise<{
     id: number;
     email: string;
     role: InvitationRole;
     expiresAt: Date;
   }> {
-    if (user.companyId !== companyId)
+    if (user!.companyId !== companyId)
       throw new NotFoundException('Company not found');
     const invitation = await this.invitationsService.resendInvitation(
       companyId,

--- a/backend/src/companies/members.controller.ts
+++ b/backend/src/companies/members.controller.ts
@@ -26,9 +26,9 @@ export class MembersController {
   @Get()
   async list(
     @Param('companyId', ParseIntPipe) companyId: number,
-    @AuthUser() user: User,
+    @AuthUser() user: User | undefined,
   ): Promise<CompanyMemberResponseDto[]> {
-    if (user.companyId !== companyId)
+    if (user!.companyId !== companyId)
       throw new NotFoundException('Company not found');
     return this.membersService.findMembers(companyId);
   }
@@ -38,9 +38,9 @@ export class MembersController {
     @Param('companyId', ParseIntPipe) companyId: number,
     @Param('userId', ParseIntPipe) userId: number,
     @Body() dto: UpdateCompanyMemberDto,
-    @AuthUser() user: User,
+    @AuthUser() user: User | undefined,
   ): Promise<CompanyMemberResponseDto> {
-    if (user.companyId !== companyId)
+    if (user!.companyId !== companyId)
       throw new NotFoundException('Company not found');
     return this.membersService.updateMember(companyId, userId, dto);
   }
@@ -49,9 +49,9 @@ export class MembersController {
   async remove(
     @Param('companyId', ParseIntPipe) companyId: number,
     @Param('userId', ParseIntPipe) userId: number,
-    @AuthUser() user: User,
+    @AuthUser() user: User | undefined,
   ): Promise<void> {
-    if (user.companyId !== companyId)
+    if (user!.companyId !== companyId)
       throw new NotFoundException('Company not found');
     await this.membersService.removeMember(companyId, userId);
   }

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -77,8 +77,8 @@ export class CustomersController {
     description: 'Customer profile',
     type: CustomerResponseDto,
   })
-  async getProfile(@AuthUser() user: User): Promise<CustomerResponseDto> {
-    return this.customersService.findByUserId(user.id, user.companyId!);
+  async getProfile(@AuthUser() user: User | undefined): Promise<CustomerResponseDto> {
+    return this.customersService.findByUserId(user!.id, user!.companyId!);
   }
 
   @Get(':id')

--- a/backend/src/users/me.controller.ts
+++ b/backend/src/users/me.controller.ts
@@ -21,10 +21,10 @@ export class MeController {
 
   @Get('companies')
   async listCompanies(
-    @AuthUser() user: User,
+    @AuthUser() user: User | undefined,
   ): Promise<CompanyMembershipResponseDto[]> {
     const memberships = await this.companyUsersRepository.find({
-      where: { userId: user.id, status: CompanyUserStatus.ACTIVE },
+      where: { userId: user!.id, status: CompanyUserStatus.ACTIVE },
       relations: ['company'],
     });
     return memberships.map((m) => ({


### PR DESCRIPTION
## Summary
- allow AuthUser decorator to return `undefined`
- update controllers to accept optional auth user

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1fd937ae08325a6445551f000c2f6