### PR TITLE
refactor: build node deps in dev containers

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,31 +1,32 @@
-# syntax=docker/dockerfile:1
+ # syntax=docker/dockerfile:1
 
-# ---- Base image ----
-ARG NODE_VERSION=24.3.0
-FROM node:${NODE_VERSION}-slim AS base
+ # ---- Dependencies stage ----
+ ARG NODE_VERSION=24.3.0
+ FROM node:${NODE_VERSION}-slim AS deps
 
-# ---- Set working directory ----
-WORKDIR /app
+ # Use root workspace lockfile to install backend dependencies
+ WORKDIR /app
+ COPY package.json package-lock.json ./
+ COPY backend/package.json backend/package.json
+ COPY shared/package.json shared/package.json
+ RUN npm ci --include=dev --workspace backend
 
-# ---- Set default environment ----
-# Allows NestJS to fall back to .env.development when run via `docker run`
-ENV NODE_ENV=development
-ENV CHOKIDAR_USEPOLLING=true
+ # ---- Development stage ----
+ FROM node:${NODE_VERSION}-slim AS base
+ WORKDIR /app
 
-# ---- Install dependencies ----
-# Use root workspace lockfile to install backend dependencies
-COPY package.json package-lock.json ./
-COPY backend/package.json backend/package.json
-COPY shared/package.json shared/package.json
-RUN npm ci --include=dev --workspace backend
+ # Set default environment
+ ENV NODE_ENV=development
+ ENV CHOKIDAR_USEPOLLING=true
 
-# ---- Copy application code ----
-# Copy backend and shared sources into dedicated workspace directories
-COPY backend/ backend/
-COPY shared/ shared/
+ # Copy installed modules and application code
+ COPY --from=deps /app/node_modules ./node_modules
+ COPY package.json package-lock.json ./
+ COPY backend/ backend/
+ COPY shared/ shared/
 
-# ---- Expose application port ----
-EXPOSE 3000
+ # Expose application port
+ EXPOSE 3000
 
-# ---- Start development server with live reload ----
-CMD ["npm", "run", "start:dev"]
+ # Start development server with live reload
+ CMD ["npm", "run", "start:dev"]

--- a/backend/docker-compose.override.yml
+++ b/backend/docker-compose.override.yml
@@ -2,11 +2,10 @@ services:
   backend:
     build:
       dockerfile: backend/Dockerfile.dev
-    working_dir: /app
+    working_dir: /app/backend
     volumes:
-      - .:/app
-      - ../shared:/shared
-      - /app/node_modules
+      - .:/app/backend
+      - ../shared:/app/shared
     env_file:
       - .env.development
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,11 +46,10 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile.dev
-    working_dir: /app
+    working_dir: /app/backend
     volumes:
-      - ./backend:/app
-      - ./shared:/shared
-      - backend_node_modules:/app/node_modules
+      - ./backend:/app/backend
+      - ./shared:/app/shared
     env_file:
       - ./backend/.env.development
     environment:
@@ -79,10 +78,10 @@ services:
     build:
       context: .
       dockerfile: frontend/Dockerfile.dev
+    working_dir: /app/frontend
     volumes:
-      - ./frontend:/app
-      - ./shared:/shared
-      - frontend_node_modules:/app/node_modules
+      - ./frontend:/app/frontend
+      - ./shared:/app/shared
     environment:
       NODE_ENV: development
       CHOKIDAR_USEPOLLING: "true"
@@ -133,8 +132,6 @@ services:
 volumes:
   postgres_data:
   grafana_data:
-  backend_node_modules:
-  frontend_node_modules:
 
 networks:
   rflandscaperpro: {}

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,30 +1,32 @@
 # syntax=docker/dockerfile:1
 
-# ---- Base image ----
+# ---- Dependencies stage ----
 ARG NODE_VERSION=24.3.0
-FROM node:${NODE_VERSION}-slim AS base
+FROM node:${NODE_VERSION}-slim AS deps
 
-# ---- Set working directory ----
-WORKDIR /app
-
-# ---- Set default environment ----
-ENV NODE_ENV=development
-ENV CHOKIDAR_USEPOLLING=true
-
-# ---- Install dependencies ----
 # Use root workspace lockfile to install frontend dependencies
+WORKDIR /app
 COPY package.json package-lock.json ./
 COPY frontend/package.json frontend/package.json
 COPY shared/package.json shared/package.json
 RUN npm ci --include=dev --workspace frontend
 
-# ---- Copy application code ----
-# Copy frontend and shared sources into dedicated workspace directories
+# ---- Development stage ----
+FROM node:${NODE_VERSION}-slim AS base
+WORKDIR /app
+
+# Set default environment
+ENV NODE_ENV=development
+ENV CHOKIDAR_USEPOLLING=true
+
+# Copy installed modules and application code
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json package-lock.json ./
 COPY frontend/ frontend/
 COPY shared/ shared/
 
-# ---- Expose application port ----
+# Expose application port
 EXPOSE 4200
 
-# ---- Start development server ----
+# Start development server
 CMD ["npm", "run", "dev:ssr"]

--- a/frontend/docker-compose.override.yml
+++ b/frontend/docker-compose.override.yml
@@ -2,10 +2,10 @@ services:
   frontend:
     build:
       dockerfile: frontend/Dockerfile.dev
+    working_dir: /app/frontend
     volumes:
-      - .:/app
-      - ../shared:/shared
-      - /app/node_modules
+      - .:/app/frontend
+      - ../shared:/app/shared
     ports:
       - "4200:4200"
     environment:


### PR DESCRIPTION
## Summary
- install workspace dependencies in dedicated build stage for backend and frontend dev images
- launch dev containers without npm install
- mount source folders under /app/<workspace> to avoid clobbering node_modules

## Testing
- `npm test -w rflandscaperpro-backend`
- `npm test -w frontend` *(fails: command sh -c ng test --watch=false --browsers=ChromeHeadless)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d6510ae08325ba4bd14e5d128f25