### PR TITLE
docs: add monitoring and logging section

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -316,13 +316,11 @@ npm run seed:drop:dev
 ## Monitoring & Logging
 
 ### Local Metrics
-- Start Prometheus together with the app using `npm run dev:compose`  
-  (or `docker compose -f docker-compose.yml -f docker-compose.override.yml up`) to bring up
-  the `prometheus` service.
-- Prometheus UI is available at `http://localhost:9090` and the application's metric endpoint
-  is exposed at `http://localhost:3000/metrics`.
-- For dashboarding, launch Grafana locally with  
-  `docker run -d --name grafana -p 3001:3000 grafana/grafana` and add Prometheus as a data source.
+- Start Prometheus and Grafana together with the app using `npm run dev:compose`
+  (or `docker compose -f docker-compose.yml -f docker-compose.override.yml up`), which brings up
+  the `prometheus` and `grafana` services.
+- Prometheus UI is available at `http://localhost:9090`, Grafana dashboards at `http://localhost:3001`,
+  and the application's metric endpoint is exposed at `http://localhost:3000/metrics`.
 
 ### Remote Logging
 - Configure remote log forwarding by setting:
@@ -332,9 +330,7 @@ npm run seed:drop:dev
   - `REMOTE_LOG_PATH` – optional HTTP path (defaults to `/`).
 - When `REMOTE_LOG_HOST` is unset, logs stay local only.
 
-### Production Services
-- For hosted metrics and logs consider [Grafana Cloud](https://grafana.com/products/cloud/),
-  [Datadog](https://www.datadoghq.com/), or [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/).
+For hosted metrics and logs consider [Grafana Cloud](https://grafana.com/products/cloud/), [Datadog](https://www.datadoghq.com/), or [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/).
 
 ## Testing Strategy
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -313,6 +313,29 @@ npm run seed:drop:dev
 - Request and response logging and tracking
 - Performance profiling and optimization
 
+## Monitoring & Logging
+
+### Local Metrics
+- Start Prometheus together with the app using `npm run dev:compose`  
+  (or `docker compose -f docker-compose.yml -f docker-compose.override.yml up`) to bring up
+  the `prometheus` service.
+- Prometheus UI is available at `http://localhost:9090` and the application's metric endpoint
+  is exposed at `http://localhost:3000/metrics`.
+- For dashboarding, launch Grafana locally with  
+  `docker run -d --name grafana -p 3001:3000 grafana/grafana` and add Prometheus as a data source.
+
+### Remote Logging
+- Configure remote log forwarding by setting:
+  - `LOG_LEVEL` – logging verbosity (`debug`, `info`, `warn`, `error`).
+  - `REMOTE_LOG_HOST` – hostname of the remote log collector.
+  - `REMOTE_LOG_PORT` – port of the collector.
+  - `REMOTE_LOG_PATH` – optional HTTP path (defaults to `/`).
+- When `REMOTE_LOG_HOST` is unset, logs stay local only.
+
+### Production Services
+- For hosted metrics and logs consider [Grafana Cloud](https://grafana.com/products/cloud/),
+  [Datadog](https://www.datadoghq.com/), or [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/).
+
 ## Testing Strategy
 
 ### Test Coverage


### PR DESCRIPTION
## Summary
- document how to run Prometheus and Grafana
- explain `/metrics` endpoint and remote log forwarding
- list env vars and link to hosted monitoring services

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe return of a value of type `any`)*

------
https://chatgpt.com/codex/tasks/task_e_68b24410d5bc8325a92223b209e8d2bb