### PR TITLE
feat: add Grafana monitoring

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -16,7 +16,7 @@ A robust and scalable NestJS backend API for landscaping business management. It
 ### Technical Features
 - Performance: Optimized database queries with strategic indexing.
 - Security: Enhanced password validation, input sanitization, error handling.
-- Monitoring: Prometheus metrics, structured logging, request tracking.
+- Monitoring: Prometheus metrics, Grafana dashboards, structured logging, request tracking.
 - Testing: Comprehensive test coverage with Jest.
 - Documentation: Interactive Swagger API documentation.
 
@@ -140,6 +140,11 @@ Successful requests return a `200 OK` with a JSON body:
 
 Infrastructure tools and load balancers can poll this route to verify that
 the service is running and ready to receive traffic.
+
+### 6. Grafana Dashboard
+- Dashboard: http://localhost:3001
+- Default login: `admin` / `admin` (prompt to change on first login)
+- Prometheus metrics are preconfigured as the default data source.
 
 ## Project Structure
 ```

--- a/backend/docker-compose.override.yml
+++ b/backend/docker-compose.override.yml
@@ -31,6 +31,17 @@ services:
     ports:
       - "9090:9090"
 
+  grafana:
+    image: grafana/grafana
+    container_name: rflandscaperpro_grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3001:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana-datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
+
   mailhog:
     image: mailhog/mailhog
     container_name: rflandscaperpro_mailhog
@@ -40,3 +51,4 @@ services:
 
 volumes:
   postgres_data:
+  grafana_data:

--- a/backend/grafana-datasource.yml
+++ b/backend/grafana-datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true


### PR DESCRIPTION
## Summary
- add Grafana container for Prometheus metrics
- configure Grafana datasource for Prometheus
- document Grafana dashboard access

## Testing
- `npm run lint` (fails: Unsafe return of a value of type `any`)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b243bd61648325a41a270dc126ae76