### PR TITLE
Enable ES module interoperability across configs

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -16,7 +16,7 @@
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "sourceMap": true,
 
     // keep the usual safety/ergonomics

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,6 +14,7 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "preserve",
+    "esModuleInterop": true,
     "paths": {
       "@rflp/shared": ["../shared/src"],
       "@rflp/shared/*": ["../shared/src/*"]


### PR DESCRIPTION
## Summary
- enable `esModuleInterop` in backend and frontend TypeScript configs
- remove redundant `allowSyntheticDefaultImports` from backend config

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: No binary for ChromeHeadless on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cfb4222083258c5c35bce0d53fa9