### PR TITLE
refactor: centralize email service

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -28,6 +28,7 @@ import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { MetricsModule } from './metrics/metrics.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { HealthModule } from './health/health.module';
+import { EmailModule } from './common/email';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { HealthModule } from './health/health.module';
     LoggerModule,
     MetricsModule,
     HealthModule,
+    EmailModule,
     ScheduleModule.forRoot(),
     ConfigModule.forRoot({
       envFilePath: (() => {

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -9,9 +9,9 @@ import { JwtStrategy } from './jwt.strategy';
 import { RefreshToken } from './refresh-token.entity';
 import { VerificationToken } from './verification-token.entity';
 import { User } from '../users/user.entity';
-import { EmailService } from '../common/email';
 import { Company } from '../companies/entities/company.entity';
 import { CompanyUser } from '../companies/entities/company-user.entity';
+import { EmailModule } from '../common/email';
 import {
   REFRESH_TOKEN_REPOSITORY,
   TypeOrmRefreshTokenRepository,
@@ -29,6 +29,7 @@ import {
   imports: [
     UsersModule,
     ConfigModule,
+    EmailModule,
     TypeOrmModule.forFeature([
       RefreshToken,
       VerificationToken,
@@ -56,7 +57,6 @@ import {
   providers: [
     AuthService,
     JwtStrategy,
-    EmailService,
     {
       provide: REFRESH_TOKEN_REPOSITORY,
       useClass: TypeOrmRefreshTokenRepository,

--- a/backend/src/common/email/email.module.ts
+++ b/backend/src/common/email/email.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { EmailService } from './email.service';
+
+@Global()
+@Module({
+  providers: [EmailService],
+  exports: [EmailService],
+})
+export class EmailModule {}

--- a/backend/src/common/email/index.ts
+++ b/backend/src/common/email/index.ts
@@ -1,3 +1,4 @@
 export * from './email.service';
 export * from './transports';
 export * from './templates';
+export * from './email.module';

--- a/backend/src/companies/companies.module.ts
+++ b/backend/src/companies/companies.module.ts
@@ -10,21 +10,21 @@ import { MembersController } from './members.controller';
 import { User } from '../users/user.entity';
 import { UsersModule } from '../users/users.module';
 import { InvitationsService } from './invitations.service';
-import { EmailService } from '../common/email';
 import { AuthModule } from '../auth/auth.module';
 import { MembersService } from './members.service';
+import { EmailModule } from '../common/email';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Company, User, CompanyUser, Invitation]),
     UsersModule,
     AuthModule,
+    EmailModule,
   ],
   providers: [
     CompaniesService,
     InvitationsService,
     MembersService,
-    EmailService,
   ],
   controllers: [CompaniesController, InvitationsController, MembersController],
   exports: [CompaniesService, InvitationsService, MembersService],

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -6,7 +6,6 @@ import { Company } from '../companies/entities/company.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { MeController } from './me.controller';
-import { EmailService } from '../common/email';
 import { UserCreationService } from './user-creation.service';
 import { CustomerRegistrationService } from './customer-registration.service';
 import { CompanyOnboardingService } from './company-onboarding.service';
@@ -14,6 +13,7 @@ import {
   USER_REPOSITORY,
   UserRepository,
 } from './repositories/user.repository';
+import { EmailModule } from '../common/email';
 
 const userRepositoryProvider = {
   provide: USER_REPOSITORY,
@@ -21,10 +21,12 @@ const userRepositoryProvider = {
 };
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, CompanyUser, Company])],
+  imports: [
+    TypeOrmModule.forFeature([User, CompanyUser, Company]),
+    EmailModule,
+  ],
   providers: [
     UsersService,
-    EmailService,
     UserCreationService,
     CustomerRegistrationService,
     CompanyOnboardingService,


### PR DESCRIPTION
## Summary
- create a global EmailModule to manage EmailService
- use EmailModule across app and remove per-module EmailService providers

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@rflp/shared')*


------
https://chatgpt.com/codex/tasks/task_e_68b3cd72e6c883258f1b9f0c7ad0b98b