### PR TITLE
Fix e2e shared module resolution

### DIFF
--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -7,7 +7,7 @@
     "^.+\\.(t|j)s$": "ts-jest"
   },
   "moduleNameMapper": {
-    "^@rflp/shared$": "<rootDir>/../shared/src",
+    "^@rflp/shared$": "<rootDir>/../shared/src/index",
     "^@rflp/shared/(.*)$": "<rootDir>/../shared/src/$1"
   }
 }


### PR DESCRIPTION
## Summary
- map `@rflp/shared` to the package index in Jest e2e config

## Testing
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68b2731f7e008325997d78f137f5506e