### PR TITLE
fix: resolve lint errors

### DIFF
--- a/backend/src/common/email/email.service.ts
+++ b/backend/src/common/email/email.service.ts
@@ -25,7 +25,7 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
 
   private readyResolve!: () => void;
   private readonly ready = new Promise<void>(
-    (res) => (this.readyResolve = res),
+    (resolve) => (this.readyResolve = resolve),
   );
 
   async onModuleInit(): Promise<void> {
@@ -55,7 +55,7 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
       try {
         await Promise.race([
           this.transporter.verify(),
-          new Promise<never>((_, reject) =>
+          new Promise<never>((_resolve, reject) =>
             setTimeout(() => reject(new Error('SMTP verify timeout')), 5000),
           ),
         ]);

--- a/backend/src/common/email/transports/ethereal.transport.ts
+++ b/backend/src/common/email/transports/ethereal.transport.ts
@@ -17,7 +17,7 @@ export class EtherealTransport implements EmailTransport {
     try {
       const testAccount = await Promise.race([
         nodemailer.createTestAccount(),
-        new Promise<never>((_, reject) =>
+        new Promise<never>((_resolve, reject) =>
           setTimeout(
             () => reject(new Error('Ethereal test account timeout')),
             5000,

--- a/backend/src/common/pagination.spec.ts
+++ b/backend/src/common/pagination.spec.ts
@@ -3,7 +3,7 @@ import { type Repository, type SelectQueryBuilder } from 'typeorm';
 import { paginate } from './pagination';
 
 describe('paginate', () => {
-  let repo: jest.Mocked<Repository<any>>;
+  let repo: jest.Mocked<Repository<unknown>>;
   let qb: Record<string, jest.Mock>;
 
   beforeEach(() => {
@@ -17,8 +17,8 @@ describe('paginate', () => {
     repo = {
       createQueryBuilder: jest
         .fn()
-        .mockReturnValue(qb as unknown as SelectQueryBuilder<any>),
-    } as unknown as jest.Mocked<Repository<any>>;
+        .mockReturnValue(qb as unknown as SelectQueryBuilder<unknown>),
+    } as unknown as jest.Mocked<Repository<unknown>>;
   });
 
   it('caps limit at 100', async () => {
@@ -27,7 +27,9 @@ describe('paginate', () => {
   });
 
   it('applies provided filters', async () => {
-    const filter = (qb: SelectQueryBuilder<any>) =>
+    const filter = (
+      qb: SelectQueryBuilder<unknown>,
+    ): SelectQueryBuilder<unknown> =>
       qb.andWhere('entity.active = :active', { active: true });
 
     await paginate(repo, { limit: 10 }, 'entity', filter);

--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -47,7 +47,7 @@ describe('CustomersService', () => {
       .spyOn(repo, 'create')
       .mockReturnValue({} as Customer);
     repo.save.mockRejectedValue(
-      new QueryFailedError('', [], { code: '23505' } as any),
+      new QueryFailedError('', [], { code: '23505' } as { code: string }),
     );
 
     const createCustomerDto: CreateCustomerDto = {

--- a/backend/src/database/typeorm.config.ts
+++ b/backend/src/database/typeorm.config.ts
@@ -10,7 +10,7 @@ import { join, resolve } from 'node:path';
 
 function coalesce<T>(...vals: (T | undefined | null | '')[]): T | undefined {
   for (const v of vals)
-    {if (v !== undefined && v !== null && v !== ('' as any)) {return v as T;}}
+    {if (v !== undefined && v !== null && v !== '') {return v as T;}}
   return undefined;
 }
 function toBool(v: unknown, fallback = false): boolean {

--- a/backend/src/jobs/jobs.service.spec.ts
+++ b/backend/src/jobs/jobs.service.spec.ts
@@ -16,6 +16,7 @@ import {
 import { type AssignJobDto } from './dto/assign-job.dto';
 import { type CreateJobDto } from './dto/create-job.dto';
 import { type ScheduleJobDto } from './dto/schedule-job.dto';
+import { type Job } from './entities/job.entity';
 import { JobsService } from './jobs.service';
 import {
   ASSIGNMENT_REPOSITORY,
@@ -86,7 +87,7 @@ describe('JobsService', () => {
   it('throws ConflictException when scheduling with resource conflict', async () => {
     jobRepo.findById.mockResolvedValue({
       assignments: [{ equipment: { id: 2 }, user: { id: 1 } }],
-    } as any);
+    } as unknown as Job);
     assignmentRepo.hasConflict.mockResolvedValue(true);
     const dto: ScheduleJobDto = { scheduledDate: new Date() };
     await expect(service.schedule(1, dto, 1)).rejects.toBeInstanceOf(
@@ -98,9 +99,9 @@ describe('JobsService', () => {
     jobRepo.findById.mockResolvedValue({
       customer: {},
       scheduledDate: new Date(),
-    } as any);
-    userRepo.findById.mockResolvedValue({ id: 1 } as any);
-    equipmentRepo.findById.mockResolvedValue({ id: 2 } as any);
+    } as unknown as Job);
+    userRepo.findById.mockResolvedValue({ id: 1 } as { id: number });
+    equipmentRepo.findById.mockResolvedValue({ id: 2 } as { id: number });
     assignmentRepo.hasConflict.mockResolvedValue(true);
     const dto: AssignJobDto = { equipmentId: 2, userId: 1 };
     await expect(service.assign(1, dto, 1)).rejects.toBeInstanceOf(

--- a/backend/src/logger/logger.module.ts
+++ b/backend/src/logger/logger.module.ts
@@ -62,23 +62,23 @@ class PrometheusLogger implements LoggerService {
     };
   }
 
-  log(message: any, ...optionalParams: any[]) {
+  log(message: unknown, ...optionalParams: unknown[]): void {
     this.counters.info.inc();
     this.logger.info?.(message, ...optionalParams);
   }
-  error(message: any, ...optionalParams: any[]) {
+  error(message: unknown, ...optionalParams: unknown[]): void {
     this.counters.error.inc();
     this.logger.error?.(message, ...optionalParams);
   }
-  warn(message: any, ...optionalParams: any[]) {
+  warn(message: unknown, ...optionalParams: unknown[]): void {
     this.counters.warn.inc();
     this.logger.warn?.(message, ...optionalParams);
   }
-  debug(message: any, ...optionalParams: any[]) {
+  debug(message: unknown, ...optionalParams: unknown[]): void {
     this.counters.debug.inc();
     this.logger.debug?.(message, ...optionalParams);
   }
-  verbose(message: any, ...optionalParams: any[]) {
+  verbose(message: unknown, ...optionalParams: unknown[]): void {
     this.counters.verbose.inc();
     this.logger.verbose?.(message, ...optionalParams);
   }

--- a/backend/src/users/__tests__/user-creation.service.spec.ts
+++ b/backend/src/users/__tests__/user-creation.service.spec.ts
@@ -41,7 +41,7 @@ describe('UserCreationService', () => {
         }
         return user;
       }),
-    } as unknown as Repository<User> & { manager: any };
+    } as unknown as Repository<User> & { manager: EntityManager };
 
     manager = {
       getRepository: jest.fn(() => usersRepository),


### PR DESCRIPTION
## Summary
- rename Promise parameters to satisfy promise/param-names rule
- replace `any` with specific or `unknown` types
- use typed parameters in logger

## Testing
- `npm run lint`
- `npm test -w rflandscaperpro-backend` *(fails: TS2339 property 'rejects' does not exist, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b4f79a09e48325ae379a2d35aa4f8a