### PR TITLE
Fix migration generation script to use timestamped filenames

### DIFF
--- a/backend/scripts/generate-migration.mjs
+++ b/backend/scripts/generate-migration.mjs
@@ -9,7 +9,10 @@ if (!MIGRATION_NAME_REGEX.test(name)) {
   process.exit(1);
 }
 
-const outPath = `src/migrations/${name}`;
+const migrationsDir = 'src/migrations';
+const timestamp = Date.now();
+const outPath = `${migrationsDir}/${name}`;
+const generatedFile = `${migrationsDir}/${timestamp}-${name}.ts`;
 
 const result = spawnSync(
   'ts-node',
@@ -17,9 +20,11 @@ const result = spawnSync(
     '--transpile-only',
     './node_modules/typeorm/cli.js',
     'migration:generate',
+    outPath,
     '-d',
     'data-source.ts',
-    outPath,
+    '--timestamp',
+    timestamp.toString(),
   ],
   { stdio: 'inherit' },
 );
@@ -28,7 +33,7 @@ if (result.status !== 0) {
   process.exit(result.status ?? 1);
 }
 
-spawnSync('npx', ['prettier', outPath + '.ts', '--write'], {
+spawnSync('npx', ['prettier', generatedFile, '--write'], {
   stdio: 'inherit',
 });
 process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- compute timestamp and pass it to TypeORM CLI for deterministic migration filenames
- format the generated migration file with Prettier

## Testing
- `npm test` *(fails: Cannot find module './migrations/1756435084873-enable-tenant-rls')*
- `npm run lint` *(fails: 4 errors in src/rls.policy.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b217f7074c8325b9e49298881daa03