### PR TITLE
chore: fix backend lint errors

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -5,6 +5,7 @@ import { RegisterDto } from './dto/register.dto';
 import { RequestPasswordResetDto } from './dto/request-password-reset.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { LoginDto } from './dto/login.dto';
+import { SignupOwnerDto } from './dto/signup-owner.dto';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -43,7 +44,7 @@ describe('AuthController', () => {
 
   it('logs in without company', async () => {
     const dto: LoginDto = { email: 'user@example.com', password: 'pass' };
-    const user = { id: 1 } as any;
+    const user: { id: number } = { id: 1 };
     const resultPayload = { access_token: 'token' };
     authService.validateUser.mockResolvedValue(user);
     authService.login.mockResolvedValue(resultPayload);
@@ -59,7 +60,7 @@ describe('AuthController', () => {
   });
 
   it('signs up a new owner', async () => {
-    const dto = {
+    const dto: SignupOwnerDto = {
       name: 'Owner',
       email: 'owner@example.com',
       password: 'Password1!',
@@ -68,7 +69,7 @@ describe('AuthController', () => {
     const response = { access_token: 'jwt' };
     authService.signupOwner.mockResolvedValue(response);
 
-    const result = await controller.signupOwner(dto as any);
+    const result = await controller.signupOwner(dto);
 
     expect(authService.signupOwner).toHaveBeenCalledWith(dto);
     expect(result).toEqual(response);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  UnauthorizedException,
-  Inject,
-} from '@nestjs/common';
+import { Injectable, UnauthorizedException, Inject } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -16,13 +12,9 @@ import { UserCreationService } from '../users/user-creation.service';
 import { RegisterDto } from './dto/register.dto';
 import { SignupOwnerDto } from './dto/signup-owner.dto';
 import { validatePasswordStrength } from './password.util';
-import { RefreshToken } from './refresh-token.entity';
-import { VerificationToken } from './verification-token.entity';
 import { EmailService } from '../common/email';
 import { verificationMail } from '../common/email/templates';
-import { Company } from '../companies/entities/company.entity';
 import {
-  CompanyUser,
   CompanyUserRole,
   CompanyUserStatus,
 } from '../companies/entities/company-user.entity';
@@ -53,7 +45,7 @@ export class AuthService {
     private readonly verificationTokenRepository: VerificationTokenRepository,
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
-     
+
     private readonly emailService: EmailService,
     @Inject(COMPANY_MEMBERSHIP_REPOSITORY)
     private readonly companyMembershipRepository: CompanyMembershipRepository,
@@ -124,14 +116,14 @@ export class AuthService {
   async signupOwner(dto: SignupOwnerDto) {
     validatePasswordStrength(dto.password);
 
-      const user = await this.userCreationService.createUser({
-        username: dto.name,
-        email: new Email(dto.email),
-        password: dto.password,
-        role: UserRole.Owner,
-        company: { name: dto.companyName },
-        isVerified: true,
-      });
+    const user = await this.userCreationService.createUser({
+      username: dto.name,
+      email: new Email(dto.email),
+      password: dto.password,
+      role: UserRole.Owner,
+      company: { name: dto.companyName },
+      isVerified: true,
+    });
 
     return this.login(user);
   }

--- a/backend/src/common/decorators/auth-user.decorator.spec.ts
+++ b/backend/src/common/decorators/auth-user.decorator.spec.ts
@@ -7,8 +7,9 @@ import { User } from '../../users/user.entity';
 describe('AuthUser Decorator', () => {
   it('should return the user from the request', () => {
     class TestController {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      test(@AuthUser() _user: User | undefined) {}
+      test(@AuthUser() user: User | undefined) {
+        return user;
+      }
     }
     const metadata = Reflect.getMetadata(
       ROUTE_ARGS_METADATA,

--- a/backend/src/common/email/templates/added-to-company.mail.ts
+++ b/backend/src/common/email/templates/added-to-company.mail.ts
@@ -2,7 +2,7 @@ import { SendMailOptions } from 'nodemailer';
 import { InvitationRole } from '../../../companies/entities/invitation.entity';
 
 function formatRole(role: InvitationRole): string {
-  return role === 'ADMIN' ? 'Admin' : 'Worker';
+  return role === InvitationRole.ADMIN ? 'Admin' : 'Worker';
 }
 
 export function addedToCompanyMail(

--- a/backend/src/common/email/templates/invitation.mail.ts
+++ b/backend/src/common/email/templates/invitation.mail.ts
@@ -2,7 +2,7 @@ import { SendMailOptions } from 'nodemailer';
 import { InvitationRole } from '../../../companies/entities/invitation.entity';
 
 function formatRole(role: InvitationRole): string {
-  return role === 'ADMIN' ? 'Admin' : 'Worker';
+  return role === InvitationRole.ADMIN ? 'Admin' : 'Worker';
 }
 
 export function invitationMail(
@@ -12,8 +12,7 @@ export function invitationMail(
   role: InvitationRole,
   expiresAt: Date,
 ): SendMailOptions {
-  const baseUrl =
-    process.env.APP_BASE_URL ?? 'https://app.rflandscaperpro.com';
+  const baseUrl = process.env.APP_BASE_URL ?? 'https://app.rflandscaperpro.com';
   const link = `${baseUrl}/invite/accept?token=${token}`;
   const roleName = formatRole(role);
   const expiry = expiresAt.toDateString();

--- a/backend/src/common/email/transports/smtp.transport.ts
+++ b/backend/src/common/email/transports/smtp.transport.ts
@@ -9,7 +9,7 @@ function parsePort(v: string | undefined, fallback: number): number {
 export class SmtpTransport implements EmailTransport {
   driver: MailDriver = 'smtp';
 
-  async create() {
+  create() {
     const port = parsePort(process.env.SMTP_PORT, 587);
     const transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST,
@@ -20,6 +20,6 @@ export class SmtpTransport implements EmailTransport {
         pass: process.env.SMTP_PASS,
       },
     });
-    return { transporter };
+    return Promise.resolve({ transporter });
   }
 }

--- a/backend/src/common/guards/jwt-auth.guard.ts
+++ b/backend/src/common/guards/jwt-auth.guard.ts
@@ -40,7 +40,10 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     context: ExecutionContext,
   ): TUser {
     if (err || !user) {
-      throw err || new UnauthorizedException();
+      if (err instanceof Error) {
+        throw err;
+      }
+      throw new UnauthorizedException();
     }
     const req = context.switchToHttp().getRequest<Request>();
     const header = req.headers['x-company-id'];

--- a/backend/src/companies/__tests__/invitations.accept-new-user.spec.ts
+++ b/backend/src/companies/__tests__/invitations.accept-new-user.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */
 import * as crypto from 'crypto';
 import { Repository } from 'typeorm';
 import { InvitationsService } from '../invitations.service';
@@ -24,21 +23,29 @@ describe('InvitationsService acceptInvitation', () => {
   beforeEach(() => {
     invitationsRepo = {
       findOne: jest.fn(),
-      save: jest.fn(async (inv) => inv),
-    } as unknown as jest.Mocked<Pick<Repository<Invitation>, 'findOne' | 'save'>>;
+      save: jest.fn((inv: Invitation) => Promise.resolve(inv)),
+    } as unknown as jest.Mocked<
+      Pick<Repository<Invitation>, 'findOne' | 'save'>
+    >;
     companyUsersRepo = {
-      create: jest.fn((dto) => Object.assign(new CompanyUser(), dto)),
-      save: jest.fn(async (m) => m),
-    } as unknown as jest.Mocked<Pick<Repository<CompanyUser>, 'create' | 'save'>>;
+      create: jest.fn((dto: Partial<CompanyUser>) =>
+        Object.assign(new CompanyUser(), dto),
+      ),
+      save: jest.fn((m: CompanyUser) => Promise.resolve(m)),
+    } as unknown as jest.Mocked<
+      Pick<Repository<CompanyUser>, 'create' | 'save'>
+    >;
     usersRepo = {
-      create: jest.fn((dto) => Object.assign(new User(), dto)),
-      save: jest.fn(async (u) => {
+      create: jest.fn((dto: Partial<User>) => Object.assign(new User(), dto)),
+      save: jest.fn((u: User) => {
         u.id = 42;
-        return u;
+        return Promise.resolve(u);
       }),
     } as unknown as jest.Mocked<Pick<Repository<User>, 'create' | 'save'>>;
     companiesRepo = {
-      findOne: jest.fn(async () => Object.assign(new Company(), { id: 7, name: 'Co' })),
+      findOne: jest.fn(() =>
+        Promise.resolve(Object.assign(new Company(), { id: 7, name: 'Co' })),
+      ),
     } as unknown as jest.Mocked<Pick<Repository<Company>, 'findOne'>>;
     emailService = {
       send: jest.fn<void, [SendMailOptions]>(),
@@ -82,8 +89,8 @@ describe('InvitationsService acceptInvitation', () => {
     const [[options]] = emailService.send.mock.calls;
     expect(options.to).toBe('new@user.com');
     expect(options.subject).toBe('You were added to a company');
-    expect((options.html as string)).toContain('Co');
-    expect((options.html as string)).toContain('Admin');
+    expect(options.html as string).toContain('Co');
+    expect(options.html as string).toContain('Admin');
   });
 
   it('rejects expired token', async () => {

--- a/backend/src/companies/__tests__/invitations.preview.spec.ts
+++ b/backend/src/companies/__tests__/invitations.preview.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/require-await */
 import * as crypto from 'crypto';
 import { Repository } from 'typeorm';
 import { InvitationsService } from '../invitations.service';

--- a/backend/src/companies/__tests__/invitations.service.spec.ts
+++ b/backend/src/companies/__tests__/invitations.service.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/require-await */
 import * as crypto from 'crypto';
 import { Repository } from 'typeorm';
 import { InvitationsService } from '../invitations.service';
@@ -13,7 +12,6 @@ import { Email } from '../../users/value-objects/email.vo';
 import { EmailService } from '../../common/email';
 import { SendMailOptions } from 'nodemailer';
 
-
 describe('InvitationsService', () => {
   let service: InvitationsService;
   let invitationsRepo: jest.Mocked<
@@ -26,10 +24,12 @@ describe('InvitationsService', () => {
 
   beforeEach(() => {
     invitationsRepo = {
-      create: jest.fn((dto) => Object.assign(new Invitation(), dto)),
-      save: jest.fn(async (inv) => {
+      create: jest.fn((dto: Partial<Invitation>) =>
+        Object.assign(new Invitation(), dto),
+      ),
+      save: jest.fn((inv: Invitation) => {
         inv.id = inv.id ?? 1;
-        return inv;
+        return Promise.resolve(inv);
       }),
       findOne: jest.fn(),
       count: jest.fn(),
@@ -43,7 +43,9 @@ describe('InvitationsService', () => {
       findOne: jest.fn(),
     } as unknown as jest.Mocked<Pick<Repository<User>, 'findOne'>>;
     companiesRepo = {
-      findOne: jest.fn(async () => Object.assign(new Company(), { id: 5, name: 'Co' })),
+      findOne: jest.fn(() =>
+        Promise.resolve(Object.assign(new Company(), { id: 5, name: 'Co' })),
+      ),
     } as unknown as jest.Mocked<Pick<Repository<Company>, 'findOne'>>;
     emailService = {
       send: jest.fn<void, [SendMailOptions]>(),
@@ -76,8 +78,8 @@ describe('InvitationsService', () => {
     expect(options.subject).toBe('Company Invitation');
     expect(invitation.tokenHash).toBe(hashed);
     expect(invitation.expiresAt).toBeInstanceOf(Date);
-    expect((options.html as string)).toContain('Co');
-    expect((options.html as string)).toContain('Worker');
+    expect(options.html as string).toContain('Co');
+    expect(options.html as string).toContain('Worker');
   });
 
   it('rejects inviting existing active member', async () => {

--- a/backend/src/companies/__tests__/members.service.spec.ts
+++ b/backend/src/companies/__tests__/members.service.spec.ts
@@ -42,7 +42,7 @@ describe('MembersService', () => {
       user: { id: 2, username: 'u', email: new Email('u@e.com') },
     });
     repo.findOne.mockResolvedValue(membership);
-    repo.save.mockImplementation(async (m) => m as CompanyUser);
+    repo.save.mockImplementation((m) => Promise.resolve(m as CompanyUser));
 
     const dto: UpdateCompanyMemberDto = {
       role: CompanyUserRole.ADMIN,

--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -42,7 +42,9 @@ describe('CustomersService', () => {
   });
 
   it('throws ConflictException when email already exists in same company', async () => {
-    repo.create.mockReturnValue({} as Customer);
+    const createMock = jest
+      .spyOn(repo, 'create')
+      .mockReturnValue({} as Customer);
     repo.save.mockRejectedValue(
       new QueryFailedError('', [], { code: '23505' } as any),
     );
@@ -66,8 +68,7 @@ describe('CustomersService', () => {
       'message',
       'Email already exists',
     );
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(repo.create).toHaveBeenCalledWith(
+    expect(createMock).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'John Doe',
         email: 'john@example.com',
@@ -109,10 +110,9 @@ describe('CustomersService', () => {
   });
 
   it('should apply search filter when finding all customers', async () => {
-    repo.findAll.mockResolvedValue([[], 0]);
+    const findAllMock = jest.spyOn(repo, 'findAll').mockResolvedValue([[], 0]);
     const pagination: PaginationQueryDto = { page: 1, limit: 10 };
     await service.findAll(pagination, 1, undefined, 'Jane');
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(repo.findAll).toHaveBeenCalledWith(pagination, 1, undefined, 'Jane');
+    expect(findAllMock).toHaveBeenCalledWith(pagination, 1, undefined, 'Jane');
   });
 });

--- a/backend/src/equipment/equipment.controller.spec.ts
+++ b/backend/src/equipment/equipment.controller.spec.ts
@@ -34,16 +34,13 @@ describe('EquipmentController', () => {
     it('should pass companyId to equipmentService.updateStatus', async () => {
       const companyId = 2;
       const dto = { status: EquipmentStatus.AVAILABLE };
-      const response = {} as EquipmentResponseDto;
-      (service.updateStatus as jest.Mock).mockResolvedValue(response);
+        const response = {} as EquipmentResponseDto;
+        const updateStatusMock = jest
+          .spyOn(service, 'updateStatus')
+          .mockResolvedValue(response);
 
       const result = await controller.updateStatus(1, dto, companyId);
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(service.updateStatus).toHaveBeenCalledWith(
-        1,
-        dto.status,
-        companyId,
-      );
+      expect(updateStatusMock).toHaveBeenCalledWith(1, dto.status, companyId);
       expect(result).toBe(response);
     });
   });
@@ -55,19 +52,20 @@ describe('EquipmentController', () => {
       const status = EquipmentStatus.AVAILABLE;
       const type = EquipmentType.MOWER;
       const search = 'mower';
-      const expectedResult = { items: [], total: 0 };
-      (service.findAll as jest.Mock).mockResolvedValue(expectedResult);
+        const expectedResult = { items: [], total: 0 };
+        const findAllMock = jest
+          .spyOn(service, 'findAll')
+          .mockResolvedValue(expectedResult);
 
-      const result = await controller.findAll(
-        pagination,
-        companyId,
-        status,
-        type,
-        search,
-      );
-      expect(result).toEqual(expectedResult);
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(service.findAll).toHaveBeenCalledWith(
+        const result = await controller.findAll(
+          pagination,
+          companyId,
+          status,
+          type,
+          search,
+        );
+        expect(result).toEqual(expectedResult);
+      expect(findAllMock).toHaveBeenCalledWith(
         pagination,
         companyId,
         status,

--- a/backend/src/equipment/equipment.service.spec.ts
+++ b/backend/src/equipment/equipment.service.spec.ts
@@ -55,11 +55,10 @@ describe('EquipmentService', () => {
   });
 
   it('should apply search filter when finding all equipment', async () => {
-    repo.findAll.mockResolvedValue([[], 0]);
+    const findAllMock = jest.spyOn(repo, 'findAll').mockResolvedValue([[], 0]);
     const pagination: PaginationQueryDto = { page: 1, limit: 10 };
     await service.findAll(pagination, 1, undefined, undefined, 'truck');
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(repo.findAll).toHaveBeenCalledWith(
+    expect(findAllMock).toHaveBeenCalledWith(
       pagination,
       1,
       undefined,

--- a/backend/src/jobs/jobs.controller.spec.ts
+++ b/backend/src/jobs/jobs.controller.spec.ts
@@ -1,8 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
-
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 describe('JobsController', () => {
   let controller: JobsController;
@@ -32,7 +31,7 @@ describe('JobsController', () => {
 
   it('should forward filters to service.findAll', async () => {
     jobsService.findAll.mockResolvedValue({ items: [], total: 0 });
-    const pagination = { page: 1, limit: 10 } as any;
+    const pagination: PaginationQueryDto = { page: 1, limit: 10 };
     const result = await controller.findAll(
       pagination,
       1,
@@ -58,7 +57,7 @@ describe('JobsController', () => {
 
   describe('findAll', () => {
     it('should call jobsService.findAll with companyId', async () => {
-      const pagination = { page: 1, limit: 10 } as any;
+      const pagination: PaginationQueryDto = { page: 1, limit: 10 };
       const completed = true;
       const customerId = 2;
       const companyId = 1;

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -20,7 +20,7 @@ export class CreateUserDto {
   username: string;
 
   @ApiProperty()
-  @Transform(({ value }) => new Email(value))
+  @Transform(({ value }: { value: string }) => new Email(value))
   email: Email;
 
   @ApiProperty()
@@ -55,7 +55,9 @@ export class CreateUserDto {
 
   @ApiPropertyOptional()
   @IsOptional()
-  @Transform(({ value }) => (value ? new PhoneNumber(value) : undefined))
+  @Transform(({ value }: { value: string | undefined }) =>
+    value ? new PhoneNumber(value) : undefined,
+  )
   phone?: PhoneNumber;
 
   @ApiPropertyOptional()

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -17,7 +17,9 @@ export class UpdateUserDto {
 
   @ApiPropertyOptional()
   @IsOptional()
-  @Transform(({ value }) => (value ? new Email(value) : undefined))
+  @Transform(({ value }: { value: string | undefined }) =>
+    value ? new Email(value) : undefined,
+  )
   email?: Email;
 
   @ApiPropertyOptional()
@@ -32,6 +34,8 @@ export class UpdateUserDto {
 
   @ApiPropertyOptional()
   @IsOptional()
-  @Transform(({ value }) => (value ? new PhoneNumber(value) : undefined))
+  @Transform(({ value }: { value: string | undefined }) =>
+    value ? new PhoneNumber(value) : undefined,
+  )
   phone?: PhoneNumber;
 }

--- a/backend/src/users/me.controller.spec.ts
+++ b/backend/src/users/me.controller.spec.ts
@@ -12,7 +12,9 @@ describe('MeController', () => {
   let repo: jest.Mocked<Pick<Repository<CompanyUser>, 'find'>>;
 
   beforeEach(() => {
-    repo = { find: jest.fn() } as any;
+    repo = { find: jest.fn() } as unknown as jest.Mocked<
+      Pick<Repository<CompanyUser>, 'find'>
+    >;
     controller = new MeController(repo as unknown as Repository<CompanyUser>);
   });
 

--- a/backend/test/auth-signup-owner.e2e-spec.ts
+++ b/backend/test/auth-signup-owner.e2e-spec.ts
@@ -1,5 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ConflictException, ValidationPipe } from '@nestjs/common';
+import {
+  INestApplication,
+  ConflictException,
+  ValidationPipe,
+} from '@nestjs/common';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { AuthController } from '../src/auth/auth.controller';
@@ -46,7 +50,8 @@ describe('Auth signup-owner endpoint (e2e)', () => {
       })
       .expect(201)
       .expect((res: request.Response) => {
-        expect(res.body.access_token).toBe('jwt');
+        const body = res.body as { access_token: string };
+        expect(body.access_token).toBe('jwt');
         expect(signupOwner).toHaveBeenCalled();
       });
   });


### PR DESCRIPTION
## Summary
- type test fixtures to eliminate `any` usage and remove stale eslint-disable blocks
- normalize email templates and SMTP transport to satisfy lint checks
- improve JWT guard error handling

## Testing
- `npm run lint --if-present`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b202aeb7d08325bd4eaed90371c4fd