### PR TITLE
feat: add master user role

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -78,9 +78,11 @@ createdb rflandscaperpro
 # Run database migrations (when available)
 npm run migration:run
 
-# Seed initial data (creates admin user and sample customer)
-# This script is intended for local development only and will
-# automatically skip execution when `NODE_ENV=production`.
+# Seed initial data (creates admin and master users and sample customer)
+# Set ADMIN_* and MASTER_* env vars to control credentials. Passwords can
+# be omitted to auto-generate secure values. This script is intended for
+# local development only and will automatically skip execution when
+# `NODE_ENV=production`.
 npm run seed:dev
 
 # Drop and re-seed the database from scratch

--- a/backend/env.example
+++ b/backend/env.example
@@ -26,6 +26,18 @@ JWT_SECRET=your_jwt_secret
 JWT_EXPIRES_IN=1d
 JWT_REFRESH_EXPIRES_IN=7d
 
+# Initial User Seeding
+# Credentials for admin and master accounts created by seed scripts.
+# If ADMIN_PASSWORD or MASTER_PASSWORD are omitted, a random password will be
+# generated and printed to the console.
+ADMIN_USERNAME=admin
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=changeme
+
+MASTER_USERNAME=master
+MASTER_EMAIL=master@example.com
+MASTER_PASSWORD=changeme
+
 # Swagger Documentation
 SWAGGER_USER=admin
 SWAGGER_PASSWORD=admin

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -108,11 +108,17 @@ describe('AuthService.signupOwner', () => {
       {} as EmailService,
       { findOne: jest.fn() } as unknown as CompanyMembershipRepository,
     );
-    loginSpy = jest.spyOn(service, 'login').mockResolvedValue({
-      access_token: '',
-      refresh_token: '',
-      user: { id: 0, username: '', email: '', role: UserRole.Owner },
-    });
+      loginSpy = jest.spyOn(service, 'login').mockResolvedValue({
+        access_token: '',
+        refresh_token: '',
+        user: {
+          id: 0,
+          username: '',
+          email: '',
+          role: UserRole.Owner,
+          roles: [UserRole.Owner],
+        },
+      });
   });
 
   it('delegates to UserCreationService.createUser', async () => {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -70,12 +70,13 @@ export class AuthService {
   }
 
   async login(user: User) {
+    const roles = [user.role];
     const payload = {
       username: user.username,
       sub: user.id,
       email: user.email,
       companyId: null as number | null,
-      roles: [user.role],
+      roles,
       role: user.role,
     };
 
@@ -92,6 +93,7 @@ export class AuthService {
         username: user.username,
         email: user.email.value,
         role: user.role,
+        roles,
       },
     };
   }

--- a/backend/src/migrations/1756502290800-auto.ts
+++ b/backend/src/migrations/1756502290800-auto.ts
@@ -101,7 +101,7 @@ export class Auto1756502290800 implements MigrationInterface {
       `CREATE INDEX "IDX_fdb2f3ad8115da4c7718109a6e" ON "customer" ("email") `,
     );
     await queryRunner.query(
-      `CREATE TYPE "public"."user_role_enum" AS ENUM('admin', 'owner', 'worker', 'customer')`,
+      `CREATE TYPE "public"."user_role_enum" AS ENUM('admin', 'master', 'owner', 'worker', 'customer')`,
     );
     await queryRunner.query(
       `CREATE TABLE "user" ("id" SERIAL NOT NULL, "username" character varying NOT NULL, "email" character varying NOT NULL, "password" character varying NOT NULL, "role" "public"."user_role_enum" NOT NULL DEFAULT 'customer', "isVerified" boolean NOT NULL DEFAULT false, "firstName" character varying, "lastName" character varying, "phone" character varying, "passwordResetToken" character varying(64), "passwordResetExpires" TIMESTAMP WITH TIME ZONE, "companyId" integer, CONSTRAINT "UQ_78a916df40e02a9deb1c4b75edb" UNIQUE ("username"), CONSTRAINT "UQ_e12875dfb3b1d92d7d7c5377e22" UNIQUE ("email"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`,

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -20,6 +20,7 @@ import { PhoneNumber } from './value-objects/phone-number.vo';
 
 export enum UserRole {
   Admin = 'admin',
+  Master = 'master',
   Owner = 'owner',
   Worker = 'worker',
   Customer = 'customer',


### PR DESCRIPTION
## Summary
- add `Master` to user roles and initial migration
- seed a master user via `MASTER_*` env vars
- include user roles array in login payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b22b5cb1208325a7c609bd7dce85e2