### PR TITLE
Use Email VO when looking up users by email

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -15,6 +15,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { validatePasswordStrength } from '../auth/password.util';
 import { UserCreationService } from './user-creation.service';
+import { Email } from './value-objects/email.vo';
 
 @Injectable()
 export class UsersService {
@@ -30,7 +31,9 @@ export class UsersService {
   }
 
   findByEmail(email: string): Promise<User | null> {
-    return this.usersRepository.findOne({ where: { email } });
+    return this.usersRepository.findOne({
+      where: { email: new Email(email) },
+    });
   }
 
   findById(id: number, companyId?: number): Promise<User | null> {


### PR DESCRIPTION
## Summary
- import Email value object into UsersService
- wrap findByEmail lookups with Email to normalize addresses

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2392a90688325bfb0eca98cdc77bc