### PR TITLE
fix: import services for user creation

### DIFF
--- a/backend/src/users/user-creation.service.ts
+++ b/backend/src/users/user-creation.service.ts
@@ -2,8 +2,8 @@ import { ConflictException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { type Repository, QueryFailedError } from 'typeorm';
 
-import { type CompanyOnboardingService } from './company-onboarding.service';
-import { type CustomerRegistrationService } from './customer-registration.service';
+import { CompanyOnboardingService } from './company-onboarding.service';
+import { CustomerRegistrationService } from './customer-registration.service';
 import { type CreateUserDto } from './dto/create-user.dto';
 import { User, UserRole } from './user.entity';
 


### PR DESCRIPTION
## Summary
- fix user creation dependencies by using value imports for `CompanyOnboardingService` and `CustomerRegistrationService`

## Testing
- `npx eslint backend/src/users/user-creation.service.ts` *(fails: All imports in the declaration are only used as types. Use `import type`  @typescript-eslint/consistent-type-imports)*
- `npm test -w rflandscaperpro-backend`


------
https://chatgpt.com/codex/tasks/task_e_68b5dada5a848325a66627ae74a87ed9