### PR TITLE
feat(auth): allow master to switch company without membership

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -132,6 +132,22 @@ export class AuthService {
     user: JwtUserPayload,
     companyId: number,
   ): Promise<{ access_token: string }> {
+    // Allow master users to switch companies without membership lookup
+    if (user.role === UserRole.Master) {
+      const payload = {
+        username: user.username,
+        sub: user.userId,
+        email: user.email,
+        companyId,
+        roles: [UserRole.Master],
+        role: UserRole.Master,
+      };
+
+      return {
+        access_token: await this.jwtService.signAsync(payload),
+      };
+    }
+
     const membership = await this.companyMembershipRepository.findOne({
       where: {
         companyId,

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -23,6 +23,7 @@ export enum UserRole {
   Owner = 'owner',
   Worker = 'worker',
   Customer = 'customer',
+  Master = 'master',
 }
 
 @Entity()


### PR DESCRIPTION
## Summary
- allow `Master` users to switch companies without membership lookup
- add `Master` to `UserRole` enum

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b22b6d4548832587dcb574ad3d732a