### PR TITLE
refactor: enforce validation consistency on update DTOs

### DIFF
--- a/backend/src/companies/dto/update-company.dto.ts
+++ b/backend/src/companies/dto/update-company.dto.ts
@@ -1,19 +1,4 @@
-import { IsEmail, IsOptional, IsString } from 'class-validator';
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCompanyDto } from './create-company.dto';
 
-export class UpdateCompanyDto {
-  @IsOptional()
-  @IsString()
-  name?: string;
-
-  @IsOptional()
-  @IsString()
-  address?: string;
-
-  @IsOptional()
-  @IsString()
-  phone?: string;
-
-  @IsOptional()
-  @IsEmail()
-  email?: string;
-}
+export class UpdateCompanyDto extends PartialType(CreateCompanyDto) {}

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -1,41 +1,17 @@
-import { IsOptional, IsString } from 'class-validator';
+import { PartialType, OmitType } from '@nestjs/mapped-types';
+import { CreateUserDto } from './create-user.dto';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { Email } from '../value-objects/email.vo';
-import { PhoneNumber } from '../value-objects/phone-number.vo';
 
-export class UpdateUserDto {
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsString()
-  username?: string;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsString()
-  password?: string;
-
+export class UpdateUserDto extends PartialType(
+  OmitType(CreateUserDto, ['role', 'company', 'isVerified', 'email'] as const),
+) {
   @ApiPropertyOptional()
   @IsOptional()
   @Transform(({ value }: { value: string | undefined }) =>
     value ? new Email(value) : undefined,
   )
   email?: Email;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsString()
-  firstName?: string;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsString()
-  lastName?: string;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @Transform(({ value }: { value: string | undefined }) =>
-    value ? new PhoneNumber(value) : undefined,
-  )
-  phone?: PhoneNumber;
 }


### PR DESCRIPTION
## Summary
- refactor UpdateCompanyDto to extend PartialType of CreateCompanyDto
- refactor UpdateUserDto to leverage PartialType while omitting restricted fields
- confirm global ValidationPipe uses whitelist, forbidNonWhitelisted, and transform

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b268960a6c832582ee754bac8e1a7e