### PR TITLE
Fix nodemailer import for SMTP transport

### DIFF
--- a/backend/src/common/email/transports/smtp.transport.ts
+++ b/backend/src/common/email/transports/smtp.transport.ts
@@ -1,4 +1,4 @@
-import nodemailer from 'nodemailer';
+import * as nodemailer from 'nodemailer';
 import { EmailTransport, MailDriver } from './transport.interface';
 
 function parsePort(v: string | undefined, fallback: number): number {


### PR DESCRIPTION
## Summary
- use namespace import for nodemailer in SMTP transport

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b22467fb9083258833c5d493df078e