### PR TITLE
Fix backend linting issues

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,4 +1,3 @@
-import 'reflect-metadata';
 import { Test, type TestingModule } from '@nestjs/testing';
 
 import { AuthController } from './auth.controller';
@@ -8,6 +7,8 @@ import { type RegisterDto } from './dto/register.dto';
 import { type RequestPasswordResetDto } from './dto/request-password-reset.dto';
 import { type ResetPasswordDto } from './dto/reset-password.dto';
 import { type SignupOwnerDto } from './dto/signup-owner.dto';
+
+import 'reflect-metadata';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -47,7 +48,7 @@ describe('AuthController', () => {
   it('logs in without company', async () => {
     const dto: LoginDto = { email: 'user@example.com', password: 'pass' };
     const user: { id: number } = { id: 1 };
-    const resultPayload = { access_token: 'token' } as any;
+    const resultPayload: { access_token: string } = { access_token: 'token' };
     authService.validateUser.mockResolvedValue(user);
     authService.login.mockResolvedValue(resultPayload);
 
@@ -68,7 +69,7 @@ describe('AuthController', () => {
       name: 'Owner',
       password: 'Password1!',
     };
-    const response = { access_token: 'jwt' } as any;
+    const response: { access_token: string } = { access_token: 'jwt' };
     authService.signupOwner.mockResolvedValue(response);
 
     const result = await controller.signupOwner(dto);

--- a/backend/src/common/pagination.spec.ts
+++ b/backend/src/common/pagination.spec.ts
@@ -1,9 +1,15 @@
-import { type Repository, type SelectQueryBuilder } from 'typeorm';
+import {
+  type ObjectLiteral,
+  type Repository,
+  type SelectQueryBuilder,
+} from 'typeorm';
 
 import { paginate } from './pagination';
 
+type Entity = ObjectLiteral & { id: number };
+
 describe('paginate', () => {
-  let repo: jest.Mocked<Repository<any>>;
+  let repo: jest.Mocked<Repository<Entity>>;
   let qb: Record<string, jest.Mock>;
 
   beforeEach(() => {
@@ -17,8 +23,8 @@ describe('paginate', () => {
     repo = {
       createQueryBuilder: jest
         .fn()
-        .mockReturnValue(qb as unknown as SelectQueryBuilder<any>),
-    } as unknown as jest.Mocked<Repository<any>>;
+        .mockReturnValue(qb as unknown as SelectQueryBuilder<Entity>),
+    } as unknown as jest.Mocked<Repository<Entity>>;
   });
 
   it('caps limit at 100', async () => {
@@ -28,8 +34,8 @@ describe('paginate', () => {
 
   it('applies provided filters', async () => {
     const filter = (
-      qb: SelectQueryBuilder<any>,
-    ): SelectQueryBuilder<any> =>
+      qb: SelectQueryBuilder<Entity>,
+    ): SelectQueryBuilder<Entity> =>
       qb.andWhere('entity.active = :active', { active: true });
 
     await paginate(repo, { limit: 10 }, 'entity', filter);


### PR DESCRIPTION
## Summary
- eliminate `any` from auth controller tests
- improve pagination spec typing and remove `any`
- switch RLS policy spec to dynamic ES import for DataSource

## Testing
- `npm run lint -w rflandscaperpro-backend`
- `npm test -w rflandscaperpro-backend`

------
https://chatgpt.com/codex/tasks/task_e_68b4ff5a48ac8325a5828f0dd6b6cdcf