### PR TITLE
feat(frontend): add HTTP error interceptor with toast notifications

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -8,6 +8,7 @@ import { provideRouter, Router } from '@angular/router';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { authInterceptor } from './auth.interceptor';
+import { httpErrorInterceptor } from './http-error.interceptor';
 import { routes } from './app.routes';
 import { ApiService } from './api.service';
 import { firstValueFrom } from 'rxjs';
@@ -28,7 +29,7 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
-    provideHttpClient(withInterceptors([authInterceptor])),
+    provideHttpClient(withInterceptors([authInterceptor, httpErrorInterceptor])),
     {
       provide: APP_INITIALIZER,
       useFactory: backendHealthInitializer,

--- a/frontend/src/app/companies/company-profile.component.ts
+++ b/frontend/src/app/companies/company-profile.component.ts
@@ -4,7 +4,7 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { CompanyService } from './company.service';
 import { Company } from './company.model';
 import { ErrorService } from '../error.service';
-import { NotificationService } from '../notification.service';
+import { ToasterService } from '../toaster.service';
 
 @Component({
   selector: 'app-company-profile',
@@ -67,7 +67,7 @@ import { NotificationService } from '../notification.service';
 export class CompanyProfileComponent implements OnInit {
   private readonly companyService = inject(CompanyService);
   private readonly errorService = inject(ErrorService);
-  private readonly notifications = inject(NotificationService);
+  private readonly notifications = inject(ToasterService);
   private fb = inject(FormBuilder);
   company?: Company;
 

--- a/frontend/src/app/customers/customer-form.component.ts
+++ b/frontend/src/app/customers/customer-form.component.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { CustomerService } from './customer.service';
 import { Customer } from './customer.model';
 import { ErrorService } from '../error.service';
-import { NotificationService } from '../notification.service';
+import { ToasterService } from '../toaster.service';
 
 @Component({
   selector: 'app-customer-form',
@@ -36,7 +36,7 @@ export class CustomerFormComponent implements OnInit {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private errorService = inject(ErrorService);
-  private notifications = inject(NotificationService);
+  private notifications = inject(ToasterService);
 
   customerId?: number;
 

--- a/frontend/src/app/equipment/equipment-detail.component.ts
+++ b/frontend/src/app/equipment/equipment-detail.component.ts
@@ -4,7 +4,7 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { EquipmentService, Equipment } from './equipment.service';
 import { ErrorService } from '../error.service';
-import { NotificationService } from '../notification.service';
+import { ToasterService } from '../toaster.service';
 
 @Component({
   selector: 'app-equipment-detail',
@@ -48,7 +48,7 @@ export class EquipmentDetailComponent {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private errorService = inject(ErrorService);
-  private notifications = inject(NotificationService);
+  private notifications = inject(ToasterService);
   private fb = inject(FormBuilder);
 
   equipmentId?: number;

--- a/frontend/src/app/error.service.ts
+++ b/frontend/src/app/error.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, inject } from '@angular/core';
-import { NotificationService } from './notification.service';
+import { ToasterService } from './toaster.service';
 import { LoggerService } from './logger.service';
 
 @Injectable({ providedIn: 'root' })
 export class ErrorService {
-  private readonly notifier = inject(NotificationService);
+  private readonly notifier = inject(ToasterService);
   private readonly logger = inject(LoggerService);
 
   show(message: string): void {

--- a/frontend/src/app/http-error-messages.ts
+++ b/frontend/src/app/http-error-messages.ts
@@ -1,0 +1,7 @@
+export const HTTP_ERROR_MESSAGES: Record<number, string> = {
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  409: 'Conflict',
+  422: 'Unprocessable entity',
+  500: 'Server error',
+};

--- a/frontend/src/app/http-error.interceptor.ts
+++ b/frontend/src/app/http-error.interceptor.ts
@@ -1,0 +1,19 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { catchError, throwError } from 'rxjs';
+import { ErrorService } from './error.service';
+import { HTTP_ERROR_MESSAGES } from './http-error-messages';
+
+export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
+  const errorService = inject(ErrorService);
+
+  return next(req).pipe(
+    catchError((error: unknown) => {
+      if (error instanceof HttpErrorResponse) {
+        const message = HTTP_ERROR_MESSAGES[error.status] ?? 'An unexpected error occurred';
+        errorService.show(message);
+      }
+      return throwError(() => error);
+    }),
+  );
+};

--- a/frontend/src/app/jobs/job-editor.component.ts
+++ b/frontend/src/app/jobs/job-editor.component.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, RouterModule, Router } from '@angular/router';
 import { JobsService } from './jobs.service';
 import { Job } from './job.model';
 import { ErrorService } from '../error.service';
-import { NotificationService } from '../notification.service';
+import { ToasterService } from '../toaster.service';
 
 @Component({
   selector: 'app-job-editor',
@@ -18,7 +18,7 @@ export class JobEditorComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private errorService = inject(ErrorService);
-  private notifications = inject(NotificationService);
+  private notifications = inject(ToasterService);
   private fb = inject(FormBuilder);
   job: Job = { title: '', customerId: 1 };
 

--- a/frontend/src/app/toaster.service.ts
+++ b/frontend/src/app/toaster.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
-export class NotificationService {
+export class ToasterService {
   show(message: string, duration = 3000): void {
     if (typeof document === 'undefined') {
       return;

--- a/frontend/src/app/users/user-detail.component.ts
+++ b/frontend/src/app/users/user-detail.component.ts
@@ -6,7 +6,7 @@ import { UserService } from './user.service';
 import { User } from './user.model';
 import { AuthService } from '../auth/auth.service';
 import { ErrorService } from '../error.service';
-import { NotificationService } from '../notification.service';
+import { ToasterService } from '../toaster.service';
 
 @Component({
   selector: 'app-user-detail',
@@ -97,7 +97,7 @@ export class UserDetailComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   protected readonly auth = inject(AuthService);
   private readonly errorService = inject(ErrorService);
-  private readonly notifications = inject(NotificationService);
+  private readonly notifications = inject(ToasterService);
   private fb = inject(FormBuilder);
   user?: User;
 

--- a/frontend/src/app/users/user-form.component.ts
+++ b/frontend/src/app/users/user-form.component.ts
@@ -4,7 +4,7 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { UserService } from './user.service';
 import { ErrorService } from '../error.service';
-import { NotificationService } from '../notification.service';
+import { ToasterService } from '../toaster.service';
 
 @Component({
   selector: 'app-user-form',
@@ -72,7 +72,7 @@ export class UserFormComponent {
   private userService = inject(UserService);
   private router = inject(Router);
   private errorService = inject(ErrorService);
-  private notifications = inject(NotificationService);
+  private notifications = inject(ToasterService);
 
   /* eslint-disable @typescript-eslint/unbound-method */
   form = this.fb.nonNullable.group({


### PR DESCRIPTION
## Summary
- add ToasterService for snack-bar style messages
- surface common HTTP errors via new interceptor
- register error interceptor alongside auth

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b270d5429c8325a5ee2420566cdcbd