### PR TITLE
chore: centralize validation pipe options

### DIFF
--- a/backend/src/common/validation-pipe-options.ts
+++ b/backend/src/common/validation-pipe-options.ts
@@ -1,0 +1,12 @@
+import { type ValidationPipeOptions } from '@nestjs/common';
+
+// Shared ValidationPipe options to keep application and tests aligned
+export const validationPipeOptions: ValidationPipeOptions = {
+  errorHttpStatusCode: 422,
+  forbidNonWhitelisted: true,
+  stopAtFirstError: true,
+  transform: true,
+  transformOptions: { enableImplicitConversion: true },
+  whitelist: true,
+};
+

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -10,6 +10,7 @@ import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './common/filters/http-exception/http-exception.filter';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { requestIdMiddleware } from './common/middleware/request-id.middleware';
+import { validationPipeOptions } from './common/validation-pipe-options';
 
 // src/main.ts
 import 'reflect-metadata';
@@ -69,16 +70,7 @@ export async function bootstrap(): Promise<void> {
     const loggingInterceptor = app.get(LoggingInterceptor, { strict: false });
     if (loggingInterceptor) {app.useGlobalInterceptors(loggingInterceptor);}
 
-    app.useGlobalPipes(
-      new ValidationPipe({
-        errorHttpStatusCode: 422,
-        forbidNonWhitelisted: true,
-        stopAtFirstError: true,
-        transform: true,
-        transformOptions: { enableImplicitConversion: true },
-        whitelist: true,
-      }),
-    );
+    app.useGlobalPipes(new ValidationPipe(validationPipeOptions));
 
     app.useGlobalFilters(new HttpExceptionFilter(winstonLogger));
 


### PR DESCRIPTION
## Summary
- centralize shared ValidationPipe options
- use shared ValidationPipe options in app bootstrap

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Auth login endpoint returns 400, Auth signup-owner endpoint returns 422)*

------
https://chatgpt.com/codex/tasks/task_e_68b5060a50f8832582fb287ebb25a9a7