### PR TITLE
fix: resolve e2e test imports and CI lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   # ---------- LINT ----------
-  lint:
+  lint-backend:
+    name: lint (backend)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,13 +19,26 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
-      - run: npm run lint
+      - run: npm run lint -w rflandscaperpro-backend
+
+  lint-frontend:
+    name: lint (frontend)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm run lint -w frontend
 
   # ---------- TEST ----------
   test-backend-unit:
     name: test (backend, unit, npm test)
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [lint-backend]
     services:
       postgres:
         image: postgres:16
@@ -60,7 +74,7 @@ jobs:
   test-backend-e2e:
     name: test (backend, e2e, npm run test:e2e)
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [lint-backend]
     services:
       postgres:
         image: postgres:16
@@ -96,7 +110,7 @@ jobs:
   test-frontend-unit:
     name: test (frontend, unit, npm test)
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [lint-frontend]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-import { type AppService } from './app.service';
+import { AppService } from './app.service';
 
 @ApiTags('app')
 @Controller()

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -10,7 +10,7 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { Public } from '../common/decorators/public.decorator';
 import { type User } from '../users/user.entity';
-import { type AuthService } from './auth.service';
+import { AuthService } from './auth.service';
 import { type LoginDto } from './dto/login.dto';
 import { type RefreshTokenDto } from './dto/refresh-token.dto';
 import { type RegisterDto } from './dto/register.dto';

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -4,22 +4,22 @@ import {
   Inject,
   Optional,
 } from '@nestjs/common';
-import { type ConfigService } from '@nestjs/config';
-import { type JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as crypto from 'node:crypto';
-import { type Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
-import { type EmailService } from '../common/email';
+import { EmailService } from '../common/email';
 import { verificationMail } from '../common/email/templates';
 import {
   CompanyUserRole,
   CompanyUserStatus,
 } from '../companies/entities/company-user.entity';
-import { type MetricsService } from '../metrics/metrics.service';
-import { type UserCreationService } from '../users/user-creation.service';
+import { MetricsService } from '../metrics/metrics.service';
+import { UserCreationService } from '../users/user-creation.service';
 import { User, UserRole } from '../users/user.entity';
-import { type UsersService } from '../users/users.service';
+import { UsersService } from '../users/users.service';
 import { Email } from '../users/value-objects/email.vo';
 import { PhoneNumber } from '../users/value-objects/phone-number.vo';
 import { type RegisterDto } from './dto/register.dto';

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable, type CanActivate, type ExecutionContext } from '@nestjs/common';
-import { type Reflector } from '@nestjs/core';
+import { Reflector } from '@nestjs/core';
 
 import { UserRole } from '../../users/user.entity';
 import { ROLES_KEY } from '../decorators/roles.decorator';

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import {
-  type HealthCheckService,
-  type TypeOrmHealthIndicator,
+  HealthCheckService,
+  TypeOrmHealthIndicator,
   type HealthCheckResult,
 } from '@nestjs/terminus';
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -29,7 +29,7 @@ import { type UpdateUserDto } from './dto/update-user.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 import { UserRole } from './user.entity';
 import { toUserResponseDto } from './users.mapper';
-import { type UsersService } from './users.service';
+import { UsersService } from './users.service';
 
 @ApiTags('users')
 @ApiBearerAuth()

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -8,11 +8,11 @@ import * as crypto from 'node:crypto';
 import { type FindOptionsWhere, MoreThan, type Repository } from 'typeorm';
 
 import { validatePasswordStrength } from '../auth/password.util';
-import { type EmailService } from '../common/email';
+import { EmailService } from '../common/email';
 import { passwordResetMail } from '../common/email/templates';
 import { type CreateUserDto } from './dto/create-user.dto';
 import { type UpdateUserDto } from './dto/update-user.dto';
-import { type UserCreationService } from './user-creation.service';
+import { UserCreationService } from './user-creation.service';
 import { User, type UserRole } from './user.entity';
 import { Email } from './value-objects/email.vo';
 

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { type INestApplication } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { type App } from 'supertest/types';
 
 import { AppController } from './../src/app.controller';

--- a/backend/test/auth-login.e2e-spec.ts
+++ b/backend/test/auth-login.e2e-spec.ts
@@ -4,7 +4,7 @@ import { JwtService } from '@nestjs/jwt';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import * as bcrypt from 'bcrypt';
-import * as request from 'supertest';
+import request from 'supertest';
 import { type App } from 'supertest/types';
 
 import { AuthController } from '../src/auth/auth.controller';
@@ -18,6 +18,8 @@ import { UserCreationService } from '../src/users/user-creation.service';
 import { User, UserRole } from '../src/users/user.entity';
 import { UsersService } from '../src/users/users.service';
 import { Email } from '../src/users/value-objects/email.vo';
+
+import './env.test';
 
 describe('Auth login endpoint (e2e)', () => {
   let app: INestApplication<App>;

--- a/backend/test/auth-signup-owner.e2e-spec.ts
+++ b/backend/test/auth-signup-owner.e2e-spec.ts
@@ -4,11 +4,13 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { type App } from 'supertest/types';
 
 import { AuthController } from '../src/auth/auth.controller';
 import { AuthService } from '../src/auth/auth.service';
+
+import './env.test';
 
 describe('Auth signup-owner endpoint (e2e)', () => {
   let app: INestApplication<App>;

--- a/backend/test/env.test.ts
+++ b/backend/test/env.test.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata';
+
 process.env.DB_HOST = process.env.DB_HOST || 'localhost';
 process.env.DB_PORT = process.env.DB_PORT || '5432';
 process.env.DB_USERNAME = process.env.DB_USERNAME || 'test';

--- a/backend/test/health.e2e-spec.ts
+++ b/backend/test/health.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { type INestApplication, ServiceUnavailableException } from '@nestjs/common';
 import { HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
 import { Test, type TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { type App } from 'supertest/types';
 
 import { HealthController } from './../src/health/health.controller';

--- a/backend/test/owners.e2e-spec.ts
+++ b/backend/test/owners.e2e-spec.ts
@@ -2,7 +2,7 @@ import { type INestApplication } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { type Request, type Response, type NextFunction } from 'express';
-import * as request from 'supertest';
+import request from 'supertest';
 import { type App } from 'supertest/types';
 
 import { EmailService } from '../src/common/email';
@@ -13,6 +13,8 @@ import { User, UserRole } from '../src/users/user.entity';
 import { UsersController } from '../src/users/users.controller';
 import { UsersService } from '../src/users/users.service';
 import { Email } from '../src/users/value-objects/email.vo';
+
+import './env.test';
 
 describe('Owner user endpoints (e2e)', () => {
   let app: INestApplication<App>;
@@ -122,7 +124,7 @@ describe('Owner user endpoints (e2e)', () => {
       .expect(200)
       .expect((res: request.Response) => {
         const body = res.body as { id: number }[];
-        expect(body).toHaveLength(1);
+        expect(body.length).toBe(1);
         expect(body[0].id).toBe(2);
       });
   });

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -3,7 +3,7 @@ import { APP_GUARD , Reflector } from '@nestjs/core';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { type Request, type Response, type NextFunction } from 'express';
-import * as request from 'supertest';
+import request from 'supertest';
 import { type App } from 'supertest/types';
 
 import { EmailService } from '../src/common/email';


### PR DESCRIPTION
## Summary
- switch to default supertest imports and add test env bootstrap
- replace type-only service imports for proper NestJS DI
- split CI lint into backend and frontend jobs

## Testing
- `npm run lint -w rflandscaperpro-backend` *(fails: Missing return type warnings)*
- `npm test -w rflandscaperpro-backend` *(fails: multiple suites failed)*
- `npm run test:e2e -w rflandscaperpro-backend` *(fails: auth signup/login expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fa3c92348325b705ebf4f3bd95fb