### PR TITLE
fix: resolve shared module in seed scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,9 +27,9 @@
     "migration:create:dev": "cross-env NODE_ENV=development npm run migration:create --",
     "migration:generate:dev": "cross-env NODE_ENV=development npm run migration:generate --",
     "migration:revert:dev": "cross-env NODE_ENV=development npm run migration:revert --",
-    "seed": "ts-node src/seed.ts",
+    "seed": "ts-node -r tsconfig-paths/register src/seed.ts",
     "seed:dev": "cross-env NODE_ENV=development npm run seed",
-    "seed:drop": "ts-node src/seed.ts --drop",
+    "seed:drop": "ts-node -r tsconfig-paths/register src/seed.ts --drop",
     "seed:drop:dev": "cross-env NODE_ENV=development npm run seed:drop"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- ensure backend seed scripts resolve local `@rflp/shared` sources via tsconfig paths

## Testing
- `npm test -w rflandscaperpro-backend`
- `npm run seed drop dev` *(fails: Missing DB env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ee41ad0883258a907a1c6b480143