### PR TITLE
feat: include schedule module in contracts

### DIFF
--- a/backend/src/contracts/contracts.module.ts
+++ b/backend/src/contracts/contracts.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { ContractsService } from './contracts.service';
 import { ContractsController } from './contracts.controller';
 import { Contract } from './entities/contract.entity';
@@ -8,7 +9,7 @@ import { Job } from '../jobs/entities/job.entity';
 import { ContractScheduler } from './contract-scheduler.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Contract, Customer, Job])],
+  imports: [TypeOrmModule.forFeature([Contract, Customer, Job]), ScheduleModule],
   controllers: [ContractsController],
   providers: [ContractsService, ContractScheduler],
   exports: [ContractsService],


### PR DESCRIPTION
## Summary
- expose NestJS scheduling for contracts by adding ScheduleModule

## Testing
- `npm --prefix backend test`
- `npm --prefix backend run lint` *(fails: process did not exit; no lint errors reported)*

------
https://chatgpt.com/codex/tasks/task_e_68b49c8f850c832585995656049b7544