### PR TITLE
Add MailHog email support for development

### DIFF
--- a/backend/docker-compose.override.yml
+++ b/backend/docker-compose.override.yml
@@ -9,6 +9,8 @@ services:
       - .env.development
     environment:
       - NODE_ENV=development
+      - MAILHOG_HOST=mailhog
+      - MAILHOG_PORT=1025
   db:
     image: postgres:14
     container_name: rflandscaperpro_db

--- a/backend/docker-compose.override.yml
+++ b/backend/docker-compose.override.yml
@@ -31,5 +31,12 @@ services:
     ports:
       - "9090:9090"
 
+  mailhog:
+    image: mailhog/mailhog
+    container_name: rflandscaperpro_mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+
 volumes:
   postgres_data:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -7,3 +7,10 @@ services:
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
+
+  mailhog:
+    image: mailhog/mailhog
+    container_name: rflandscaperpro_mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -7,10 +7,3 @@ services:
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
-
-  mailhog:
-    image: mailhog/mailhog
-    container_name: rflandscaperpro_mailhog
-    ports:
-      - "1025:1025"
-      - "8025:8025"

--- a/backend/src/common/email/email.service.ts
+++ b/backend/src/common/email/email.service.ts
@@ -27,12 +27,16 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
   );
 
   async onModuleInit(): Promise<void> {
+    const hasMailhog =
+      !!process.env.MAILHOG_HOST || !!process.env.MAILHOG_PORT;
     this.driver =
       process.env.NODE_ENV === 'production'
         ? 'smtp'
-        : process.env.SMTP_USER && process.env.SMTP_PASS
+        : hasMailhog
           ? 'smtp'
-          : 'ethereal';
+          : process.env.SMTP_USER && process.env.SMTP_PASS
+            ? 'smtp'
+            : 'ethereal';
     this.logger.log(`Initializing EmailService with driver: ${this.driver}`);
 
     if (this.driver === 'smtp') {


### PR DESCRIPTION
## Summary
- add MailHog service to backend docker compose
- configure development compose to route email through MailHog
- detect MailHog settings in EmailService and SMTP transport

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b23a76dd508325b8329efd8be3e57d