### PR TITLE
Start Docker service automatically in development script

### DIFF
--- a/development.ps1
+++ b/development.ps1
@@ -32,7 +32,13 @@ function Preflight {
 
   $svc = Get-Service -Name 'com.docker.service' -ErrorAction SilentlyContinue
   if ($null -eq $svc) { throw "Docker Desktop service 'com.docker.service' not found." }
-  if ($svc.Status -ne 'Running') { throw "Docker Desktop service is not running. Start Docker Desktop." }
+  if ($svc.Status -ne 'Running') {
+    Start-Service -Name 'com.docker.service' -ErrorAction Stop
+    do {
+      Start-Sleep -Seconds 1
+      $svc = Get-Service -Name 'com.docker.service' -ErrorAction SilentlyContinue
+    } until ($svc.Status -eq 'Running')
+  }
 
   if (Get-Command wsl -ErrorAction SilentlyContinue) {
     try {


### PR DESCRIPTION
## Summary
- Start Docker Desktop service if not running and wait for it to be ready in `development.ps1`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Keyv is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bf146068832580bdd9ebd4742de3