### PR TITLE
feat: add log level metrics

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -16,7 +16,7 @@ A robust and scalable NestJS backend API for landscaping business management. It
 ### Technical Features
 - Performance: Optimized database queries with strategic indexing.
 - Security: Enhanced password validation, input sanitization, error handling.
-- Monitoring: Prometheus metrics, structured logging, request tracking.
+- Monitoring: Prometheus metrics, structured logging, request tracking. Includes per-log-level log counters.
 - Testing: Comprehensive test coverage with Jest.
 - Documentation: Interactive Swagger API documentation.
 
@@ -123,6 +123,16 @@ npm run start:prod
 - Health Check: http://localhost:3000/api/health
 - Metrics: http://localhost:3000/api/metrics
 - Production Base URL: https://rflandscaperpro.com/api
+
+#### Log Metrics
+
+Counters track how many log messages are emitted at each level and are exposed on the metrics endpoint:
+
+- `log_error_total`
+- `log_warn_total`
+- `log_info_total`
+- `log_debug_total`
+- `log_verbose_total`
 
 #### Health Check
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -30,7 +30,7 @@ import { HealthModule } from './health/health.module';
 
 @Module({
   imports: [
-    PrometheusModule.register(),
+    PrometheusModule.register({ global: true }),
     LoggerModule,
     MetricsModule,
     HealthModule,

--- a/backend/src/logger/logger.module.ts
+++ b/backend/src/logger/logger.module.ts
@@ -1,5 +1,8 @@
-import { WinstonModule } from 'nest-winston';
+import { Module, Injectable, Inject, LoggerService } from '@nestjs/common';
+import { WinstonModule, WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import * as winston from 'winston';
+import { makeCounterProvider, InjectMetric } from '@willsoto/nestjs-prometheus';
+import { Counter } from 'prom-client';
 
 const transports: winston.transport[] = [
   new winston.transports.Console(),
@@ -18,7 +21,72 @@ if (process.env.REMOTE_LOG_HOST) {
   );
 }
 
-export const LoggerModule = WinstonModule.forRoot({
-  level: process.env.LOG_LEVEL || 'info',
-  transports,
-});
+const LOG_LEVELS = ['error', 'warn', 'info', 'debug', 'verbose'] as const;
+
+@Injectable()
+class PrometheusLogger implements LoggerService {
+  private readonly counters: Record<
+    (typeof LOG_LEVELS)[number],
+    Counter<string>
+  >;
+
+  constructor(
+    @Inject('BASE_LOGGER') private readonly logger: LoggerService,
+    @InjectMetric('log_error_total') errorCounter: Counter<string>,
+    @InjectMetric('log_warn_total') warnCounter: Counter<string>,
+    @InjectMetric('log_info_total') infoCounter: Counter<string>,
+    @InjectMetric('log_debug_total') debugCounter: Counter<string>,
+    @InjectMetric('log_verbose_total') verboseCounter: Counter<string>,
+  ) {
+    this.counters = {
+      error: errorCounter,
+      warn: warnCounter,
+      info: infoCounter,
+      debug: debugCounter,
+      verbose: verboseCounter,
+    };
+  }
+
+  log(message: any, ...optionalParams: any[]) {
+    this.counters.info.inc();
+    this.logger.log(message, ...optionalParams);
+  }
+  error(message: any, ...optionalParams: any[]) {
+    this.counters.error.inc();
+    this.logger.error(message, ...optionalParams);
+  }
+  warn(message: any, ...optionalParams: any[]) {
+    this.counters.warn.inc();
+    this.logger.warn(message, ...optionalParams);
+  }
+  debug(message: any, ...optionalParams: any[]) {
+    this.counters.debug.inc();
+    this.logger.debug(message, ...optionalParams);
+  }
+  verbose(message: any, ...optionalParams: any[]) {
+    this.counters.verbose.inc();
+    this.logger.verbose(message, ...optionalParams);
+  }
+}
+
+@Module({
+  imports: [
+    WinstonModule.forRoot({
+      level: process.env.LOG_LEVEL || 'info',
+      transports,
+    }),
+  ],
+  providers: [
+    ...LOG_LEVELS.map((level) =>
+      makeCounterProvider({
+        name: `log_${level}_total`,
+        help: `Total number of ${level} logs`,
+      }),
+    ),
+    { provide: 'BASE_LOGGER', useExisting: WINSTON_MODULE_NEST_PROVIDER },
+    PrometheusLogger,
+    { provide: WINSTON_MODULE_NEST_PROVIDER, useExisting: PrometheusLogger },
+  ],
+  exports: [WINSTON_MODULE_NEST_PROVIDER],
+})
+export class LoggerModule {}


### PR DESCRIPTION
## Summary
- add Prometheus counters for each log level and wrap Winston logger to increment them
- expose log counters via global Prometheus module
- document log metrics in backend README

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe return of a value of type `any` in test/auth-login.e2e-spec.ts)*
- `npx eslint src/logger/logger.module.ts src/app.module.ts --fix`

------
https://chatgpt.com/codex/tasks/task_e_68b243dc6cfc8325ba97d6a1e5db3560