### PR TITLE
feat: add notification service for user feedback

### DIFF
--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -302,5 +302,4 @@ export class ApiService {
       },
     );
   }
-
 }

--- a/frontend/src/app/companies/company-profile.component.ts
+++ b/frontend/src/app/companies/company-profile.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { CompanyService } from './company.service';
 import { Company } from './company.model';
 import { ErrorService } from '../error.service';
+import { NotificationService } from '../notification.service';
 
 @Component({
   selector: 'app-company-profile',
@@ -66,6 +67,7 @@ import { ErrorService } from '../error.service';
 export class CompanyProfileComponent implements OnInit {
   private readonly companyService = inject(CompanyService);
   private readonly errorService = inject(ErrorService);
+  private readonly notifications = inject(NotificationService);
   private fb = inject(FormBuilder);
   company?: Company;
 
@@ -103,9 +105,7 @@ export class CompanyProfileComponent implements OnInit {
       .updateCompany(this.company.id, { ...this.company, ...this.form.getRawValue() })
       .subscribe({
         next: () => {
-          if (typeof window !== 'undefined') {
-            window.alert('Company updated successfully');
-          }
+          this.notifications.show('Company updated successfully');
         },
         error: () => this.errorService.show('Failed to save company'),
       });

--- a/frontend/src/app/customers/customer-form.component.ts
+++ b/frontend/src/app/customers/customer-form.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { CustomerService } from './customer.service';
 import { Customer } from './customer.model';
 import { ErrorService } from '../error.service';
+import { NotificationService } from '../notification.service';
 
 @Component({
   selector: 'app-customer-form',
@@ -35,6 +36,7 @@ export class CustomerFormComponent implements OnInit {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private errorService = inject(ErrorService);
+  private notifications = inject(NotificationService);
 
   customerId?: number;
 
@@ -66,9 +68,7 @@ export class CustomerFormComponent implements OnInit {
 
     action$.subscribe({
       next: () => {
-        if (typeof window !== 'undefined') {
-          window.alert('Customer saved successfully');
-        }
+        this.notifications.show('Customer saved successfully');
         void this.router.navigate(['/customers']);
       },
       error: () => this.errorService.show('Failed to save customer'),

--- a/frontend/src/app/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/dashboard.component.ts
@@ -1,11 +1,8 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { ApiService, Paginated } from '../api.service';
-import { UpcomingJobSummary, EquipmentCount } from '../models/dashboard.models';
 import { JobsApiService } from '../api/jobs-api.service';
 import { EquipmentApiService } from '../api/equipment-api.service';
 import { UsersApiService } from '../api/users-api.service';
-
 
 @Component({
   selector: 'app-dashboard',
@@ -41,7 +38,6 @@ export class DashboardComponent implements OnInit {
   protected readonly activeUsers = signal(0);
 
   ngOnInit(): void {
-
     this.jobsApi.getUpcomingJobs().subscribe((data) => this.upcomingJobs.set(data.total));
     this.equipmentApi
       .getEquipmentCount('available')
@@ -50,6 +46,5 @@ export class DashboardComponent implements OnInit {
       .getEquipmentCount('in_use')
       .subscribe((data) => this.equipmentInUse.set(data.total));
     this.usersApi.getUsers().subscribe((data) => this.activeUsers.set(data.length));
-
   }
 }

--- a/frontend/src/app/equipment/equipment-detail.component.ts
+++ b/frontend/src/app/equipment/equipment-detail.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { EquipmentService, Equipment } from './equipment.service';
 import { ErrorService } from '../error.service';
+import { NotificationService } from '../notification.service';
 
 @Component({
   selector: 'app-equipment-detail',
@@ -47,6 +48,7 @@ export class EquipmentDetailComponent {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private errorService = inject(ErrorService);
+  private notifications = inject(NotificationService);
   private fb = inject(FormBuilder);
 
   equipmentId?: number;
@@ -78,9 +80,7 @@ export class EquipmentDetailComponent {
     if (this.equipmentId) {
       this.equipmentService.updateEquipment(this.equipmentId, payload).subscribe({
         next: () => {
-          if (typeof window !== 'undefined') {
-            window.alert('Equipment updated successfully');
-          }
+          this.notifications.show('Equipment updated successfully');
           void this.router.navigate(['/equipment']);
         },
         error: () => this.errorService.show('Failed to update equipment'),
@@ -88,9 +88,7 @@ export class EquipmentDetailComponent {
     } else {
       this.equipmentService.createEquipment(payload).subscribe({
         next: () => {
-          if (typeof window !== 'undefined') {
-            window.alert('Equipment created successfully');
-          }
+          this.notifications.show('Equipment created successfully');
           void this.router.navigate(['/equipment']);
         },
         error: () => this.errorService.show('Failed to create equipment'),
@@ -102,9 +100,7 @@ export class EquipmentDetailComponent {
     if (this.equipmentId) {
       this.equipmentService.deleteEquipment(this.equipmentId).subscribe({
         next: () => {
-          if (typeof window !== 'undefined') {
-            window.alert('Equipment deleted successfully');
-          }
+          this.notifications.show('Equipment deleted successfully');
           void this.router.navigate(['/equipment']);
         },
         error: () => this.errorService.show('Failed to delete equipment'),

--- a/frontend/src/app/error.service.ts
+++ b/frontend/src/app/error.service.ts
@@ -1,12 +1,14 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { NotificationService } from './notification.service';
+import { LoggerService } from './logger.service';
 
 @Injectable({ providedIn: 'root' })
 export class ErrorService {
+  private readonly notifier = inject(NotificationService);
+  private readonly logger = inject(LoggerService);
+
   show(message: string): void {
-    // Display the error to the user; replace alert with snackbar if available
-    console.error(message);
-    if (typeof window !== 'undefined') {
-      window.alert(message);
-    }
+    this.logger.error(message);
+    this.notifier.show(message);
   }
 }

--- a/frontend/src/app/jobs/job-editor.component.ts
+++ b/frontend/src/app/jobs/job-editor.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, RouterModule, Router } from '@angular/router';
 import { JobsService } from './jobs.service';
 import { Job } from './job.model';
 import { ErrorService } from '../error.service';
+import { NotificationService } from '../notification.service';
 
 @Component({
   selector: 'app-job-editor',
@@ -17,6 +18,7 @@ export class JobEditorComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private errorService = inject(ErrorService);
+  private notifications = inject(NotificationService);
   private fb = inject(FormBuilder);
   job: Job = { title: '', customerId: 1 };
 
@@ -51,9 +53,7 @@ export class JobEditorComponent implements OnInit {
     if (this.job.id) {
       this.jobsService.update(this.job.id, payload).subscribe({
         next: () => {
-          if (typeof window !== 'undefined') {
-            window.alert('Job updated successfully');
-          }
+          this.notifications.show('Job updated successfully');
           void this.router.navigate(['/jobs']);
         },
         error: () => this.errorService.show('Failed to update job'),
@@ -61,9 +61,7 @@ export class JobEditorComponent implements OnInit {
     } else {
       this.jobsService.create(payload).subscribe({
         next: () => {
-          if (typeof window !== 'undefined') {
-            window.alert('Job created successfully');
-          }
+          this.notifications.show('Job created successfully');
           void this.router.navigate(['/jobs']);
         },
         error: () => this.errorService.show('Failed to create job'),
@@ -78,9 +76,7 @@ export class JobEditorComponent implements OnInit {
         next: (job) => {
           this.job = job;
           this.form.patchValue(job);
-          if (typeof window !== 'undefined') {
-            window.alert('Job scheduled successfully');
-          }
+          this.notifications.show('Job scheduled successfully');
         },
         error: () => this.errorService.show('Failed to schedule job'),
       });
@@ -92,9 +88,7 @@ export class JobEditorComponent implements OnInit {
       this.jobsService.assign(this.job.id, { userId, equipmentId }).subscribe({
         next: (job) => {
           this.job = job;
-          if (typeof window !== 'undefined') {
-            window.alert('Job assigned successfully');
-          }
+          this.notifications.show('Job assigned successfully');
         },
         error: () => this.errorService.show('Failed to assign job'),
       });

--- a/frontend/src/app/logger.service.ts
+++ b/frontend/src/app/logger.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class LoggerService {
+  error(message: string): void {
+    if (typeof console !== 'undefined') {
+      console.error(message);
+    }
+  }
+}

--- a/frontend/src/app/notification.service.ts
+++ b/frontend/src/app/notification.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  show(message: string, duration = 3000): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const snack = document.createElement('div');
+    snack.className = 'app-snackbar';
+    snack.textContent = message;
+    document.body.appendChild(snack);
+    requestAnimationFrame(() => snack.classList.add('show'));
+    setTimeout(() => {
+      snack.classList.remove('show');
+      setTimeout(() => document.body.removeChild(snack), 300);
+    }, duration);
+  }
+}

--- a/frontend/src/app/users/user-detail.component.ts
+++ b/frontend/src/app/users/user-detail.component.ts
@@ -6,6 +6,7 @@ import { UserService } from './user.service';
 import { User } from './user.model';
 import { AuthService } from '../auth/auth.service';
 import { ErrorService } from '../error.service';
+import { NotificationService } from '../notification.service';
 
 @Component({
   selector: 'app-user-detail',
@@ -96,6 +97,7 @@ export class UserDetailComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   protected readonly auth = inject(AuthService);
   private readonly errorService = inject(ErrorService);
+  private readonly notifications = inject(NotificationService);
   private fb = inject(FormBuilder);
   user?: User;
 
@@ -130,9 +132,7 @@ export class UserDetailComponent implements OnInit {
     const payload: User = { ...this.user, ...this.form.getRawValue() } as User;
     this.userService.updateUser(payload).subscribe({
       next: () => {
-        if (typeof window !== 'undefined') {
-          window.alert('User updated successfully');
-        }
+        this.notifications.show('User updated successfully');
       },
       error: () => this.errorService.show('Failed to save user'),
     });

--- a/frontend/src/app/users/user-form.component.ts
+++ b/frontend/src/app/users/user-form.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { UserService } from './user.service';
 import { ErrorService } from '../error.service';
+import { NotificationService } from '../notification.service';
 
 @Component({
   selector: 'app-user-form',
@@ -71,6 +72,7 @@ export class UserFormComponent {
   private userService = inject(UserService);
   private router = inject(Router);
   private errorService = inject(ErrorService);
+  private notifications = inject(NotificationService);
 
   form = this.fb.nonNullable.group({
     username: ['', Validators.required.bind(Validators)],
@@ -104,9 +106,7 @@ export class UserFormComponent {
       if (this.isOwner) payload.company = company;
       this.userService.createUser(payload).subscribe({
         next: () => {
-          if (typeof window !== 'undefined') {
-            window.alert('User created successfully');
-          }
+          this.notifications.show('User created successfully');
           void this.router.navigate(['/users']);
         },
         error: () => this.errorService.show('Failed to create user'),

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,1 +1,23 @@
 /* You can add global styles to this file, and also import other style files */
+.app-snackbar {
+  visibility: hidden;
+  min-width: 200px;
+  background-color: #323232;
+  color: #fff;
+  text-align: center;
+  border-radius: 2px;
+  padding: 16px;
+  position: fixed;
+  left: 50%;
+  bottom: 30px;
+  transform: translateX(-50%);
+  z-index: 1000;
+  opacity: 0;
+  transition: visibility 0s linear 0.3s, opacity 0.3s;
+}
+
+.app-snackbar.show {
+  visibility: visible;
+  opacity: 1;
+  transition-delay: 0s;
+}


### PR DESCRIPTION
## Summary
- add NotificationService and LoggerService
- route errors through ErrorService with logging
- replace `window.alert` with snackbar notifications in forms and editors
- remove unused imports in dashboard component

## Testing
- `npm run lint`
- `npm test` *(fails: TS2304 Cannot find name 'Equipment' in src/app/api.service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fdc21c2c8325bed887f89fc8ab79