### PR TITLE
Fix CacheInterceptor missing http adapter

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -161,9 +161,7 @@ if (envFilePath) {
     LoggingInterceptor,
     {
       provide: APP_INTERCEPTOR,
-      useFactory: (cache: Cache, reflector: Reflector) =>
-        new CacheInterceptor(cache, reflector),
-      inject: [CACHE_MANAGER, Reflector],
+      useClass: CacheInterceptor,
     },
     {
       provide: APP_GUARD,


### PR DESCRIPTION
## Summary
- let Nest inject HttpAdapterHost by registering `CacheInterceptor` with `useClass`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e3a9a4248325b62a32ed999e96c8