### PR TITLE
Add timeout handling for email transport initialization

### DIFF
--- a/backend/src/common/email/transports/ethereal.transport.ts
+++ b/backend/src/common/email/transports/ethereal.transport.ts
@@ -1,20 +1,42 @@
+import { Logger } from '@nestjs/common';
 import * as nodemailer from 'nodemailer';
 import { EmailTransport, MailDriver } from './transport.interface';
 
+function toError(e: unknown): Error {
+  return e instanceof Error
+    ? e
+    : new Error(typeof e === 'string' ? e : JSON.stringify(e));
+}
+
 export class EtherealTransport implements EmailTransport {
   driver: MailDriver = 'ethereal';
+  private readonly logger = new Logger(EtherealTransport.name);
 
   async create() {
-    const testAccount = await nodemailer.createTestAccount();
-    const transporter = nodemailer.createTransport({
-      host: 'smtp.ethereal.email',
-      port: 587,
-      secure: false,
-      auth: {
-        user: testAccount.user,
-        pass: testAccount.pass,
-      },
-    });
-    return { transporter, testAccount };
+    try {
+      const testAccount = await Promise.race([
+        nodemailer.createTestAccount(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Ethereal test account timeout')), 5000),
+        ),
+      ]);
+      const transporter = nodemailer.createTransport({
+        host: 'smtp.ethereal.email',
+        port: 587,
+        secure: false,
+        auth: {
+          user: testAccount.user,
+          pass: testAccount.pass,
+        },
+      });
+      return { transporter, testAccount };
+    } catch (e) {
+      const err = toError(e);
+      this.logger.warn(
+        `Failed to create ethereal test account: ${err.message}. Using no-op transport.`,
+      );
+      const transporter = nodemailer.createTransport({ jsonTransport: true });
+      return { transporter };
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add 5s timeout and no-op fallback when creating nodemailer test account
- guard SMTP transporter verification with 5s timeout and ethereal fallback

## Testing
- `cd backend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b46e1a33cc832599207329704d45e7