### PR TITLE
Check backend health on startup and show error page

### DIFF
--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -63,6 +63,6 @@ export class ApiService {
   }
 
   getHealth(): Observable<{ status: string }> {
-    return this.request<{ status: string }>('GET', `${environment.apiUrl}/health`);
+    return this.http.get<{ status: string }>(`${environment.apiUrl}/health`);
   }
 }

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -2,12 +2,25 @@ import {
   ApplicationConfig,
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection,
+  APP_INITIALIZER,
 } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { authInterceptor } from './auth.interceptor';
 import { routes } from './app.routes';
+import { ApiService } from './api.service';
+import { firstValueFrom } from 'rxjs';
+
+function backendHealthInitializer(api: ApiService, router: Router): () => Promise<void> {
+  return () =>
+    firstValueFrom(api.getHealth()).then(
+      () => undefined,
+      () => {
+        void router.navigate(['/server-error']);
+      },
+    );
+}
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -16,5 +29,11 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
     provideHttpClient(withInterceptors([authInterceptor])),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: backendHealthInitializer,
+      deps: [ApiService, Router],
+      multi: true,
+    },
   ],
 };

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -6,6 +6,11 @@ import { roleGuard } from './auth/role.guard';
 
 export const routes: Routes = [
   {
+    path: 'server-error',
+    loadComponent: () =>
+      import('./server-error/server-error.component').then((m) => m.ServerErrorComponent),
+  },
+  {
     path: 'login',
     loadComponent: () => import('./auth/login/login.component').then((m) => m.LoginComponent),
   },

--- a/frontend/src/app/server-error/server-error.component.ts
+++ b/frontend/src/app/server-error/server-error.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-server-error',
+  standalone: true,
+  template: `
+    <div class="server-error">
+      <h1>RF Landscaper Pro</h1>
+      <p>is undergoing difficulties. Please try again later.</p>
+    </div>
+  `,
+})
+export class ServerErrorComponent {}


### PR DESCRIPTION
## Summary
- Check backend health at startup and redirect to dedicated error page if unreachable
- Add server error route and simple error component
- Call health endpoint directly to avoid spurious error notifications

## Testing
- `npm run lint` (frontend)
- `npm test` (frontend) *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run lint` (backend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68b226e7ff80832580227c057fdd0419