### PR TITLE
Run migrations after dropping database in seed

### DIFF
--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -29,10 +29,13 @@ async function main() {
 
   try {
     if (drop) {
-      console.log('Dropping and re-syncing database schema...');
+      console.log('Dropping and rebuilding database schema through migrations...');
       await ds.dropDatabase();
-      await ds.synchronize();
-      console.log('Database dropped and schema synchronized.');
+      if (!ds.isInitialized) {
+        await ds.initialize();
+      }
+      await ds.runMigrations();
+      console.log('Database dropped and migrations run.');
     }
 
     await ds.transaction(async (trx) => {


### PR DESCRIPTION
## Summary
- rebuild database schema via migrations when seeding with `--drop`
- ensure datasource remains initialized before running migrations

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b20fc6ae8c8325a35a881b1e98eb7a