### PR TITLE
Handle company membership objects from API

### DIFF
--- a/frontend/src/app/auth.interceptor.ts
+++ b/frontend/src/app/auth.interceptor.ts
@@ -16,8 +16,8 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  if (company && !isLogin && !isSwitchCompany) {
-    headers['X-Company-ID'] = company;
+  if (company !== null && !isLogin && !isSwitchCompany) {
+    headers['X-Company-ID'] = String(company);
   }
 
   if (Object.keys(headers).length) {

--- a/frontend/src/app/company-switcher/company-switcher.component.ts
+++ b/frontend/src/app/company-switcher/company-switcher.component.ts
@@ -9,7 +9,9 @@ import { AuthService } from '../auth/auth.service';
   imports: [CommonModule, FormsModule],
   template: `
     <select [(ngModel)]="selected" (ngModelChange)="onChange($event)">
-      <option *ngFor="let c of auth.getCompanies()" [ngValue]="c">{{ c }}</option>
+      <option *ngFor="let c of auth.getCompanies()" [ngValue]="c.companyId">
+        {{ c.companyName || c.companyId }}
+      </option>
     </select>
   `,
 })
@@ -17,10 +19,10 @@ export class CompanySwitcherComponent {
   protected auth = inject(AuthService);
   selected = this.auth.getCompany();
 
-  onChange(company: string): void {
-    if (company) {
-      this.auth.switchCompany(company).subscribe(() => {
-        this.selected = company;
+  onChange(companyId: number): void {
+    if (companyId) {
+      this.auth.switchCompany(companyId).subscribe(() => {
+        this.selected = companyId;
         if (typeof window !== 'undefined') {
           window.location.reload();
         }

--- a/frontend/src/app/invitations/invitations.service.ts
+++ b/frontend/src/app/invitations/invitations.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
+import { CompanyMembership } from '../auth/auth.service';
 
 export interface InvitationPreview {
   companyName: string;
@@ -21,8 +22,8 @@ export class InvitationsService {
   accept(
     token: string,
     data?: { name: string; password: string },
-  ): Observable<{ access_token: string; companies?: string[] }> {
-    return this.http.post<{ access_token: string; companies?: string[] }>(
+  ): Observable<{ access_token: string; companies?: CompanyMembership[] }> {
+    return this.http.post<{ access_token: string; companies?: CompanyMembership[] }>(
       `${environment.apiUrl}/invitations/${token}/accept`,
       data ?? {},
     );

--- a/frontend/src/app/team/team.service.ts
+++ b/frontend/src/app/team/team.service.ts
@@ -14,7 +14,7 @@ export class TeamService {
 
   private getCompanyId(): number {
     const id = this.auth.getCompany();
-    return id ? Number(id) : 0;
+    return id ?? 0;
   }
 
   getMembers(): Observable<CompanyMember[]> {


### PR DESCRIPTION
## Summary
- Model company memberships in `AuthService` and persist them with id, name and role
- Display company names in company switcher and switch using numeric IDs
- Include company ID header when authenticated requests are made and adjust invitation handling

## Testing
- `npm test` (backend)
- `npm run lint` (frontend)
- `npm run build` (frontend)
- `npm test` (frontend) *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b22413570483259923925890697a6c