### PR TITLE
feat: allow disabling email service

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -63,6 +63,8 @@ THROTTLE_TTL=60
 THROTTLE_LIMIT=20
 
 # Email Configuration
+# Set to false to disable email sending entirely
+EMAIL_ENABLED=true
 # The backend uses an Ethereal test account automatically in development and test
 # environments unless SMTP_USER and SMTP_PASS are provided.
 # Optionally set the following variables to use a real SMTP server locally.

--- a/backend/src/common/email/email.service.ts
+++ b/backend/src/common/email/email.service.ts
@@ -27,6 +27,15 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
   );
 
   async onModuleInit(): Promise<void> {
+    const emailEnabled =
+      process.env.EMAIL_ENABLED !== 'false' &&
+      process.env.EMAIL_ENABLED !== '0';
+    if (!emailEnabled) {
+      this.logger.log('EmailService disabled via EMAIL_ENABLED');
+      this.readyResolve();
+      return;
+    }
+
     const hasMailhog = !!process.env.MAILHOG_HOST || !!process.env.MAILHOG_PORT;
     this.driver =
       process.env.NODE_ENV === 'production'
@@ -70,7 +79,7 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
   }
 
   onModuleDestroy(): void {
-    this.transporter.close?.();
+    this.transporter?.close?.();
   }
 
   private formatRecipients(to: nodemailer.SendMailOptions['to']): string {


### PR DESCRIPTION
## Summary
- allow disabling email service via `EMAIL_ENABLED`
- document `EMAIL_ENABLED` env flag

## Testing
- `npm test`
- `npm run lint` *(fails: process appears to hang; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68b46e35cb5c83259f3c0ca4ce5a4b6b