### PR TITLE
fix password validation regex

### DIFF
--- a/backend/src/auth/password.util.ts
+++ b/backend/src/auth/password.util.ts
@@ -1,7 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 
 export const PASSWORD_REGEX =
-  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/;
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/;
 
 export function validatePasswordStrength(password: string): void {
   if (password.length < 8) {


### PR DESCRIPTION
## Summary
- fix password regex to allow full string and all required character classes

## Testing
- `npm run test:e2e -w rflandscaperpro-backend` *(fails: Auth signup-owner endpoint (e2e) signs up an owner and returns a token expected 201 got 422)*
- `npm run test:e2e -w rflandscaperpro-backend` *(fails: Auth login endpoint (e2e) logs in a verified user and returns a token expected 201 got 400)*

------
https://chatgpt.com/codex/tasks/task_e_68b501ee9dc083259fa950767b4dadf5