### PR TITLE
fix: correct Dockerfile app paths

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,7 +28,8 @@ COPY backend/package*.json ./
 RUN npm ci --include=dev
 
 # Copy source code
-COPY backend ./
+# Copy backend sources directly into /app
+COPY backend/ ./
 COPY shared /shared
 
 # Build the app

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -17,7 +17,8 @@ COPY backend/package*.json ./
 RUN npm install
 
 # ---- Copy application code ----
-COPY backend ./
+# Copy the backend source directly into the workdir rather than nesting it
+COPY backend/ ./
 COPY shared /shared
 
 # ---- Expose application port ----

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,8 @@ COPY frontend/package*.json ./
 RUN npm ci
 
 # Copy source code
-COPY frontend ./
+# Copy frontend sources directly into /app
+COPY frontend/ ./
 COPY shared /shared
 
 # Build the Angular app

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -16,7 +16,8 @@ COPY frontend/package*.json ./
 RUN npm install
 
 # ---- Copy application code ----
-COPY frontend ./
+# Copy the frontend source directly into the workdir rather than nesting it
+COPY frontend/ ./
 COPY shared /shared
 
 # ---- Expose application port ----


### PR DESCRIPTION
## Summary
- ensure backend Dockerfiles copy source code directly into /app
- ensure frontend Dockerfiles copy source code directly into /app

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend` *(fails: No binary for ChromeHeadless)*
- `docker build -f backend/Dockerfile.dev .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b35f36b9588325acaecacdfb6e1e77