### PR TITLE
feat(logger): make logger module global

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -28,7 +28,6 @@ import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 import { MetricsThrottlerGuard } from './common/guards/metrics-throttler.guard';
 import { TenantGuard } from './common/tenant.guard';
-import { LoggerModule } from './logger/logger.module';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { MetricsModule } from './metrics/metrics.module';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -60,7 +59,6 @@ if (envFilePath) {
 @Module({
   imports: [
     PrometheusModule.register({ global: true }),
-    LoggerModule,
     MetricsModule,
     HealthModule,
     EmailModule,

--- a/backend/src/logger/logger.module.ts
+++ b/backend/src/logger/logger.module.ts
@@ -1,4 +1,10 @@
-import { Module, Injectable, Inject, LoggerService } from '@nestjs/common';
+import {
+  Module,
+  Injectable,
+  Inject,
+  LoggerService,
+  Global,
+} from '@nestjs/common';
 import { WinstonModule, WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import * as winston from 'winston';
 import { makeCounterProvider, InjectMetric } from '@willsoto/nestjs-prometheus';
@@ -72,6 +78,7 @@ class PrometheusLogger implements LoggerService {
   }
 }
 
+@Global()
 @Module({
   imports: [
     WinstonModule.forRoot({


### PR DESCRIPTION
## Summary
- make LoggerModule global with Nest's `@Global` decorator
- remove redundant LoggerModule import from AppModule

## Testing
- `npm --prefix backend run lint` *(fails: Parsing error - test files not found by project service)*
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68b49c5afa048325a414cd661c2433b7