### PR TITLE
fix: ensure tests run with jest types

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -95,6 +95,11 @@
     "moduleNameMapper": {
       "^@rflp/shared(.*)$": "<rootDir>/../../shared/src$1"
     },
+    "globals": {
+      "ts-jest": {
+        "tsconfig": "<rootDir>/../tsconfig.spec.json"
+      }
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { Test, type TestingModule } from '@nestjs/testing';
 
 import { AppController } from './app.controller';

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-import { type AppService } from './app.service';
+import { AppService } from './app.service';
 
 @ApiTags('app')
 @Controller()

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { Test, type TestingModule } from '@nestjs/testing';
 
 import { AuthController } from './auth.controller';
@@ -46,7 +47,7 @@ describe('AuthController', () => {
   it('logs in without company', async () => {
     const dto: LoginDto = { email: 'user@example.com', password: 'pass' };
     const user: { id: number } = { id: 1 };
-    const resultPayload = { access_token: 'token' };
+    const resultPayload = { access_token: 'token' } as any;
     authService.validateUser.mockResolvedValue(user);
     authService.login.mockResolvedValue(resultPayload);
 
@@ -67,7 +68,7 @@ describe('AuthController', () => {
       name: 'Owner',
       password: 'Password1!',
     };
-    const response = { access_token: 'jwt' };
+    const response = { access_token: 'jwt' } as any;
     authService.signupOwner.mockResolvedValue(response);
 
     const result = await controller.signupOwner(dto);

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -10,7 +10,7 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { Public } from '../common/decorators/public.decorator';
 import { type User } from '../users/user.entity';
-import { type AuthService } from './auth.service';
+import { AuthService } from './auth.service';
 import { type LoginDto } from './dto/login.dto';
 import { type RefreshTokenDto } from './dto/refresh-token.dto';
 import { type RegisterDto } from './dto/register.dto';

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,7 +1,6 @@
 import { UnauthorizedException } from '@nestjs/common';
 import { type ConfigService } from '@nestjs/config';
 import { type JwtService } from '@nestjs/jwt';
-import { describe, beforeEach, it } from 'node:test';
 import { type Repository } from 'typeorm';
 
 import { type EmailService } from '../common/email';

--- a/backend/src/common/pagination.spec.ts
+++ b/backend/src/common/pagination.spec.ts
@@ -3,7 +3,7 @@ import { type Repository, type SelectQueryBuilder } from 'typeorm';
 import { paginate } from './pagination';
 
 describe('paginate', () => {
-  let repo: jest.Mocked<Repository<unknown>>;
+  let repo: jest.Mocked<Repository<any>>;
   let qb: Record<string, jest.Mock>;
 
   beforeEach(() => {
@@ -17,8 +17,8 @@ describe('paginate', () => {
     repo = {
       createQueryBuilder: jest
         .fn()
-        .mockReturnValue(qb as unknown as SelectQueryBuilder<unknown>),
-    } as unknown as jest.Mocked<Repository<unknown>>;
+        .mockReturnValue(qb as unknown as SelectQueryBuilder<any>),
+    } as unknown as jest.Mocked<Repository<any>>;
   });
 
   it('caps limit at 100', async () => {
@@ -28,8 +28,8 @@ describe('paginate', () => {
 
   it('applies provided filters', async () => {
     const filter = (
-      qb: SelectQueryBuilder<unknown>,
-    ): SelectQueryBuilder<unknown> =>
+      qb: SelectQueryBuilder<any>,
+    ): SelectQueryBuilder<any> =>
       qb.andWhere('entity.active = :active', { active: true });
 
     await paginate(repo, { limit: 10 }, 'entity', filter);

--- a/backend/src/customers/customers.controller.spec.ts
+++ b/backend/src/customers/customers.controller.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { Test, type TestingModule } from '@nestjs/testing';
 
 import { PaginationParams } from '../common/pagination';

--- a/backend/src/customers/customers.controller.ts
+++ b/backend/src/customers/customers.controller.ts
@@ -27,7 +27,7 @@ import { CompanyId } from '../common/decorators/company-id.decorator';
 import { Roles } from '../common/decorators/roles.decorator';
 import { type PaginationParams, type Paginated } from '../common/pagination';
 import { UserRole , type User } from '../users/user.entity';
-import { type CustomersService } from './customers.service';
+import { CustomersService } from './customers.service';
 import { type CreateCustomerDto } from './dto/create-customer.dto';
 import { CustomerResponseDto } from './dto/customer-response.dto';
 import { type UpdateCustomerDto } from './dto/update-customer.dto';

--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -47,7 +47,11 @@ describe('CustomersService', () => {
       .spyOn(repo, 'create')
       .mockReturnValue({} as Customer);
     repo.save.mockRejectedValue(
-      new QueryFailedError('', [], { code: '23505' } as { code: string }),
+      new QueryFailedError(
+        '',
+        [],
+        Object.assign(new Error(), { code: '23505' }),
+      ),
     );
 
     const createCustomerDto: CreateCustomerDto = {

--- a/backend/src/equipment/equipment.controller.spec.ts
+++ b/backend/src/equipment/equipment.controller.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { Test, type TestingModule } from '@nestjs/testing';
 
 import { type EquipmentResponseDto } from './dto/equipment-response.dto';

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -31,7 +31,7 @@ import { EquipmentResponseDto } from './dto/equipment-response.dto';
 import { type UpdateEquipmentStatusDto } from './dto/update-equipment-status.dto';
 import { type UpdateEquipmentDto } from './dto/update-equipment.dto';
 import { EquipmentStatus, EquipmentType } from './entities/equipment.entity';
-import { type EquipmentService } from './equipment.service';
+import { EquipmentService } from './equipment.service';
 
 @ApiTags('equipment')
 @ApiBearerAuth()

--- a/backend/src/jobs/jobs.controller.spec.ts
+++ b/backend/src/jobs/jobs.controller.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { Test, type TestingModule } from '@nestjs/testing';
 
 import { type PaginationParams } from '../common/pagination';

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -32,7 +32,7 @@ import { type CreateJobDto } from './dto/create-job.dto';
 import { JobResponseDto } from './dto/job-response.dto';
 import { type ScheduleJobDto } from './dto/schedule-job.dto';
 import { type UpdateJobDto } from './dto/update-job.dto';
-import { type JobsService } from './jobs.service';
+import { JobsService } from './jobs.service';
 
 @ApiTags('jobs')
 @ApiBearerAuth()

--- a/backend/src/jobs/jobs.service.spec.ts
+++ b/backend/src/jobs/jobs.service.spec.ts
@@ -9,10 +9,12 @@ import {
   EQUIPMENT_REPOSITORY,
   type IEquipmentRepository,
 } from '../equipment/repositories/equipment.repository';
+import { Equipment } from '../equipment/entities/equipment.entity';
 import {
   USER_REPOSITORY,
   type IUserRepository,
 } from '../users/repositories/user.repository';
+import { User } from '../users/user.entity';
 import { type AssignJobDto } from './dto/assign-job.dto';
 import { type CreateJobDto } from './dto/create-job.dto';
 import { type ScheduleJobDto } from './dto/schedule-job.dto';
@@ -100,8 +102,8 @@ describe('JobsService', () => {
       customer: {},
       scheduledDate: new Date(),
     } as unknown as Job);
-    userRepo.findById.mockResolvedValue({ id: 1 } as { id: number });
-    equipmentRepo.findById.mockResolvedValue({ id: 2 } as { id: number });
+    userRepo.findById.mockResolvedValue({ id: 1 } as unknown as User);
+    equipmentRepo.findById.mockResolvedValue({ id: 2 } as unknown as Equipment);
     assignmentRepo.hasConflict.mockResolvedValue(true);
     const dto: AssignJobDto = { equipmentId: 2, userId: 1 };
     await expect(service.assign(1, dto, 1)).rejects.toBeInstanceOf(

--- a/backend/src/rls.policy.spec.ts
+++ b/backend/src/rls.policy.spec.ts
@@ -1,13 +1,15 @@
 import { runWithCompanyId } from './common/tenant/tenant-context';
 import { Company } from './companies/entities/company.entity';
 import { Customer } from './customers/entities/customer.entity';
-import dataSource from './data-source';
 
 process.env.DB_HOST = 'localhost';
 process.env.DB_PORT = '5432';
 process.env.DB_USERNAME = 'appuser';
 process.env.DB_PASSWORD = 'test';
 process.env.DB_NAME = 'rflandscaperpro_test';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const dataSource = require('./data-source').default;
 
 async function enableCustomerRls() {
   const qr = dataSource.createQueryRunner();

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -29,7 +29,7 @@ import { type UpdateUserDto } from './dto/update-user.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 import { UserRole } from './user.entity';
 import { toUserResponseDto } from './users.mapper';
-import { type UsersService } from './users.service';
+import { UsersService } from './users.service';
 
 @ApiTags('users')
 @ApiBearerAuth()

--- a/backend/tsconfig.spec.json
+++ b/backend/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "exclude": ["node_modules", "dist", "test", "scripts"]
+}


### PR DESCRIPTION
## Summary
- add tsconfig for Jest to include node and jest types
- import controller services as runtime dependencies for Nest DI
- patch tests to use reflect-metadata and correct typings

## Testing
- `npm test -w rflandscaperpro-backend`

------
https://chatgpt.com/codex/tasks/task_e_68b4fa55757883259c9881d1b4d8c0b2