### PR TITLE
fix(shared): resolve module import paths in dev

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -4,6 +4,6 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "tsConfigPath": "tsconfig.build.json"
+    "tsConfigPath": "tsconfig.json"
   }
 }


### PR DESCRIPTION
## Summary
- use tsconfig.json for Nest's compiler to load shared source during development

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3359503f48325982e8716aa06e8ca