### PR TITLE
chore: centralize docker compose configuration

### DIFF
--- a/development.ps1
+++ b/development.ps1
@@ -1,16 +1,4 @@
 #!/usr/bin/env pwsh
 $ErrorActionPreference = "Stop"
-$network = "rflandscaperpro"
-# Check if Docker network exists; create if not
-& docker network inspect $network *> $null
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "Creating Docker network '$network'..."
-    & docker network create $network | Out-Null
-}
-$services = @("db", "logging", "mailhog", "backend", "frontend", "prometheus", "grafana")
-foreach ($dir in $services) {
-    Write-Host "Starting $dir..."
-    Push-Location $dir
-    & docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
-    Pop-Location
-}
+
+docker compose up -d

--- a/development.sh
+++ b/development.sh
@@ -1,13 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-NETWORK=rflandscaperpro
-if ! docker network inspect "$NETWORK" >/dev/null 2>&1; then
-  docker network create "$NETWORK"
-fi
-
-services=(db logging mailhog backend frontend prometheus grafana)
-for dir in "${services[@]}"; do
-  echo "Starting $dir..."
-  (cd "$dir" && docker compose -f docker-compose.yml -f docker-compose.override.yml up -d)
-done
+docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,95 @@
+services:
+  db:
+    container_name: db
+    image: postgres:14
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: rflandscaperpro
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - rflandscaperpro
+
+  logging:
+    container_name: logserver
+    image: fluent/fluentd:v1.16-debian
+    volumes:
+      - ./logging/fluentd.conf:/fluentd/etc/fluent.conf:ro
+    ports:
+      - "9880:9880"
+    networks:
+      - rflandscaperpro
+
+  mailhog:
+    container_name: mailhog
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    networks:
+      - rflandscaperpro
+
+  backend:
+    container_name: backend
+    image: rflandscaperpro/backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./backend:/app
+      - /app/node_modules
+    env_file:
+      - ./backend/.env.development
+    environment:
+      - NODE_ENV=development
+    ports:
+      - "3000:3000"
+    networks:
+      - rflandscaperpro
+
+  frontend:
+    container_name: frontend
+    image: rflandscaperpro/frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    ports:
+      - "4200:4200"
+    environment:
+      - NODE_ENV=development
+    networks:
+      - rflandscaperpro
+
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    networks:
+      - rflandscaperpro
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
+    ports:
+      - "3001:3000"
+    networks:
+      - rflandscaperpro
+
+volumes:
+  postgres_data:
+  grafana_data:
+
+networks:
+  rflandscaperpro:


### PR DESCRIPTION
## Summary
- add a root `docker-compose.yml` for development that inlines backend and frontend overrides
- restore service-level `docker-compose.yml` and `docker-compose.override.yml` files for backend, frontend, db, logging, mailhog, prometheus, and grafana
- drop redundant root `docker-compose.override.yml`

## Testing
- `docker-compose -f docker-compose.yml config`
- `for dir in backend frontend db logging mailhog prometheus grafana; do docker-compose -f $dir/docker-compose.yml -f $dir/docker-compose.override.yml config; done`


------
https://chatgpt.com/codex/tasks/task_e_68b256aa1b808325825dfc437a511f30