### PR TITLE
fix: cast logger messages to string

### DIFF
--- a/backend/src/logger/logger.module.ts
+++ b/backend/src/logger/logger.module.ts
@@ -64,23 +64,23 @@ class PrometheusLogger implements LoggerService {
 
   log(message: unknown, ...optionalParams: unknown[]): void {
     this.counters.info.inc();
-    this.logger.info?.(message, ...optionalParams);
+    this.logger.info?.(String(message), ...optionalParams);
   }
   error(message: unknown, ...optionalParams: unknown[]): void {
     this.counters.error.inc();
-    this.logger.error?.(message, ...optionalParams);
+    this.logger.error?.(String(message), ...optionalParams);
   }
   warn(message: unknown, ...optionalParams: unknown[]): void {
     this.counters.warn.inc();
-    this.logger.warn?.(message, ...optionalParams);
+    this.logger.warn?.(String(message), ...optionalParams);
   }
   debug(message: unknown, ...optionalParams: unknown[]): void {
     this.counters.debug.inc();
-    this.logger.debug?.(message, ...optionalParams);
+    this.logger.debug?.(String(message), ...optionalParams);
   }
   verbose(message: unknown, ...optionalParams: unknown[]): void {
     this.counters.verbose.inc();
-    this.logger.verbose?.(message, ...optionalParams);
+    this.logger.verbose?.(String(message), ...optionalParams);
   }
 }
 


### PR DESCRIPTION
## Summary
- cast logger messages to string before delegating to Winston logger

## Testing
- `npm run lint -w rflandscaperpro-backend`
- `npm run build -w rflandscaperpro-backend`
- `npm test -w rflandscaperpro-backend`


------
https://chatgpt.com/codex/tasks/task_e_68b517ca8bbc83259e7d53381bb212fa