### PR TITLE
fix: inject email and metrics services

### DIFF
--- a/backend/src/companies/invitations.service.ts
+++ b/backend/src/companies/invitations.service.ts
@@ -14,9 +14,11 @@ import * as crypto from 'node:crypto';
 import { type Repository, MoreThan, IsNull, QueryFailedError } from 'typeorm';
 
 import { validatePasswordStrength } from '../auth/password.util';
-import { type EmailService } from '../common/email';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import { EmailService } from '../common/email';
 import { invitationMail, addedToCompanyMail } from '../common/email/templates';
-import { type MetricsService } from '../metrics/metrics.service';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import { MetricsService } from '../metrics/metrics.service';
 import { User, UserRole } from '../users/user.entity';
 import { Email } from '../users/value-objects/email.vo';
 import { type AcceptInvitationDto } from './dto/accept-invitation.dto';


### PR DESCRIPTION
## Summary
- ensure InvitationsService injects EmailService and MetricsService
- silence lint warnings by disabling consistent-type-imports for runtime injections

## Testing
- `npm test`
- `npx eslint src/companies/invitations.service.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5e3704d7483258b0ab7ed748b21d5