### PR TITLE
build: compile shared package before backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,12 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: backend/package-lock.json
+      - name: Install shared dependencies
+        run: npm ci
+        working-directory: shared
+      - name: Build shared package
+        run: npm run build
+        working-directory: shared
       - run: npm ci
       - name: Build backend
         run: npm run build


### PR DESCRIPTION
## Summary
- ensure CI builds shared package before backend compilation

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a1e21dc88325aecfe6a5c317d956