### PR TITLE
feat: add docker preflight checks

### DIFF
--- a/development.sh
+++ b/development.sh
@@ -1,21 +1,45 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Start the development environment using Docker.
+# Provides preflight checks and friendly error messages so the script
+# can be dropped into new environments without modification.
+set -uo pipefail
+
+preflight() {
+  echo "→ Running Docker preflight checks"
+
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker CLI not found. Install Docker." >&2
+    return 1
+  fi
+
+  if ! docker info >/dev/null 2>&1; then
+    echo "Cannot communicate with Docker daemon." >&2
+    if [[ $EUID -ne 0 ]] && ! groups 2>/dev/null | grep -q '\bdocker\b'; then
+      echo "You may need administrative privileges (run as root or add your user to the docker group)." >&2
+    fi
+    return 1
+  fi
+}
+
+compose() {
+  echo "→ docker compose $*"
+  if ! output=$(docker compose "$@" 2>&1); then
+    echo "$output" >&2
+    if [[ "$output" == *"error during connect"* || "$output" == *"permission denied"* ]]; then
+      echo "Failed to communicate with Docker daemon. Is it running and accessible?" >&2
+    fi
+    return 1
+  fi
+}
 
 if [[ "${1:-}" == "--local" ]]; then
   (cd backend && npm run start:dev) &
   (cd frontend && npm start) &
   wait
 else
-  if ! command -v docker >/dev/null 2>&1; then
-    echo "Docker CLI not found. Install Docker." >&2
-    exit 1
-  fi
-  if ! docker info >/dev/null 2>&1; then
-    echo "Docker daemon not running or not reachable." >&2
-    exit 1
-  fi
+  preflight || exit 1
 
-  docker compose up -d
+  compose up -d || exit 1
 
   printf '%s\n' \
     'Services are available at the following endpoints:' \


### PR DESCRIPTION
## Summary
- make development.sh resilient with a preflight that checks Docker CLI, daemon access, and user privileges
- wrap docker compose calls to provide friendly error messages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: TypeError: Keyv is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c2ed0a2c8325b8fec061bc742987