### PR TITLE
fix: guard optional logger methods

### DIFF
--- a/backend/src/logger/logger.module.ts
+++ b/backend/src/logger/logger.module.ts
@@ -61,11 +61,11 @@ class PrometheusLogger implements LoggerService {
   }
   debug(message: any, ...optionalParams: any[]) {
     this.counters.debug.inc();
-    this.logger.debug(message, ...optionalParams);
+    this.logger.debug?.(message, ...optionalParams);
   }
   verbose(message: any, ...optionalParams: any[]) {
     this.counters.verbose.inc();
-    this.logger.verbose(message, ...optionalParams);
+    this.logger.verbose?.(message, ...optionalParams);
   }
 }
 


### PR DESCRIPTION
## Summary
- safely invoke optional `debug` and `verbose` methods in custom Prometheus logger

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b24ac2b5348325b898cfcca2b897fb