### PR TITLE
fix eslint parsing for migration script

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -25,6 +25,15 @@ export default tseslint.config(
     },
   },
   {
+    files: ['scripts/**/*.mjs'],
+    languageOptions: {
+      sourceType: 'module',
+      parserOptions: {
+        projectService: { allowDefaultProject: ['scripts/generate-migration.mjs'] },
+      },
+    },
+  },
+  {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "scripts", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Summary
- handle backend scripts outside of TypeScript project
- exclude scripts from backend build config

## Testing
- `npx --yes eslint scripts/generate-migration.mjs`
- `npm test` *(fails: Cannot find module './migrations/1756435084873-enable-tenant-rls')*


------
https://chatgpt.com/codex/tasks/task_e_68b21cc90ff883259812efabceea4063