### PR TITLE
Ensure non-null user fields and map entity

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -141,6 +141,8 @@ describe('AuthService.signupOwner', () => {
     expect(userCreationService.createUser).toHaveBeenCalledWith({
       company: { name: 'ACME' },
       email: new Email('owner@example.com'),
+      firstName: 'owner',
+      lastName: 'owner',
       isVerified: true,
       password: 'Password123!',
       role: UserRole.CompanyOwner,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -124,12 +124,16 @@ export class AuthService {
     // Validate password strength
     validatePasswordStrength(registerDto.password);
 
-    const { email, phone, ...rest } = registerDto;
+    const { email, phone, role, firstName, lastName, ...rest } = registerDto;
     const user = await this.usersService.create({
       ...rest,
+      role: role ?? UserRole.Customer,
+      firstName: firstName ?? '',
+      lastName: lastName ?? '',
       company: registerDto.company,
       email: new Email(email),
       phone: phone ? new PhoneNumber(phone) : undefined,
+      isVerified: false,
     });
 
     const token = await this.createVerificationToken(user.id);
@@ -143,6 +147,8 @@ export class AuthService {
     const user = await this.userCreationService.createUser({
       company: { name: dto.companyName },
       email: new Email(dto.email),
+      firstName: dto.name,
+      lastName: dto.name,
       isVerified: true,
       password: dto.password,
       role: UserRole.CompanyOwner,

--- a/backend/src/users/__tests__/user-creation.service.spec.ts
+++ b/backend/src/users/__tests__/user-creation.service.spec.ts
@@ -9,6 +9,7 @@ import { type CustomerRegistrationService } from '../customer-registration.servi
 import { UserCreationService } from '../user-creation.service';
 import { User, UserRole } from '../user.entity';
 import { Email } from '../value-objects/email.vo';
+import { PhoneNumber } from '../value-objects/phone-number.vo';
 
 const UNIQUE_VIOLATION = '23505';
 
@@ -73,13 +74,30 @@ describe('UserCreationService', () => {
       email: new Email('user1@example.com'),
       password,
       username: 'user1',
+      role: UserRole.Customer,
+      company: {
+        name: 'Acme Co',
+        address: '123 Street',
+        phone: '1234567890',
+        email: 'company@example.com',
+      },
+      firstName: 'First',
+      lastName: 'Last',
+      phone: new PhoneNumber('1234567890'),
+      isVerified: false,
     });
     const createMock = jest.spyOn(usersRepository, 'create');
-    expect(createMock).toHaveBeenCalledWith({
-      email: expect.any(Email) as unknown as Email,
-      password,
-      username: 'user1',
-    });
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: expect.any(Email) as unknown as Email,
+        password,
+        username: 'user1',
+        role: UserRole.Customer,
+        firstName: 'First',
+        lastName: 'Last',
+        isVerified: false,
+      }),
+    );
     expect(customerRegistrationService.register).toHaveBeenCalled();
     expect(user.role).toBe(UserRole.Customer);
     const isMatch = await bcrypt.compare(password, user.password);
@@ -101,11 +119,20 @@ describe('UserCreationService', () => {
       },
     );
     const user = await service.createUser({
-      company: { name: 'ACME Landscaping' },
+      company: {
+        name: 'ACME Landscaping',
+        address: '123 Street',
+        phone: '1234567890',
+        email: 'acme@example.com',
+      },
       email: new Email('owner@example.com'),
       password: 'secret',
       role: UserRole.CompanyOwner,
       username: 'owner',
+      firstName: 'First',
+      lastName: 'Owner',
+      phone: new PhoneNumber('1234567890'),
+      isVerified: false,
     });
 
     expect(companyOnboardingService.onboard).toHaveBeenCalled();
@@ -122,6 +149,16 @@ describe('UserCreationService', () => {
         password: 'secret',
         role: UserRole.Worker,
         username: 'worker',
+        company: {
+          name: 'Acme Co',
+          address: '123 Street',
+          phone: '1234567890',
+          email: 'company@example.com',
+        },
+        firstName: 'First',
+        lastName: 'Worker',
+        phone: new PhoneNumber('1234567890'),
+        isVerified: false,
       }),
     ).rejects.toMatchObject({ status: 400 });
 
@@ -141,6 +178,17 @@ describe('UserCreationService', () => {
         email: new Email('existing@example.com'),
         password: 'secret',
         username: 'existing',
+        role: UserRole.Customer,
+        company: {
+          name: 'Acme Co',
+          address: '123 Street',
+          phone: '1234567890',
+          email: 'company@example.com',
+        },
+        firstName: 'First',
+        lastName: 'Last',
+        phone: new PhoneNumber('1234567890'),
+        isVerified: false,
       }),
     ).rejects.toMatchObject({
       message: 'Username or email already exists',

--- a/backend/src/users/__tests__/users.service.spec.ts
+++ b/backend/src/users/__tests__/users.service.spec.ts
@@ -8,6 +8,7 @@ import { type UserCreationService } from '../user-creation.service';
 import { User, UserRole } from '../user.entity';
 import { UsersService } from '../users.service';
 import { Email } from '../value-objects/email.vo';
+import { PhoneNumber } from '../value-objects/phone-number.vo';
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -59,6 +60,17 @@ describe('UsersService', () => {
       email: new Email('user1@example.com'),
       password: 'secret',
       username: 'user1',
+      role: UserRole.Customer,
+      company: {
+        name: 'Acme Co',
+        address: '123 Street',
+        phone: '1234567890',
+        email: 'company@example.com',
+      },
+      firstName: 'First',
+      lastName: 'Last',
+      phone: new PhoneNumber('1234567890'),
+      isVerified: false,
     };
     const created = Object.assign(new User(), dto);
     userCreationService.createUser.mockResolvedValueOnce(created);

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -2,12 +2,13 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type, Transform } from 'class-transformer';
 import {
   IsEnum,
-  IsOptional,
   IsString,
   MinLength,
   Matches,
   ValidateNested,
   IsBoolean,
+  IsNotEmpty,
+  IsOptional,
 } from 'class-validator';
 
 import { CreateCompanyDto } from '../../companies/dto/create-company.dto';
@@ -18,14 +19,17 @@ import { PhoneNumber } from '../value-objects/phone-number.vo';
 export class CreateUserDto {
   @ApiProperty()
   @IsString()
+  @IsNotEmpty()
   username: string;
 
   @ApiProperty()
   @Transform(({ value }: { value: string }) => new Email(value))
+  @IsNotEmpty()
   email: Email;
 
   @ApiProperty()
   @IsString()
+  @IsNotEmpty()
   @MinLength(8, { message: 'Password must be at least 8 characters long' })
   @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/, {
     message:
@@ -33,10 +37,9 @@ export class CreateUserDto {
   })
   password: string;
 
-  @ApiPropertyOptional({ enum: UserRole })
+  @ApiProperty({ enum: UserRole })
   @IsEnum(UserRole)
-  @IsOptional()
-  role?: UserRole;
+  role: UserRole;
 
   @ApiPropertyOptional({ type: () => CreateCompanyDto })
   @ValidateNested()
@@ -44,25 +47,25 @@ export class CreateUserDto {
   @IsOptional()
   company?: CreateCompanyDto;
 
-  @ApiPropertyOptional()
+  @ApiProperty()
   @IsString()
-  @IsOptional()
-  firstName?: string;
+  @IsNotEmpty()
+  firstName: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  lastName: string;
 
   @ApiPropertyOptional()
   @IsString()
-  @IsOptional()
-  lastName?: string;
-
-  @ApiPropertyOptional()
   @IsOptional()
   @Transform(({ value }: { value: string | undefined }) =>
     value ? new PhoneNumber(value) : undefined,
   )
   phone?: PhoneNumber;
 
-  @ApiPropertyOptional()
-  @IsOptional()
+  @ApiProperty()
   @IsBoolean()
-  isVerified?: boolean;
+  isVerified: boolean;
 }

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -27,7 +27,7 @@ export enum UserRole {
   Customer = 'customer',
 }
 
-@Entity()
+@Entity('users')
 export class User {
   @PrimaryGeneratedColumn()
   id: number;

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -61,6 +61,17 @@ describe('UsersController (e2e)', () => {
         email: 'user@example.com',
         password: 'SecurePass123!',
         username: 'user',
+        role: 'customer',
+        company: {
+          name: 'Acme Co',
+          address: '123 Street',
+          phone: '1234567890',
+          email: 'company@example.com',
+        },
+        firstName: 'First',
+        lastName: 'Last',
+        phone: '1234567890',
+        isVerified: false,
       })
       .expect(403);
   });


### PR DESCRIPTION
## Summary
- Map `User` entity to `users` table to resolve signup failures
- Require key user fields during creation to prevent null values
- Adjust auth service and tests for new validation

## Testing
- `npm test -w rflandscaperpro-backend`

------
https://chatgpt.com/codex/tasks/task_e_68b5edace6e4832594000e2806d800da