### PR TITLE
chore: drop compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   db:
     image: postgres:14


### PR DESCRIPTION
## Summary
- remove obsolete version field from docker-compose

## Testing
- `docker compose config >/tmp/compose-before.yml`
- `docker compose config >/tmp/compose-after.yml`
- `diff -u /tmp/compose-before.yml /tmp/compose-after.yml`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51faf4b708325b860734d0163ed2d