### PR TITLE
Return 200 for login endpoint

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -5,13 +5,14 @@ import {
   Req,
   UsePipes,
   ValidationPipe,
+  HttpCode,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { Public } from '../common/decorators/public.decorator';
 import { type User } from '../users/user.entity';
 import { AuthService } from './auth.service';
-import { type LoginDto } from './dto/login.dto';
+import { LoginDto } from './dto/login.dto';
 import { type RefreshTokenDto } from './dto/refresh-token.dto';
 import { type RegisterDto } from './dto/register.dto';
 import { type RequestPasswordResetDto } from './dto/request-password-reset.dto';
@@ -36,6 +37,7 @@ export class AuthController {
 
   @Public()
   @Post('login')
+  @HttpCode(200)
   @UsePipes(
     new ValidationPipe({
       errorHttpStatusCode: 400,

--- a/backend/test/auth-login.e2e-spec.ts
+++ b/backend/test/auth-login.e2e-spec.ts
@@ -93,7 +93,7 @@ describe('Auth login endpoint (e2e)', () => {
     return request(app.getHttpServer())
       .post('/api/auth/login')
       .send({ email: 'verified@example.com', password: 'Password1!' })
-      .expect(201)
+      .expect(200)
       .expect((res: request.Response) => {
         const body = res.body as { access_token: string };
         expect(body.access_token).toBeDefined();


### PR DESCRIPTION
## Summary
- ensure LoginDto is imported at runtime for validation
- respond with HTTP 200 from auth login
- update auth login e2e test to expect 200

## Testing
- `npm run test:e2e -- test/auth-login.e2e-spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b50f8f26848325b3dacf00b2b1d9f0