### PR TITLE
feat: display service endpoints in dev scripts

### DIFF
--- a/development.ps1
+++ b/development.ps1
@@ -2,3 +2,15 @@
 $ErrorActionPreference = "Stop"
 
 docker compose up -d
+
+Write-Host @" 
+Services are available at the following endpoints:
+  Frontend:   http://localhost:4200
+  Backend:    http://localhost:3000
+  Swagger UI: http://localhost:3000/docs
+  Log Server: http://localhost:9880
+  Mailhog UI: http://localhost:8025 (SMTP: localhost:1025)
+  Database:   localhost:5432
+  Prometheus: http://localhost:9090
+  Grafana:    http://localhost:3001
+"@

--- a/development.sh
+++ b/development.sh
@@ -2,3 +2,15 @@
 set -e
 
 docker compose up -d
+
+cat <<'EOF'
+Services are available at the following endpoints:
+  Frontend:   http://localhost:4200
+  Backend:    http://localhost:3000
+  Swagger UI: http://localhost:3000/docs
+  Log Server: http://localhost:9880
+  Mailhog UI: http://localhost:8025 (SMTP: localhost:1025)
+  Database:   localhost:5432
+  Prometheus: http://localhost:9090
+  Grafana:    http://localhost:3001
+EOF


### PR DESCRIPTION
## Summary
- show URLs for frontend, backend, Swagger UI, log server, Mailhog, database, Prometheus and Grafana when starting development environment

## Testing
- `bash development.sh` *(fails: docker command not found)*
- `pwsh development.ps1` *(fails: pwsh command not found)*
- `bash -c 'docker(){ :; }; source development.sh'`


------
https://chatgpt.com/codex/tasks/task_e_68b25c167b2c8325b592f4adb3054b59