### PR TITLE
Fix server startup error handling for SSR build

### DIFF
--- a/frontend/src/server.ts
+++ b/frontend/src/server.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/ssr/node';
 import express from 'express';
 import { join } from 'node:path';
-import winston from 'winston';
+import * as winston from 'winston';
 
 const browserDistFolder = join(import.meta.dirname, '../browser');
 
@@ -57,10 +57,14 @@ app.use((req, res, next) => {
  */
 if (isMainModule(import.meta.url)) {
   const port = process.env['PORT'] || 4000;
-  app.listen(port, (error) => {
+  app.listen(port, (error?: unknown) => {
     if (error) {
-      logger.error('Server startup error', { message: error.message, stack: error.stack });
-      throw error;
+      const err =
+        error instanceof Error
+          ? error
+          : new Error(typeof error === 'string' ? error : JSON.stringify(error));
+      logger.error('Server startup error', { message: err.message, stack: err.stack });
+      throw err;
     }
     logger.info(`Node Express server listening on http://localhost:${port}`, {
       port,


### PR DESCRIPTION
## Summary
- ensure server startup always throws an `Error` instance
- import winston via namespace and safely stringify non-Error values

## Testing
- `npx eslint src/server.ts`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68b30f0816648325868e7687808e3f16