### PR TITLE
chore(seed): allow overriding seed email addresses

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -63,6 +63,10 @@ LOG_LEVEL=debug
 # REMOTE_LOG_PATH=/
 ```
 
+To customize the accounts created by the seed script, set
+`COMPANY_ADMIN_*`, `MASTER_*`, and `SAMPLE_CUSTOMER_EMAIL` in your environment
+file.
+
 If no SMTP credentials are defined, the application falls back to an Ethereal test
 account and logs preview URLs for emails.
 
@@ -79,9 +83,10 @@ createdb rflandscaperpro
 npm run migration:run
 
 # Seed initial data (creates company admin and master users and sample customer)
-# Set COMPANY_ADMIN_* and MASTER_* env vars to control credentials. Passwords can
-# be omitted to auto-generate secure values. This script is intended for
-# local development only and will automatically skip execution when
+# Set COMPANY_ADMIN_* and MASTER_* env vars to control credentials,
+# and SAMPLE_CUSTOMER_EMAIL to specify the seeded customer's email.
+# Passwords can be omitted to auto-generate secure values. This script is
+# intended for local development only and will automatically skip execution when
 # `NODE_ENV=production`.
 npm run seed:dev
 

--- a/backend/env.example
+++ b/backend/env.example
@@ -38,6 +38,9 @@ MASTER_USERNAME=master
 MASTER_EMAIL=master@example.com
 MASTER_PASSWORD=changeme
 
+# Sample customer email for seed data
+SAMPLE_CUSTOMER_EMAIL=customer@example.com
+
 # Swagger Documentation
 SWAGGER_USER=admin
 SWAGGER_PASSWORD=admin

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -158,7 +158,8 @@ async function main() {
       );
 
       // --- Sample customer ---
-      const customerEmail = 'customer@example.com';
+      const customerEmail =
+        process.env.SAMPLE_CUSTOMER_EMAIL ?? 'customer@example.com';
       await customerRepo.upsert(
         {
           name: 'John Doe',


### PR DESCRIPTION
## Summary
- allow overriding seeded customer email via `SAMPLE_CUSTOMER_EMAIL`
- document seeding email configuration in README and env example

## Testing
- `npm test`
- `npm run lint` *(fails: 7 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b23a4eed5c832599ff7c685477f3bc