### PR TITLE
Rename user table to users

### DIFF
--- a/backend/src/migrations/1756502290800-auto.ts
+++ b/backend/src/migrations/1756502290800-auto.ts
@@ -104,10 +104,10 @@ export class Auto1756502290800 implements MigrationInterface {
       `CREATE TYPE "public"."user_role_enum" AS ENUM('admin', 'master', 'owner', 'worker', 'customer')`,
     );
     await queryRunner.query(
-      `CREATE TABLE "user" ("id" SERIAL NOT NULL, "username" character varying NOT NULL, "email" character varying NOT NULL, "password" character varying NOT NULL, "role" "public"."user_role_enum" NOT NULL DEFAULT 'customer', "isVerified" boolean NOT NULL DEFAULT false, "firstName" character varying, "lastName" character varying, "phone" character varying, "passwordResetToken" character varying(64), "passwordResetExpires" TIMESTAMP WITH TIME ZONE, "companyId" integer, CONSTRAINT "UQ_78a916df40e02a9deb1c4b75edb" UNIQUE ("username"), CONSTRAINT "UQ_e12875dfb3b1d92d7d7c5377e22" UNIQUE ("email"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "users" ("id" SERIAL NOT NULL, "username" character varying NOT NULL, "email" character varying NOT NULL, "password" character varying NOT NULL, "role" "public"."user_role_enum" NOT NULL DEFAULT 'customer', "isVerified" boolean NOT NULL DEFAULT false, "firstName" character varying, "lastName" character varying, "phone" character varying, "passwordResetToken" character varying(64), "passwordResetExpires" TIMESTAMP WITH TIME ZONE, "companyId" integer, CONSTRAINT "UQ_78a916df40e02a9deb1c4b75edb" UNIQUE ("username"), CONSTRAINT "UQ_e12875dfb3b1d92d7d7c5377e22" UNIQUE ("email"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
-      `CREATE INDEX "IDX_user_password_reset_token" ON "user" ("passwordResetToken") `,
+      `CREATE INDEX "IDX_user_password_reset_token" ON "users" ("passwordResetToken") `,
     );
     await queryRunner.query(
       `CREATE TABLE "verification_token" ("id" SERIAL NOT NULL, "token" character varying NOT NULL, "expiresAt" TIMESTAMP WITH TIME ZONE NOT NULL, "userId" integer NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_74bc3066ea24f13f37d52a12c79" PRIMARY KEY ("id"))`,
@@ -125,19 +125,19 @@ export class Auto1756502290800 implements MigrationInterface {
       `ALTER TABLE "company_user" ADD CONSTRAINT "FK_92e4bc953bf0ca4c707f29b0ff8" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "company_user" ADD CONSTRAINT "FK_b886c13768760ebda801512000b" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+      `ALTER TABLE "company_user" ADD CONSTRAINT "FK_b886c13768760ebda801512000b" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "company_user" ADD CONSTRAINT "FK_918eeb10742b8093a4a0192e136" FOREIGN KEY ("invitedBy") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+      `ALTER TABLE "company_user" ADD CONSTRAINT "FK_918eeb10742b8093a4a0192e136" FOREIGN KEY ("invitedBy") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
       `ALTER TABLE "invitation" ADD CONSTRAINT "FK_757968494b8501e4e3b27860fb0" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "invitation" ADD CONSTRAINT "FK_0a26eda5483cd889e0ace2fe748" FOREIGN KEY ("invitedBy") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+      `ALTER TABLE "invitation" ADD CONSTRAINT "FK_0a26eda5483cd889e0ace2fe748" FOREIGN KEY ("invitedBy") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "company" ADD CONSTRAINT "FK_ee87438803acb531639e8284be0" FOREIGN KEY ("ownerId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+      `ALTER TABLE "company" ADD CONSTRAINT "FK_ee87438803acb531639e8284be0" FOREIGN KEY ("ownerId") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
       `ALTER TABLE "equipment" ADD CONSTRAINT "FK_2a71b4423071a434b29eb7a6855" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
@@ -146,7 +146,7 @@ export class Auto1756502290800 implements MigrationInterface {
       `ALTER TABLE "assignment" ADD CONSTRAINT "FK_7ba90fca6d054c56d8572cab731" FOREIGN KEY ("jobId") REFERENCES "job"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "assignment" ADD CONSTRAINT "FK_b3ae3ab674b9ba61a5771e906da" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+      `ALTER TABLE "assignment" ADD CONSTRAINT "FK_b3ae3ab674b9ba61a5771e906da" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
       `ALTER TABLE "assignment" ADD CONSTRAINT "FK_9bf9a42ea97ab681df00c3e544f" FOREIGN KEY ("equipmentId") REFERENCES "equipment"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
@@ -173,16 +173,16 @@ export class Auto1756502290800 implements MigrationInterface {
       `ALTER TABLE "customer" ADD CONSTRAINT "FK_a9d874b83a7879be8538bf08b09" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "customer" ADD CONSTRAINT "FK_3f62b42ed23958b120c235f74df" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+      `ALTER TABLE "customer" ADD CONSTRAINT "FK_3f62b42ed23958b120c235f74df" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ADD CONSTRAINT "FK_86586021a26d1180b0968f98502" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+      `ALTER TABLE "users" ADD CONSTRAINT "FK_86586021a26d1180b0968f98502" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "verification_token" ADD CONSTRAINT "FK_0748c047a951e34c0b686bfadb2" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+      `ALTER TABLE "verification_token" ADD CONSTRAINT "FK_0748c047a951e34c0b686bfadb2" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "refresh_token" ADD CONSTRAINT "FK_8e913e288156c133999341156ad" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+      `ALTER TABLE "refresh_token" ADD CONSTRAINT "FK_8e913e288156c133999341156ad" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
   }
 
@@ -194,7 +194,7 @@ export class Auto1756502290800 implements MigrationInterface {
       `ALTER TABLE "verification_token" DROP CONSTRAINT "FK_0748c047a951e34c0b686bfadb2"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" DROP CONSTRAINT "FK_86586021a26d1180b0968f98502"`,
+      `ALTER TABLE "users" DROP CONSTRAINT "FK_86586021a26d1180b0968f98502"`,
     );
     await queryRunner.query(
       `ALTER TABLE "customer" DROP CONSTRAINT "FK_3f62b42ed23958b120c235f74df"`,
@@ -261,7 +261,7 @@ export class Auto1756502290800 implements MigrationInterface {
     await queryRunner.query(
       `DROP INDEX "public"."IDX_user_password_reset_token"`,
     );
-    await queryRunner.query(`DROP TABLE "user"`);
+    await queryRunner.query(`DROP TABLE "users"`);
     await queryRunner.query(`DROP TYPE "public"."user_role_enum"`);
     await queryRunner.query(
       `DROP INDEX "public"."IDX_fdb2f3ad8115da4c7718109a6e"`,

--- a/backend/src/migrations/1756658984658-Init.ts
+++ b/backend/src/migrations/1756658984658-Init.ts
@@ -11,13 +11,13 @@ export class Init1756658984658 implements MigrationInterface {
       `CREATE TYPE "public"."user_role_enum" AS ENUM('master', 'company_admin', 'company_owner', 'worker', 'customer')`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" DROP DEFAULT`,
+      `ALTER TABLE "users" ALTER COLUMN "role" DROP DEFAULT`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" TYPE "public"."user_role_enum" USING "role"::"text"::"public"."user_role_enum"`,
+      `ALTER TABLE "users" ALTER COLUMN "role" TYPE "public"."user_role_enum" USING "role"::"text"::"public"."user_role_enum"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" SET DEFAULT 'customer'`,
+      `ALTER TABLE "users" ALTER COLUMN "role" SET DEFAULT 'customer'`,
     );
     await queryRunner.query(`DROP TYPE "public"."user_role_enum_old"`);
     await queryRunner.query(
@@ -27,13 +27,13 @@ export class Init1756658984658 implements MigrationInterface {
       `CREATE TYPE "public"."user_role_enum" AS ENUM('master', 'company_admin', 'company_owner', 'worker', 'customer')`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" DROP DEFAULT`,
+      `ALTER TABLE "users" ALTER COLUMN "role" DROP DEFAULT`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" TYPE "public"."user_role_enum" USING "role"::"text"::"public"."user_role_enum"`,
+      `ALTER TABLE "users" ALTER COLUMN "role" TYPE "public"."user_role_enum" USING "role"::"text"::"public"."user_role_enum"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" SET DEFAULT 'customer'`,
+      `ALTER TABLE "users" ALTER COLUMN "role" SET DEFAULT 'customer'`,
     );
     await queryRunner.query(`DROP TYPE "public"."user_role_enum_old"`);
   }
@@ -43,13 +43,13 @@ export class Init1756658984658 implements MigrationInterface {
       `CREATE TYPE "public"."user_role_enum_old" AS ENUM('admin', 'master', 'owner', 'worker', 'customer')`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" DROP DEFAULT`,
+      `ALTER TABLE "users" ALTER COLUMN "role" DROP DEFAULT`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" TYPE "public"."user_role_enum_old" USING "role"::"text"::"public"."user_role_enum_old"`,
+      `ALTER TABLE "users" ALTER COLUMN "role" TYPE "public"."user_role_enum_old" USING "role"::"text"::"public"."user_role_enum_old"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" SET DEFAULT 'customer'`,
+      `ALTER TABLE "users" ALTER COLUMN "role" SET DEFAULT 'customer'`,
     );
     await queryRunner.query(`DROP TYPE "public"."user_role_enum"`);
     await queryRunner.query(
@@ -59,13 +59,13 @@ export class Init1756658984658 implements MigrationInterface {
       `CREATE TYPE "public"."user_role_enum_old" AS ENUM('admin', 'master', 'owner', 'worker', 'customer')`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" DROP DEFAULT`,
+      `ALTER TABLE "users" ALTER COLUMN "role" DROP DEFAULT`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" TYPE "public"."user_role_enum_old" USING "role"::"text"::"public"."user_role_enum_old"`,
+      `ALTER TABLE "users" ALTER COLUMN "role" TYPE "public"."user_role_enum_old" USING "role"::"text"::"public"."user_role_enum_old"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "user" ALTER COLUMN "role" SET DEFAULT 'customer'`,
+      `ALTER TABLE "users" ALTER COLUMN "role" SET DEFAULT 'customer'`,
     );
     await queryRunner.query(`DROP TYPE "public"."user_role_enum"`);
     await queryRunner.query(

--- a/backend/src/migrations/1756754626440-rename-user-table.ts
+++ b/backend/src/migrations/1756754626440-rename-user-table.ts
@@ -1,0 +1,13 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class RenameUserTable1756754626440 implements MigrationInterface {
+  name = 'RenameUserTable1756754626440';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" RENAME TO "users"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" RENAME TO "user"`);
+  }
+}


### PR DESCRIPTION
## Summary
- rename initial `user` table to `users` and update foreign key references
- fix existing migrations to target `users`
- add migration to rename `user` to `users`

## Testing
- `npx eslint backend/src/migrations/1756502290800-auto.ts backend/src/migrations/1756658984658-Init.ts backend/src/migrations/1756754626440-rename-user-table.ts && echo 'lint ok'`
- `DB_HOST=localhost DB_PORT=5432 DB_USERNAME=postgres DB_PASSWORD=password DB_NAME=rflandscaperpro npm run migration:run` *(fails: Cannot find module './cli.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b5f29951c08325a2b0bc6cdd22981d