### PR TITLE
fix: type refresh token mock in auth login e2e test

### DIFF
--- a/backend/test/auth-login.e2e-spec.ts
+++ b/backend/test/auth-login.e2e-spec.ts
@@ -16,6 +16,7 @@ import { VERIFICATION_TOKEN_REPOSITORY } from '../src/auth/repositories/verifica
 import { COMPANY_MEMBERSHIP_REPOSITORY } from '../src/auth/repositories/company-membership.repository';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { EmailService } from '../src/common/email';
+import { RefreshToken } from '../src/auth/refresh-token.entity';
 
 describe('Auth login endpoint (e2e)', () => {
   let app: INestApplication<App>;
@@ -51,7 +52,12 @@ describe('Auth login endpoint (e2e)', () => {
         {
           provide: REFRESH_TOKEN_REPOSITORY,
           useValue: {
-            create: jest.fn().mockImplementation((data) => data),
+            create: jest
+              .fn()
+              .mockImplementation(
+                (data: Partial<RefreshToken>): RefreshToken =>
+                  data as RefreshToken,
+              ),
             save: jest.fn(),
           },
         },


### PR DESCRIPTION
## Summary
- type the mock for `REFRESH_TOKEN_REPOSITORY.create` in the auth login e2e test to avoid returning `any`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2478cc3b48325b1f18a6396321067