### PR TITLE
Handle dynamic routes in server rendering

### DIFF
--- a/frontend/src/app/app.routes.server.ts
+++ b/frontend/src/app/app.routes.server.ts
@@ -2,6 +2,30 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
   {
+    path: 'customers/:id/edit',
+    renderMode: RenderMode.Server,
+  },
+  {
+    path: 'customers/:id',
+    renderMode: RenderMode.Server,
+  },
+  {
+    path: 'equipment/:id',
+    renderMode: RenderMode.Server,
+  },
+  {
+    path: 'jobs/:id',
+    renderMode: RenderMode.Server,
+  },
+  {
+    path: 'contracts/:id',
+    renderMode: RenderMode.Server,
+  },
+  {
+    path: 'users/:id',
+    renderMode: RenderMode.Server,
+  },
+  {
     path: '**',
     renderMode: RenderMode.Prerender,
   },


### PR DESCRIPTION
## Summary
- avoid prerendering dynamic routes by rendering them on the server

## Testing
- `npm run build`
- `npm test` *(fails: No binary for ChromeHeadless)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2099861d883259f18c9e8d7380346