### PR TITLE
Disable automatic migrations

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -51,8 +51,6 @@ DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=your_password
 DB_NAME=rflandscaperpro
-# Auto-run migrations on startup (set to true in production if desired)
-# RUN_MIGRATIONS=false
 JWT_SECRET=your_secure_jwt_secret
 JWT_EXPIRES_IN=1d
 JWT_REFRESH_EXPIRES_IN=7d
@@ -87,8 +85,7 @@ Sample output from the `logserver` container:
 ```
 {"message":"hello world"}
 ```
-
-To automatically apply database changes on startup (such as in production), set `RUN_MIGRATIONS=true`. In development, omit this variable and run migrations manually with `npm run migration:run`.
+Migrations are not executed automatically at application startup. Run them explicitly with `npm run migration:run` before launching the server (for example, in your CI/CD pipeline).
 
 ### 3. Database Setup
 ```bash

--- a/backend/src/database/typeorm.config.ts
+++ b/backend/src/database/typeorm.config.ts
@@ -16,7 +16,9 @@ const typeOrmConfig: DataSourceOptions = {
   database: process.env.DB_NAME,
   entities: [join(__dirname, '..', '**/*.entity{.ts,.js}')],
   migrations: [join(__dirname, '..', 'migrations/*{.ts,.js}')],
-  migrationsRun: process.env.RUN_MIGRATIONS === 'true',
+  // Migrations are executed separately via CLI (npm run migration:run)
+  // to avoid unexpected latency and exit behavior at application startup.
+  migrationsRun: false,
   synchronize: false,
   ssl: isProduction ? { rejectUnauthorized: false } : false,
 };


### PR DESCRIPTION
## Summary
- stop running TypeORM migrations automatically at app startup
- document that migrations must be run explicitly via `npm run migration:run`

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b39da03b908325b0208db35c69a711