### PR TITLE
chore: add lockfiles script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RF Landscaper Pro is an enterprise-grade application that streamlines landscapin
 
 ## Package Management
 
-This monorepo uses a single root `package-lock.json` for all workspaces; per-package lockfiles are not used.
+This monorepo uses a single root `package-lock.json` for all workspaces; per-package lockfiles are not used. After adding or upgrading dependencies, run `npm run lockfiles` to regenerate the lockfile before committing.
 
 ## Windows Setup
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "seed:drop": "npm run seed:drop -w rflandscaperpro-backend",
     "lint": "eslint . --cache --cache-location .eslintcache --fix",
     "lint:types": "eslint . --ext .ts --config eslint.types.config.mjs",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "lockfiles": "npm install --package-lock-only --workspaces"
   }
 }


### PR DESCRIPTION
## Summary
- add npm script to regenerate lockfiles across workspaces
- document running `npm run lockfiles` after dependency changes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: TypeError: Keyv is not a constructor)


------
https://chatgpt.com/codex/tasks/task_e_68b5d9f7ac3083259f9992cfad30a26d