### PR TITLE
Mark seed users as verified

### DIFF
--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -69,6 +69,7 @@ async function main() {
           firstName: 'Master',
           lastName: 'User',
           phone: new PhoneNumber('555-000-0000'),
+          isVerified: true,
         },
         {
           conflictPaths: ['username'],
@@ -109,6 +110,7 @@ async function main() {
           firstName: 'Admin',
           lastName: 'User',
           phone: new PhoneNumber('555-000-0000'),
+          isVerified: true,
         },
         {
           conflictPaths: ['username'],


### PR DESCRIPTION
## Summary
- ensure master and company admin users are marked verified during seeding

## Testing
- `npm test`
- `DB_HOST=localhost DB_PORT=5432 DB_USERNAME=postgres DB_PASSWORD=postgres DB_NAME=rflandscaperpro JWT_SECRET=secret npm run seed` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b2392fd198832585da54752b84aef7