### PR TITLE
ci: add Postgres-backed test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,33 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rflandscaperpro
+        options: >-
+          --health-cmd "pg_isready"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
+      fail-fast: false
       matrix:
-        project: [backend, frontend]
+        include:
+          - project: backend
+            test: unit
+            command: npm test
+          - project: backend
+            test: e2e
+            command: npm run test:e2e
+          - project: frontend
+            test: unit
+            command: npm test
     defaults:
       run:
         working-directory: ${{ matrix.project }}
@@ -43,9 +67,15 @@ jobs:
           cache: npm
           cache-dependency-path: ${{ matrix.project }}/package-lock.json
       - run: npm ci
-      - run: npm test --if-present
+      - run: ${{ matrix.command }}
         env:
           CI: true
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_USERNAME: postgres
+          DB_PASSWORD: postgres
+          DB_NAME: rflandscaperpro
+          JWT_SECRET: testsecret
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- run backend unit, backend e2e, and frontend unit tests in CI using a matrix
- start PostgreSQL service for tests

## Testing
- `npm test --prefix backend`
- `npm run test:e2e --prefix backend` (fails: missing env vars, assertion errors)
- `npm test --prefix frontend` (fails: Chromium not installed)


------
https://chatgpt.com/codex/tasks/task_e_68b26a4b93e0832588872f4e5a6cbc5a