### PR TITLE
refactor: rely on global email module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -33,7 +33,6 @@ import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { MetricsModule } from './metrics/metrics.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { HealthModule } from './health/health.module';
-import { EmailModule } from './common/email';
 
 // --- Env file resolution ---
 const nodeEnv = (process.env.NODE_ENV || 'development').toLowerCase();
@@ -63,7 +62,6 @@ if (envFilePath) {
     LoggerModule,
     MetricsModule,
     HealthModule,
-    EmailModule,
     ScheduleModule.forRoot(),
     ConfigModule.forRoot({
       isGlobal: true,

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -11,7 +11,6 @@ import { VerificationToken } from './verification-token.entity';
 import { User } from '../users/user.entity';
 import { Company } from '../companies/entities/company.entity';
 import { CompanyUser } from '../companies/entities/company-user.entity';
-import { EmailModule } from '../common/email';
 import {
   REFRESH_TOKEN_REPOSITORY,
   TypeOrmRefreshTokenRepository,
@@ -29,7 +28,6 @@ import {
   imports: [
     UsersModule,
     ConfigModule,
-    EmailModule,
     TypeOrmModule.forFeature([
       RefreshToken,
       VerificationToken,

--- a/backend/src/common/email/email.module.spec.ts
+++ b/backend/src/common/email/email.module.spec.ts
@@ -1,0 +1,34 @@
+import { Test } from '@nestjs/testing';
+import { Module, Injectable } from '@nestjs/common';
+import { EmailModule, EmailService } from './';
+
+@Injectable()
+class Consumer {
+  constructor(public readonly emailService: EmailService) {}
+}
+
+@Module({
+  providers: [Consumer],
+})
+class ConsumerModule {}
+
+describe('EmailModule global provider', () => {
+  const original = process.env.EMAIL_ENABLED;
+
+  beforeAll(() => {
+    process.env.EMAIL_ENABLED = 'false';
+  });
+
+  afterAll(() => {
+    process.env.EMAIL_ENABLED = original;
+  });
+
+  it('makes EmailService available without importing the module', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EmailModule, ConsumerModule],
+    }).compile();
+
+    const consumer = moduleRef.get(Consumer);
+    expect(consumer.emailService).toBeInstanceOf(EmailService);
+  });
+});

--- a/backend/src/companies/companies.module.ts
+++ b/backend/src/companies/companies.module.ts
@@ -12,14 +12,12 @@ import { UsersModule } from '../users/users.module';
 import { InvitationsService } from './invitations.service';
 import { AuthModule } from '../auth/auth.module';
 import { MembersService } from './members.service';
-import { EmailModule } from '../common/email';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Company, User, CompanyUser, Invitation]),
     UsersModule,
     AuthModule,
-    EmailModule,
   ],
   providers: [
     CompaniesService,

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -13,7 +13,6 @@ import {
   USER_REPOSITORY,
   UserRepository,
 } from './repositories/user.repository';
-import { EmailModule } from '../common/email';
 
 const userRepositoryProvider = {
   provide: USER_REPOSITORY,
@@ -23,7 +22,6 @@ const userRepositoryProvider = {
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, CompanyUser, Company]),
-    EmailModule,
   ],
   providers: [
     UsersService,


### PR DESCRIPTION
## Summary
- remove EmailModule from feature modules since it's global
- add test ensuring EmailService resolves via the global EmailModule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b49c4ad0408325b5125d24059f3b84