### PR TITLE
refactor: centralize TypeORM configuration

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,7 +8,7 @@ import {
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import * as Joi from 'joi';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { join } from 'path';
+import typeOrmConfig from './database/typeorm.config';
 import { CustomersModule } from './customers/customers.module';
 import { JobsModule } from './jobs/jobs.module';
 import { EquipmentModule } from './equipment/equipment.module';
@@ -78,29 +78,15 @@ import { HealthModule } from './health/health.module';
       }),
     }),
     TypeOrmModule.forRootAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService, WINSTON_MODULE_NEST_PROVIDER],
-      useFactory: (config: ConfigService, logger: LoggerService) => {
-        const isProduction = config.get<string>('NODE_ENV') === 'production';
+      inject: [WINSTON_MODULE_NEST_PROVIDER],
+      useFactory: (logger: LoggerService) => {
+        const isProduction = process.env.NODE_ENV === 'production';
         logger.log(
           `Connecting to DB in ${isProduction ? 'production' : 'development'} mode`,
         );
         return {
-          type: 'postgres',
-          host: config.get<string>('DB_HOST'),
-          port: Number(config.get('DB_PORT')) || 5432,
-          username: config.get<string>('DB_USERNAME'),
-          password: config.get<string>('DB_PASSWORD'),
-          database: config.get<string>('DB_NAME'),
+          ...typeOrmConfig,
           autoLoadEntities: true,
-          synchronize: false,
-          migrations: [join(__dirname, 'migrations/*{.ts,.js}')],
-          migrationsRun: true,
-          ssl: isProduction
-            ? {
-                rejectUnauthorized: false,
-              }
-            : false,
         };
       },
     }),

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -1,24 +1,8 @@
-import { config } from 'dotenv';
-config({ path: `.env.${process.env.NODE_ENV || 'development'}` });
 import { DataSource, QueryRunner } from 'typeorm';
-import { join } from 'path';
 import { getCurrentCompanyId } from './common/tenant/tenant-context';
+import typeOrmConfig from './database/typeorm.config';
 
-const isProduction = process.env.NODE_ENV === 'production';
-
-const dataSource = new DataSource({
-  type: 'postgres',
-  host: process.env.DB_HOST,
-  port: Number(process.env.DB_PORT) || 5432,
-  username: process.env.DB_USERNAME,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_NAME,
-  entities: [join(__dirname, '**/*.entity{.ts,.js}')],
-  migrations: [join(__dirname, 'migrations/*{.ts,.js}')],
-  migrationsRun: process.env.RUN_MIGRATIONS === 'true',
-  synchronize: false,
-  ssl: isProduction ? { rejectUnauthorized: false } : false,
-});
+const dataSource = new DataSource(typeOrmConfig);
 
 type CreateQR = DataSource['createQueryRunner'];
 

--- a/backend/src/database/typeorm.config.ts
+++ b/backend/src/database/typeorm.config.ts
@@ -1,0 +1,24 @@
+import { config } from 'dotenv';
+import { join } from 'path';
+import { DataSourceOptions } from 'typeorm';
+
+// Load environment variables based on current NODE_ENV
+config({ path: `.env.${process.env.NODE_ENV || 'development'}` });
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const typeOrmConfig: DataSourceOptions = {
+  type: 'postgres',
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT) || 5432,
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  entities: [join(__dirname, '..', '**/*.entity{.ts,.js}')],
+  migrations: [join(__dirname, '..', 'migrations/*{.ts,.js}')],
+  migrationsRun: process.env.RUN_MIGRATIONS === 'true',
+  synchronize: false,
+  ssl: isProduction ? { rejectUnauthorized: false } : false,
+};
+
+export default typeOrmConfig;


### PR DESCRIPTION
## Summary
- centralize TypeORM options in `src/database/typeorm.config.ts`
- use shared options in data source and NestJS `TypeOrmModule`

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: ... was not found by the project service)*

------
https://chatgpt.com/codex/tasks/task_e_68b398d4402883259b332a088ec25688