### PR TITLE
Add teardown scripts for Docker compose dev stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,12 @@ To launch the full stack for local work, use the helper scripts in the repositor
 
 These scripts ensure the `rflandscaperpro` Docker network exists and start the database, backend, frontend, and supporting tools using `docker compose`.
 
+When you are finished with the stack, shut everything down with the teardown scripts:
+
+- **macOS/Linux**: `./down.sh`
+- **Windows PowerShell**: `pwsh -File .\down.ps1`
+
+Pass `--prune` to either script to remove the `rflandscaperpro` Docker network after the containers stop.
+
 > **PowerShell note:** Windows may block script execution. Temporarily bypass the policy with `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass`. Run the script from the repository root, using Windows path separators (for example, `.\development.ps1`).
 

--- a/down.ps1
+++ b/down.ps1
@@ -1,0 +1,8 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+docker compose down
+
+if ($args -contains "--prune") {
+  docker network prune -f
+}

--- a/down.sh
+++ b/down.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+docker compose down
+
+if [[ "$1" == "--prune" ]]; then
+  docker network prune -f
+fi


### PR DESCRIPTION
## Summary
- add `down.sh` and `down.ps1` to stop all services and optionally prune the Docker network
- document teardown workflow in README

## Testing
- `./down.sh --prune` *(fails: docker: command not found)*
- `pwsh -File down.ps1 --prune` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2598f4bfc8325b45f1fc7a9246df8