### PR TITLE
Allow master users to access all companies

### DIFF
--- a/backend/src/common/tenant.guard.spec.ts
+++ b/backend/src/common/tenant.guard.spec.ts
@@ -1,13 +1,31 @@
 import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { TenantGuard } from './tenant.guard';
+import { UserRole } from '../users/user.entity';
 
 describe('TenantGuard', () => {
   it('allows access to metrics endpoint without company ID', () => {
-    const guard = new TenantGuard(new Reflector());
+    const guard = new TenantGuard({
+      getAllAndOverride: jest.fn(),
+    } as unknown as Reflector);
     const context = {
       switchToHttp: () => ({
         getRequest: () => ({ path: '/api/metrics', headers: {} }),
+      }),
+      getHandler: () => undefined,
+      getClass: () => undefined,
+    } as unknown as ExecutionContext;
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('allows master without company ID', () => {
+    const guard = new TenantGuard({
+      getAllAndOverride: jest.fn(),
+    } as unknown as Reflector);
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role: UserRole.Master }, headers: {} }),
       }),
       getHandler: () => undefined,
       getClass: () => undefined,

--- a/backend/src/users/me.controller.spec.ts
+++ b/backend/src/users/me.controller.spec.ts
@@ -5,21 +5,29 @@ import {
   CompanyUserRole,
   CompanyUserStatus,
 } from '../companies/entities/company-user.entity';
-import { User } from './user.entity';
+import { Company } from '../companies/entities/company.entity';
+import { User, UserRole } from './user.entity';
 
 describe('MeController', () => {
   let controller: MeController;
-  let repo: jest.Mocked<Pick<Repository<CompanyUser>, 'find'>>;
+  let companyUserRepo: jest.Mocked<Pick<Repository<CompanyUser>, 'find'>>;
+  let companyRepo: jest.Mocked<Pick<Repository<Company>, 'find'>>;
 
   beforeEach(() => {
-    repo = { find: jest.fn() } as unknown as jest.Mocked<
+    companyUserRepo = { find: jest.fn() } as unknown as jest.Mocked<
       Pick<Repository<CompanyUser>, 'find'>
     >;
-    controller = new MeController(repo as unknown as Repository<CompanyUser>);
+    companyRepo = { find: jest.fn() } as unknown as jest.Mocked<
+      Pick<Repository<Company>, 'find'>
+    >;
+    controller = new MeController(
+      companyUserRepo as unknown as Repository<CompanyUser>,
+      companyRepo as unknown as Repository<Company>,
+    );
   });
 
   it('returns active memberships', async () => {
-    repo.find.mockResolvedValue([
+    companyUserRepo.find.mockResolvedValue([
       Object.assign(new CompanyUser(), {
         companyId: 1,
         role: CompanyUserRole.ADMIN,
@@ -31,10 +39,24 @@ describe('MeController', () => {
     const user = Object.assign(new User(), { id: 1 });
     const result = await controller.listCompanies(user);
 
-    expect(repo.find).toHaveBeenCalledWith({
+    expect(companyUserRepo.find).toHaveBeenCalledWith({
       where: { userId: 1, status: CompanyUserStatus.ACTIVE },
       relations: ['company'],
     });
+    expect(result).toEqual([
+      { companyId: 1, companyName: 'Acme', role: CompanyUserRole.ADMIN },
+    ]);
+  });
+
+  it('returns all companies for master user', async () => {
+    companyRepo.find.mockResolvedValue([
+      Object.assign(new Company(), { id: 1, name: 'Acme' }),
+    ]);
+
+    const user = Object.assign(new User(), { id: 1, role: UserRole.Master });
+    const result = await controller.listCompanies(user);
+
+    expect(companyRepo.find).toHaveBeenCalled();
     expect(result).toEqual([
       { companyId: 1, companyName: 'Acme', role: CompanyUserRole.ADMIN },
     ]);

--- a/backend/src/users/me.controller.ts
+++ b/backend/src/users/me.controller.ts
@@ -3,10 +3,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import {
   CompanyUser,
+  CompanyUserRole,
   CompanyUserStatus,
 } from '../companies/entities/company-user.entity';
+import { Company } from '../companies/entities/company.entity';
 import { AuthUser } from '../common/decorators/auth-user.decorator';
-import { User } from './user.entity';
+import { User, UserRole } from './user.entity';
 import { CompanyMembershipResponseDto } from './dto/company-membership-response.dto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
@@ -17,12 +19,22 @@ export class MeController {
   constructor(
     @InjectRepository(CompanyUser)
     private readonly companyUsersRepository: Repository<CompanyUser>,
+    @InjectRepository(Company)
+    private readonly companiesRepository: Repository<Company>,
   ) {}
 
   @Get('companies')
   async listCompanies(
     @AuthUser() user: User | undefined,
   ): Promise<CompanyMembershipResponseDto[]> {
+    if (user?.role === UserRole.Master) {
+      const companies = await this.companiesRepository.find();
+      return companies.map((c) => ({
+        companyId: c.id,
+        companyName: c.name ?? '',
+        role: CompanyUserRole.ADMIN,
+      }));
+    }
     const memberships = await this.companyUsersRepository.find({
       where: { userId: user!.id, status: CompanyUserStatus.ACTIVE },
       relations: ['company'],

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -19,6 +19,7 @@ import { Email } from './value-objects/email.vo';
 import { PhoneNumber } from './value-objects/phone-number.vo';
 
 export enum UserRole {
+  Master = 'master',
   Admin = 'admin',
   Owner = 'owner',
   Worker = 'worker',


### PR DESCRIPTION
## Summary
- Add `Master` to `UserRole` and expose repository of all companies
- Return every company for master users
- Permit master role in `TenantGuard` with optional `x-company-id`
- Cover new behavior with unit tests

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b22b76c3b88325b77b7adee2f6d3e0