### PR TITLE
fix: specify varchar type for email column

### DIFF
--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -34,6 +34,7 @@ export class User {
   username: string;
 
   @Column({
+    type: 'varchar',
     unique: true,
     transformer: {
       to: (value: Email): string => value.value,


### PR DESCRIPTION
## Summary
- specify `varchar` type for `User.email` column to avoid unsupported data type error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20cb2b8c083258620176df2189ac4