### PR TITLE
Fix nodemailer import for ethereal email transport

### DIFF
--- a/backend/src/common/email/transports/ethereal.transport.ts
+++ b/backend/src/common/email/transports/ethereal.transport.ts
@@ -1,4 +1,4 @@
-import nodemailer from 'nodemailer';
+import * as nodemailer from 'nodemailer';
 import { EmailTransport, MailDriver } from './transport.interface';
 
 export class EtherealTransport implements EmailTransport {


### PR DESCRIPTION
## Summary
- fix EtherealTransport nodemailer import so createTestAccount exists at runtime

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b22651811c83258d9e4514b2465754