### PR TITLE
Add validation to owner signup DTO

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -16,7 +16,7 @@ import { type RefreshTokenDto } from './dto/refresh-token.dto';
 import { type RegisterDto } from './dto/register.dto';
 import { type RequestPasswordResetDto } from './dto/request-password-reset.dto';
 import { type ResetPasswordDto } from './dto/reset-password.dto';
-import { type SignupOwnerDto } from './dto/signup-owner.dto';
+import { SignupOwnerDto } from './dto/signup-owner.dto';
 import { type SwitchCompanyDto } from './dto/switch-company.dto';
 import { type VerifyEmailDto } from './dto/verify-email.dto';
 import { type JwtUserPayload } from './interfaces/jwt-user-payload.interface';

--- a/backend/src/auth/dto/signup-owner.dto.ts
+++ b/backend/src/auth/dto/signup-owner.dto.ts
@@ -1,15 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength, Matches } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsString, Matches, MinLength } from 'class-validator';
 
 import { PASSWORD_REGEX } from '../password.util';
 
 export class SignupOwnerDto {
   @ApiProperty()
   @IsString()
+  @IsNotEmpty()
   name: string;
 
   @ApiProperty()
   @IsEmail()
+  @IsNotEmpty()
   email: string;
 
   @ApiProperty({
@@ -18,6 +20,7 @@ export class SignupOwnerDto {
     example: 'SecurePass123!',
   })
   @IsString()
+  @IsNotEmpty()
   @MinLength(8, { message: 'Password must be at least 8 characters long' })
   @Matches(PASSWORD_REGEX, {
     message:
@@ -27,5 +30,6 @@ export class SignupOwnerDto {
 
   @ApiProperty()
   @IsString()
+  @IsNotEmpty()
   companyName: string;
 }


### PR DESCRIPTION
## Summary
- enforce non-empty fields in `SignupOwnerDto`
- ensure `AuthController` uses concrete `SignupOwnerDto` type

## Testing
- `npm run test:e2e -- test/auth-signup-owner.e2e-spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b50f7ea0588325baa6f123dc6a7911