### PR TITLE
Exit early on migration generation failure

### DIFF
--- a/backend/scripts/generate-migration.mjs
+++ b/backend/scripts/generate-migration.mjs
@@ -1,13 +1,24 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync } from 'node:child_process';
 
-const name = process.argv[2] || "auto";
+const name = process.argv[2] || 'auto';
 const outPath = `src/migrations/${name}`;
 
 const result = spawnSync(
-  "ts-node",
-  ["--transpile-only", "./node_modules/typeorm/cli.js",
-   "migration:generate", "-d", "data-source.ts", outPath],
-  { stdio: "inherit" }
+  'ts-node',
+  [
+    '--transpile-only',
+    './node_modules/typeorm/cli.js',
+    'migration:generate',
+    '-d',
+    'data-source.ts',
+    outPath,
+  ],
+  { stdio: 'inherit' },
 );
-spawnSync("npx", ["prettier", outPath + ".ts", "--write"], { stdio: "inherit" });
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+spawnSync('npx', ['prettier', outPath + '.ts', '--write'], {
+  stdio: 'inherit',
+});
 process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- bail out of `generate-migration.mjs` if the TypeORM command exits with an error before running Prettier

## Testing
- `npx prettier scripts/generate-migration.mjs --write`
- `npm test` *(fails: Cannot find module './migrations/1756435084873-enable-tenant-rls')*


------
https://chatgpt.com/codex/tasks/task_e_68b2160f30788325995377d12ac32ffa