### PR TITLE
Fix optional auth guard null handling and role checks

### DIFF
--- a/backend/src/common/guards/optional-jwt-auth.guard.ts
+++ b/backend/src/common/guards/optional-jwt-auth.guard.ts
@@ -13,12 +13,12 @@ export class OptionalJwtAuthGuard extends JwtAuthGuard {
     user: TUser,
     info: unknown,
     context: ExecutionContext,
-  ): TUser | null {
+  ): TUser {
     try {
       return super.handleRequest(err, user, info, context);
     } catch (e) {
       if (e instanceof UnauthorizedException) {
-        return null;
+        return null as unknown as TUser;
       }
       throw e;
     }

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -18,8 +18,6 @@ export class RolesGuard implements CanActivate {
     const { user } = context
       .switchToHttp()
       .getRequest<{ user?: { roles?: UserRole[] } }>();
-    return user?.roles
-      ? requiredRoles.some((role) => user.roles.includes(role))
-      : false;
+    return requiredRoles.some((role) => user?.roles?.includes(role) ?? false);
   }
 }


### PR DESCRIPTION
## Summary
- ensure optional JWT auth guard returns null without type errors
- handle possible undefined roles in RolesGuard

## Testing
- `npm run build`
- `npm test`
- `npx eslint src/common/guards/optional-jwt-auth.guard.ts src/common/guards/roles.guard.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b2066016748325a8a015a7b259a2e2