### PR TITLE
feat: rename admin and owner roles

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -78,8 +78,8 @@ createdb rflandscaperpro
 # Run database migrations (when available)
 npm run migration:run
 
-# Seed initial data (creates admin and master users and sample customer)
-# Set ADMIN_* and MASTER_* env vars to control credentials. Passwords can
+# Seed initial data (creates company admin and master users and sample customer)
+# Set COMPANY_ADMIN_* and MASTER_* env vars to control credentials. Passwords can
 # be omitted to auto-generate secure values. This script is intended for
 # local development only and will automatically skip execution when
 # `NODE_ENV=production`.
@@ -114,7 +114,7 @@ npm run start:prod
 
 ### 5. Access the API
 - API Base URL: http://localhost:3000/api
-- Swagger Docs: http://localhost:3000/api/docs (admin/admin)
+- Swagger Docs: http://localhost:3000/api/docs (company_admin/company_admin)
 - Health Check: http://localhost:3000/api/health
 - Metrics: http://localhost:3000/api/metrics
 - Production Base URL: https://rflandscaperpro.com/api

--- a/backend/env.example
+++ b/backend/env.example
@@ -27,12 +27,12 @@ JWT_EXPIRES_IN=1d
 JWT_REFRESH_EXPIRES_IN=7d
 
 # Initial User Seeding
-# Credentials for admin and master accounts created by seed scripts.
-# If ADMIN_PASSWORD or MASTER_PASSWORD are omitted, a random password will be
+# Credentials for company admin and master accounts created by seed scripts.
+# If COMPANY_ADMIN_PASSWORD or MASTER_PASSWORD are omitted, a random password will be
 # generated and printed to the console.
-ADMIN_USERNAME=admin
-ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=changeme
+COMPANY_ADMIN_USERNAME=admin
+COMPANY_ADMIN_EMAIL=admin@example.com
+COMPANY_ADMIN_PASSWORD=changeme
 
 MASTER_USERNAME=master
 MASTER_EMAIL=master@example.com

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -81,8 +81,8 @@ describe('AuthService.switchCompany', () => {
       sub: 1,
       email: 'a@e.com',
       companyId: 2,
-      roles: [UserRole.Admin],
-      role: UserRole.Admin,
+      roles: [UserRole.CompanyAdmin],
+      role: UserRole.CompanyAdmin,
     });
     expect(result).toEqual({ access_token: 'jwt' });
   });
@@ -115,8 +115,8 @@ describe('AuthService.signupOwner', () => {
           id: 0,
           username: '',
           email: '',
-          role: UserRole.Owner,
-          roles: [UserRole.Owner],
+          role: UserRole.CompanyOwner,
+          roles: [UserRole.CompanyOwner],
         },
       });
   });
@@ -126,7 +126,7 @@ describe('AuthService.signupOwner', () => {
       id: 1,
       username: 'owner',
       email: 'owner@example.com',
-      role: UserRole.Owner,
+      role: UserRole.CompanyOwner,
     });
     userCreationService.createUser.mockResolvedValue(user);
 
@@ -141,7 +141,7 @@ describe('AuthService.signupOwner', () => {
       username: 'owner',
       email: new Email('owner@example.com'),
       password: 'Password123!',
-      role: UserRole.Owner,
+      role: UserRole.CompanyOwner,
       company: { name: 'ACME' },
       isVerified: true,
     });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -122,7 +122,7 @@ export class AuthService {
       username: dto.name,
       email: new Email(dto.email),
       password: dto.password,
-      role: UserRole.Owner,
+      role: UserRole.CompanyOwner,
       company: { name: dto.companyName },
       isVerified: true,
     });
@@ -163,9 +163,9 @@ export class AuthService {
   private mapRole(role: CompanyUserRole): UserRole {
     switch (role) {
       case CompanyUserRole.OWNER:
-        return UserRole.Owner;
+        return UserRole.CompanyOwner;
       case CompanyUserRole.ADMIN:
-        return UserRole.Admin;
+        return UserRole.CompanyAdmin;
       default:
         return UserRole.Worker;
     }

--- a/backend/src/common/guards/jwt-auth.guard.spec.ts
+++ b/backend/src/common/guards/jwt-auth.guard.spec.ts
@@ -28,7 +28,7 @@ describe('JwtAuthGuard', () => {
     expect(() =>
       guard.handleRequest(
         null,
-        { id: 1, companyId: 1, role: UserRole.Admin },
+        { id: 1, companyId: 1, role: UserRole.CompanyAdmin },
         null,
         context,
       ),

--- a/backend/src/companies/companies.controller.ts
+++ b/backend/src/companies/companies.controller.ts
@@ -42,7 +42,7 @@ export class CompaniesController {
     return company;
   }
 
-  @Roles(UserRole.Owner)
+@Roles(UserRole.CompanyOwner)
   @Get('workers')
   async getWorkers(@AuthUser() user: User | undefined): Promise<UserResponseDto[]> {
     const owner = await this.usersService.findById(user!.id);
@@ -52,7 +52,7 @@ export class CompaniesController {
     return workers.map(toUserResponseDto);
   }
 
-  @Roles(UserRole.Owner, UserRole.Admin)
+  @Roles(UserRole.CompanyOwner, UserRole.CompanyAdmin)
   @Post()
   async create(
     @Body() dto: CreateCompanyDto,
@@ -61,7 +61,7 @@ export class CompaniesController {
     return this.companiesService.create(dto, user!.id);
   }
 
-  @Roles(UserRole.Owner, UserRole.Admin)
+  @Roles(UserRole.CompanyOwner, UserRole.CompanyAdmin)
   @Patch(':id')
   async update(
     @Param('id', ParseIntPipe) id: number,
@@ -72,7 +72,7 @@ export class CompaniesController {
     return this.companiesService.update(id, dto);
   }
 
-  @Roles(UserRole.Owner, UserRole.Admin)
+  @Roles(UserRole.CompanyOwner, UserRole.CompanyAdmin)
   @Post(':companyId/invitations')
   async invite(
     @Param('companyId', ParseIntPipe) companyId: number,
@@ -99,7 +99,7 @@ export class CompaniesController {
     };
   }
 
-  @Roles(UserRole.Owner, UserRole.Admin)
+  @Roles(UserRole.CompanyOwner, UserRole.CompanyAdmin)
   @Post(':companyId/invitations/:inviteId/revoke')
   async revokeInvitation(
     @Param('companyId', ParseIntPipe) companyId: number,
@@ -112,7 +112,7 @@ export class CompaniesController {
     return { success: true };
   }
 
-  @Roles(UserRole.Owner, UserRole.Admin)
+  @Roles(UserRole.CompanyOwner, UserRole.CompanyAdmin)
   @Post(':companyId/invitations/:inviteId/resend')
   async resendInvitation(
     @Param('companyId', ParseIntPipe) companyId: number,

--- a/backend/src/companies/members.controller.ts
+++ b/backend/src/companies/members.controller.ts
@@ -18,7 +18,7 @@ import { UpdateCompanyMemberDto } from './dto/update-company-member.dto';
 
 @ApiTags('companies')
 @ApiBearerAuth()
-@Roles(UserRole.Owner, UserRole.Admin)
+@Roles(UserRole.CompanyOwner, UserRole.CompanyAdmin)
 @Controller('companies/:companyId/members')
 export class MembersController {
   constructor(private readonly membersService: MembersService) {}

--- a/backend/src/contracts/contracts.controller.ts
+++ b/backend/src/contracts/contracts.controller.ts
@@ -28,7 +28,7 @@ export class ContractsController {
   constructor(private readonly contractsService: ContractsService) {}
 
   @Post()
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Create contract' })
   @ApiResponse({ status: 201, type: ContractResponseDto })
   create(
@@ -39,7 +39,7 @@ export class ContractsController {
   }
 
   @Get()
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'List contracts' })
   @ApiResponse({ status: 200, type: [ContractResponseDto] })
   findAll(@CompanyId() companyId: number): Promise<ContractResponseDto[]> {
@@ -47,7 +47,7 @@ export class ContractsController {
   }
 
   @Patch(':id')
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Update contract' })
   @ApiResponse({ status: 200, type: ContractResponseDto })
   update(
@@ -59,7 +59,7 @@ export class ContractsController {
   }
 
   @Post(':id/cancel')
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Cancel contract' })
   @ApiResponse({ status: 200, description: 'Contract cancelled' })
   cancel(

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -38,7 +38,7 @@ export class CustomersController {
   constructor(private readonly customersService: CustomersService) {}
 
   @Post()
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Create customer' })
   @ApiResponse({
     status: 201,
@@ -53,7 +53,7 @@ export class CustomersController {
   }
 
   @Get()
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'List customers for the authenticated company' })
   @ApiQuery({ name: 'page', required: false })
   @ApiQuery({ name: 'limit', required: false })
@@ -82,7 +82,7 @@ export class CustomersController {
   }
 
   @Get(':id')
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Get customer by id' })
   @ApiResponse({
     status: 200,
@@ -97,7 +97,7 @@ export class CustomersController {
   }
 
   @Patch(':id')
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Update customer' })
   @ApiResponse({
     status: 200,
@@ -113,7 +113,7 @@ export class CustomersController {
   }
 
   @Patch(':id/activate')
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Activate customer' })
   @ApiResponse({
     status: 200,
@@ -128,7 +128,7 @@ export class CustomersController {
   }
 
   @Patch(':id/deactivate')
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Deactivate customer' })
   @ApiResponse({
     status: 200,
@@ -144,7 +144,7 @@ export class CustomersController {
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Delete customer' })
   @ApiResponse({ status: 204, description: 'Customer deleted' })
   async remove(

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -37,7 +37,7 @@ export class EquipmentController {
   constructor(private readonly equipmentService: EquipmentService) {}
 
   @Post()
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Create equipment' })
   @ApiResponse({
     status: 201,
@@ -52,7 +52,7 @@ export class EquipmentController {
   }
 
   @Get()
-  @Roles(UserRole.Admin, UserRole.Worker, UserRole.Customer)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker, UserRole.Customer)
   @ApiOperation({ summary: 'List equipment for the authenticated company' })
   @ApiQuery({ name: 'page', required: false })
   @ApiQuery({ name: 'limit', required: false })
@@ -79,7 +79,7 @@ export class EquipmentController {
   }
 
   @Get(':id')
-  @Roles(UserRole.Admin, UserRole.Worker, UserRole.Customer)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker, UserRole.Customer)
   @ApiOperation({ summary: 'Get equipment by id' })
   @ApiResponse({
     status: 200,
@@ -94,7 +94,7 @@ export class EquipmentController {
   }
 
   @Patch(':id')
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Update equipment' })
   @ApiResponse({
     status: 200,
@@ -110,7 +110,7 @@ export class EquipmentController {
   }
 
   @Patch(':id/status')
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Update equipment status' })
   @ApiResponse({
     status: 200,
@@ -131,7 +131,7 @@ export class EquipmentController {
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Delete equipment' })
   @ApiResponse({ status: 204, description: 'Equipment deleted' })
   async remove(

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -39,7 +39,7 @@ export class JobsController {
   constructor(private readonly jobsService: JobsService) {}
 
   @Post()
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Create job' })
   @ApiResponse({
     status: 201,
@@ -54,7 +54,7 @@ export class JobsController {
   }
 
   @Get()
-  @Roles(UserRole.Admin, UserRole.Worker, UserRole.Customer)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker, UserRole.Customer)
   @ApiOperation({ summary: 'List jobs for the authenticated company' })
   @ApiQuery({ name: 'page', required: false })
   @ApiQuery({ name: 'limit', required: false })
@@ -91,7 +91,7 @@ export class JobsController {
   }
 
   @Get(':id')
-  @Roles(UserRole.Admin, UserRole.Worker, UserRole.Customer)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker, UserRole.Customer)
   @ApiOperation({ summary: 'Get job by id' })
   @ApiResponse({
     status: 200,
@@ -106,7 +106,7 @@ export class JobsController {
   }
 
   @Patch(':id')
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Update job' })
   @ApiResponse({
     status: 200,
@@ -122,7 +122,7 @@ export class JobsController {
   }
 
   @Post(':id/schedule')
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Schedule job' })
   @ApiResponse({
     status: 200,
@@ -138,7 +138,7 @@ export class JobsController {
   }
 
   @Post(':id/assign')
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Assign resources to job' })
   @ApiResponse({
     status: 200,
@@ -154,7 +154,7 @@ export class JobsController {
   }
 
   @Post(':id/bulk-assign')
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Assign multiple resources to job' })
   @ApiResponse({
     status: 200,
@@ -170,7 +170,7 @@ export class JobsController {
   }
 
   @Delete(':id/assignments/:assignmentId')
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Remove assignment from job' })
   @ApiResponse({
     status: 200,
@@ -187,7 +187,7 @@ export class JobsController {
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @Roles(UserRole.Admin, UserRole.Worker)
+  @Roles(UserRole.CompanyAdmin, UserRole.Worker)
   @ApiOperation({ summary: 'Delete job' })
   @ApiResponse({ status: 204, description: 'Job deleted' })
   async remove(

--- a/backend/src/migrations/1756502290801-rename-user-role-enum.ts
+++ b/backend/src/migrations/1756502290801-rename-user-role-enum.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameUserRoleEnum1756502290801 implements MigrationInterface {
+  name = 'RenameUserRoleEnum1756502290801';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."user_role_enum" RENAME VALUE 'admin' TO 'company_admin'`
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."user_role_enum" RENAME VALUE 'owner' TO 'company_owner'`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."user_role_enum" RENAME VALUE 'company_owner' TO 'owner'`
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."user_role_enum" RENAME VALUE 'company_admin' TO 'admin'`
+    );
+  }
+}

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -88,22 +88,24 @@ async function main() {
         );
       }
 
-      // --- Admin user ---
-      const adminUsername = process.env.ADMIN_USERNAME ?? 'admin';
-      const adminEmail = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+      // --- Company admin user ---
+      const companyAdminUsername =
+        process.env.COMPANY_ADMIN_USERNAME ?? 'admin';
+      const companyAdminEmail =
+        process.env.COMPANY_ADMIN_EMAIL ?? 'admin@example.com';
 
-      const rawAdminPassword =
-        process.env.ADMIN_PASSWORD ??
+      const rawCompanyAdminPassword =
+        process.env.COMPANY_ADMIN_PASSWORD ??
         crypto.randomBytes(16).toString('base64url');
 
-      const hashed = await bcrypt.hash(rawAdminPassword, 12);
+      const hashed = await bcrypt.hash(rawCompanyAdminPassword, 12);
 
       await userRepo.upsert(
         {
-          username: adminUsername,
-          email: new Email(adminEmail),
+          username: companyAdminUsername,
+          email: new Email(companyAdminEmail),
           password: hashed,
-          role: UserRole.Admin,
+          role: UserRole.CompanyAdmin,
           firstName: 'Admin',
           lastName: 'User',
           phone: new PhoneNumber('555-000-0000'),
@@ -114,15 +116,17 @@ async function main() {
         },
       );
       const adminUser = await userRepo.findOneOrFail({
-        where: { username: adminUsername },
+        where: { username: companyAdminUsername },
       });
 
-      if (!process.env.ADMIN_PASSWORD) {
+      if (!process.env.COMPANY_ADMIN_PASSWORD) {
         console.log(
-          `Admin user ensured. Generated password: ${rawAdminPassword}`,
+          `Company admin user ensured. Generated password: ${rawCompanyAdminPassword}`,
         );
       } else {
-        console.log('Admin user ensured (password from environment variable).');
+        console.log(
+          'Company admin user ensured (password from environment variable).',
+        );
       }
 
       // --- Sample company ---

--- a/backend/src/users/__tests__/user-creation.service.spec.ts
+++ b/backend/src/users/__tests__/user-creation.service.spec.ts
@@ -103,7 +103,7 @@ describe('UserCreationService', () => {
       username: 'owner',
       email: new Email('owner@example.com'),
       password: 'secret',
-      role: UserRole.Owner,
+      role: UserRole.CompanyOwner,
       company: { name: 'ACME Landscaping' },
     });
 

--- a/backend/src/users/__tests__/users.service.spec.ts
+++ b/backend/src/users/__tests__/users.service.spec.ts
@@ -188,8 +188,8 @@ describe('UsersService', () => {
   it('updates user role', async () => {
     const user = Object.assign(new User(), { id: 1, role: UserRole.Customer });
     usersRepository.findOne.mockResolvedValue(user);
-    const updated = await service.updateRole(1, UserRole.Admin);
-    expect(updated.role).toBe(UserRole.Admin);
+    const updated = await service.updateRole(1, UserRole.CompanyAdmin);
+    expect(updated.role).toBe(UserRole.CompanyAdmin);
     expect(usersRepository.save).toHaveBeenCalledWith(user);
   });
 });

--- a/backend/src/users/company-onboarding.service.ts
+++ b/backend/src/users/company-onboarding.service.ts
@@ -13,7 +13,7 @@ export class CompanyOnboardingService {
   ) {
     if (!company) {
       throw new BadRequestException(
-        'Company information is required for owner and worker accounts',
+        'Company information is required for company owner and worker accounts',
       );
     }
     const companyRepository = manager.getRepository(Company);
@@ -23,7 +23,7 @@ export class CompanyOnboardingService {
     if (!existing) {
       existing = companyRepository.create({
         ...company,
-        ownerId: user.role === UserRole.Owner ? user.id : undefined,
+        ownerId: user.role === UserRole.CompanyOwner ? user.id : undefined,
       });
       existing = await companyRepository.save(existing);
     }

--- a/backend/src/users/user-creation.service.ts
+++ b/backend/src/users/user-creation.service.ts
@@ -28,7 +28,7 @@ export class UserCreationService {
         if (savedUser.role === UserRole.Customer) {
           await this.customerRegistrationService.register(savedUser, manager);
         } else if (
-          savedUser.role === UserRole.Owner ||
+          savedUser.role === UserRole.CompanyOwner ||
           savedUser.role === UserRole.Worker
         ) {
           await this.companyOnboardingService.onboard(

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -20,12 +20,10 @@ import { PhoneNumber } from './value-objects/phone-number.vo';
 
 export enum UserRole {
   Master = 'master',
-  Admin = 'admin',
-  Master = 'master',
-  Owner = 'owner',
+  CompanyAdmin = 'company_admin',
+  CompanyOwner = 'company_owner',
   Worker = 'worker',
   Customer = 'customer',
-  Master = 'master',
 }
 
 @Entity()

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -36,7 +36,7 @@ import { toUserResponseDto } from './users.mapper';
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @Roles(UserRole.Admin, UserRole.Owner)
+  @Roles(UserRole.CompanyAdmin, UserRole.CompanyOwner)
   @Post()
   @ApiOperation({ summary: 'Create user' })
   @ApiResponse({
@@ -48,7 +48,7 @@ export class UsersController {
     @Req() req: { user: { userId: number; role: UserRole } },
     @Body() createUserDto: CreateUserDto,
   ): Promise<UserResponseDto> {
-    if (req.user.role === UserRole.Owner) {
+    if (req.user.role === UserRole.CompanyOwner) {
       if (createUserDto.role && createUserDto.role !== UserRole.Worker) {
         throw new BadRequestException('Owners can only create workers');
       }
@@ -64,7 +64,7 @@ export class UsersController {
   }
 
   @Get()
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'List users' })
   @ApiResponse({
     status: 200,
@@ -77,7 +77,7 @@ export class UsersController {
   }
 
   @Get('workers')
-  @Roles(UserRole.Owner)
+  @Roles(UserRole.CompanyOwner)
   @ApiOperation({ summary: 'List company workers' })
   @ApiResponse({
     status: 200,
@@ -92,7 +92,7 @@ export class UsersController {
   }
 
   @Get(':id')
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Get user by id' })
   @ApiResponse({
     status: 200,
@@ -108,7 +108,7 @@ export class UsersController {
   }
 
   @Patch(':id')
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Update user' })
   @ApiResponse({
     status: 200,
@@ -124,7 +124,7 @@ export class UsersController {
   }
 
   @Patch('workers/:id')
-  @Roles(UserRole.Owner)
+  @Roles(UserRole.CompanyOwner)
   @ApiOperation({ summary: 'Update company worker' })
   @ApiResponse({
     status: 200,
@@ -150,7 +150,7 @@ export class UsersController {
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Delete user' })
   @ApiResponse({ status: 204, description: 'User deleted' })
   async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
@@ -158,7 +158,7 @@ export class UsersController {
   }
 
   @Patch(':id/role')
-  @Roles(UserRole.Admin)
+  @Roles(UserRole.CompanyAdmin)
   @ApiOperation({ summary: 'Update user role' })
   @ApiResponse({
     status: 200,

--- a/backend/test/owners.e2e-spec.ts
+++ b/backend/test/owners.e2e-spec.ts
@@ -20,7 +20,7 @@ describe('Owner user endpoints (e2e)', () => {
       Object.assign(new User(), {
         id: 1,
         username: 'owner1',
-        role: UserRole.Owner,
+        role: UserRole.CompanyOwner,
         companyId: 1,
       }),
       Object.assign(new User(), {
@@ -33,7 +33,7 @@ describe('Owner user endpoints (e2e)', () => {
       Object.assign(new User(), {
         id: 3,
         username: 'owner2',
-        role: UserRole.Owner,
+        role: UserRole.CompanyOwner,
         companyId: 2,
       }),
       Object.assign(new User(), {
@@ -96,7 +96,7 @@ describe('Owner user endpoints (e2e)', () => {
         _res: Response,
         next: NextFunction,
       ) => {
-        req.user = { userId: 1, role: UserRole.Owner, companyId: 1 };
+        req.user = { userId: 1, role: UserRole.CompanyOwner, companyId: 1 };
         next();
       },
     );

--- a/frontend/src/app/admin/admin.component.ts
+++ b/frontend/src/app/admin/admin.component.ts
@@ -6,8 +6,8 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [CommonModule],
   template: `
-    <h2>Admin Area</h2>
-    <p>Only admins can see this page.</p>
+    <h2>Company Admin Area</h2>
+    <p>Only company admins can see this page.</p>
   `,
 })
 export class AdminComponent {}

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -61,7 +61,7 @@ export const routes: Routes = [
   {
     path: 'team',
     canActivate: [AuthGuard, roleGuard],
-    data: { roles: ['owner', 'admin'] },
+    data: { roles: ['company_owner', 'company_admin'] },
     loadChildren: () => import('./team/team.routes').then((m) => m.teamRoutes),
   },
   {

--- a/frontend/src/app/auth/admin.guard.ts
+++ b/frontend/src/app/auth/admin.guard.ts
@@ -4,5 +4,5 @@ import { AuthService } from './auth.service';
 
 export const AdminGuard: CanActivateFn = () => {
   const auth = inject(AuthService);
-  return auth.hasRole('admin');
+  return auth.hasRole('company_admin');
 };

--- a/frontend/src/app/auth/signup-owner/signup-owner.component.ts
+++ b/frontend/src/app/auth/signup-owner/signup-owner.component.ts
@@ -12,7 +12,7 @@ import { ErrorService } from '../../error.service';
   imports: [CommonModule, ReactiveFormsModule],
   template: `
     <p>
-      <small>Company details are required to create an owner account.</small>
+      <small>Company details are required to create a company owner account.</small>
     </p>
     <form [formGroup]="form" (ngSubmit)="submit()">
       <input type="text" formControlName="name" placeholder="Name" />

--- a/frontend/src/app/companies/worker-list.component.ts
+++ b/frontend/src/app/companies/worker-list.component.ts
@@ -15,10 +15,10 @@ import { AuthService } from '../auth/auth.service';
     <ul>
       <li *ngFor="let w of workers">
         <a [routerLink]="['/users', w.id]">{{ w.username }}</a>
-        <button *ngIf="auth.hasRole('admin')" (click)="delete(w.id)">Delete</button>
+        <button *ngIf="auth.hasRole('company_admin')" (click)="delete(w.id)">Delete</button>
       </li>
     </ul>
-    <button *ngIf="auth.hasRole('admin')" (click)="addWorker()">Add Worker</button>
+    <button *ngIf="auth.hasRole('company_admin')" (click)="addWorker()">Add Worker</button>
   `,
 })
 export class WorkerListComponent implements OnInit {

--- a/frontend/src/app/layout/layout.component.html
+++ b/frontend/src/app/layout/layout.component.html
@@ -9,16 +9,16 @@
       *ngIf="!auth.isAuthenticated()"
       routerLink="/signup/company"
       routerLinkActive="active"
-      >Owner Sign Up</a>
+      >Company Owner Sign Up</a>
     <button *ngIf="auth.isAuthenticated()" (click)="logout()">Logout</button>
-    <a *ngIf="auth.hasRole('admin')" routerLink="/users" routerLinkActive="active">Admin Panel</a>
+    <a *ngIf="auth.hasRole('company_admin')" routerLink="/users" routerLinkActive="active">Company Admin Panel</a>
     <a routerLink="/dashboard" routerLinkActive="active">Dashboard</a>
     <a routerLink="/customers" routerLinkActive="active">Customers</a>
     <a routerLink="/equipment" routerLinkActive="active">Equipment</a>
     <a routerLink="/jobs" routerLinkActive="active">Jobs</a>
     <a routerLink="/company/profile" routerLinkActive="active">Company</a>
     <a
-      *ngIf="auth.hasRole('owner') || auth.hasRole('admin')"
+      *ngIf="auth.hasRole('company_owner') || auth.hasRole('company_admin')"
       routerLink="/team"
       routerLinkActive="active"
       >Team</a>

--- a/frontend/src/app/users/user-detail.component.ts
+++ b/frontend/src/app/users/user-detail.component.ts
@@ -74,7 +74,7 @@ import { NotificationService } from '../notification.service';
         >
           {{ form.controls.phone.errors | json }}
         </div>
-        <div *ngIf="auth.hasRole('admin')">
+        <div *ngIf="auth.hasRole('company_admin')">
           <label>
             Role:
             <input formControlName="role" />

--- a/frontend/src/app/users/user-form.component.ts
+++ b/frontend/src/app/users/user-form.component.ts
@@ -41,7 +41,7 @@ import { NotificationService } from '../notification.service';
         Role:
         <select formControlName="role">
           <option value="customer">Customer</option>
-          <option value="owner">Owner</option>
+          <option value="company_owner">Company Owner</option>
           <option value="worker">Worker</option>
         </select>
       </label>
@@ -117,6 +117,6 @@ export class UserFormComponent {
   }
 
   get isOwner(): boolean {
-    return this.form.controls.role.value === 'owner';
+    return this.form.controls.role.value === 'company_owner';
   }
 }

--- a/frontend/src/app/users/user-list.component.ts
+++ b/frontend/src/app/users/user-list.component.ts
@@ -14,10 +14,10 @@ import { AuthService } from '../auth/auth.service';
     <ul>
       <li *ngFor="let u of users">
         <a [routerLink]="[u.id]">{{ u.username }}</a>
-        <button *ngIf="auth.hasRole('admin')" (click)="delete(u.id)">Delete</button>
+        <button *ngIf="auth.hasRole('company_admin')" (click)="delete(u.id)">Delete</button>
       </li>
     </ul>
-    <button *ngIf="auth.hasRole('admin')" (click)="addUser()">Add User</button>
+    <button *ngIf="auth.hasRole('company_admin')" (click)="addUser()">Add User</button>
   `,
 })
 export class UserListComponent implements OnInit {

--- a/frontend/src/app/users/users.routes.ts
+++ b/frontend/src/app/users/users.routes.ts
@@ -5,19 +5,19 @@ export const usersRoutes: Routes = [
   {
     path: '',
     canActivate: [roleGuard],
-    data: { roles: ['admin'] },
+    data: { roles: ['company_admin'] },
     loadComponent: () => import('./user-list.component').then((m) => m.UserListComponent),
   },
   {
     path: 'new',
     canActivate: [roleGuard],
-    data: { roles: ['admin'] },
+    data: { roles: ['company_admin'] },
     loadComponent: () => import('./user-form.component').then((m) => m.UserFormComponent),
   },
   {
     path: ':id',
     canActivate: [roleGuard],
-    data: { roles: ['admin'] },
+    data: { roles: ['company_admin'] },
     loadComponent: () => import('./user-detail.component').then((m) => m.UserDetailComponent),
   },
 ];


### PR DESCRIPTION
## Summary
- use CompanyAdmin and CompanyOwner enums for users
- rename seeding env vars and adjust references across backend and frontend
- add migration to rename user_role_enum values

## Testing
- `npm run migration:run` *(fails: connect ECONNREFUSED ::1:5432)*
- `npm test` (backend)
- `npm test` (frontend) *(fails: No binary for ChromeHeadless)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b22f22f63483258f50de8262d4170e