### PR TITLE
feat(frontend): enforce backend password policy on sign-up forms

### DIFF
--- a/frontend/src/app/auth/signup-owner/signup-owner.component.ts
+++ b/frontend/src/app/auth/signup-owner/signup-owner.component.ts
@@ -7,6 +7,9 @@ import { finalize } from 'rxjs';
 import { ErrorService } from '../../error.service';
 import { AuthService } from '../auth.service';
 
+const PASSWORD_REGEX =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/;
+
 @Component({
   imports: [CommonModule, ReactiveFormsModule],
   selector: 'app-signup-owner',
@@ -18,7 +21,11 @@ import { AuthService } from '../auth.service';
     <form [formGroup]="form" (ngSubmit)="submit()">
       <input type="text" formControlName="name" placeholder="Name" />
       <input type="email" formControlName="email" placeholder="Email" />
-      <input type="password" formControlName="password" placeholder="Password" />
+      <input
+        type="password"
+        formControlName="password"
+        placeholder="Password (8+ chars, upper & lower case, number, special)"
+      />
       <input type="text" formControlName="companyName" placeholder="Company Name" />
       <button type="submit" [disabled]="loading">Sign Up</button>
     </form>
@@ -34,7 +41,14 @@ export class SignupOwnerComponent {
     companyName: ['', Validators.required.bind(Validators)],
     email: ['', [Validators.required.bind(Validators), Validators.email.bind(Validators)]],
     name: ['', Validators.required.bind(Validators)],
-    password: ['', Validators.required.bind(Validators)],
+    password: [
+      '',
+      [
+        Validators.required.bind(Validators),
+        Validators.minLength(8).bind(Validators),
+        Validators.pattern(PASSWORD_REGEX).bind(Validators),
+      ],
+    ],
   });
 
   loading = false;

--- a/frontend/src/app/invitations/accept-invitation.component.ts
+++ b/frontend/src/app/invitations/accept-invitation.component.ts
@@ -8,6 +8,9 @@ import { AuthService } from '../auth/auth.service';
 import { ErrorService } from '../error.service';
 import { InvitationsService, type InvitationPreview } from './invitations.service';
 
+const PASSWORD_REGEX =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/;
+
 @Component({
   imports: [CommonModule, ReactiveFormsModule],
   selector: 'app-accept-invitation',
@@ -34,7 +37,11 @@ import { InvitationsService, type InvitationPreview } from './invitations.servic
         <div *ngIf="mode === 'create'">
           <form [formGroup]="createForm" (ngSubmit)="create()">
             <input type="text" formControlName="name" placeholder="Name" />
-            <input type="password" formControlName="password" placeholder="Password" />
+            <input
+              type="password"
+              formControlName="password"
+              placeholder="Password (8+ chars, upper & lower case, number, special)"
+            />
             <button type="submit" [disabled]="createLoading">Create Account</button>
           </form>
           <button type="button" (click)="mode = 'login'">I have an account</button>
@@ -63,7 +70,14 @@ export class AcceptInvitationComponent implements OnInit {
 
   createForm = this.fb.nonNullable.group({
     name: ['', Validators.required.bind(Validators)],
-    password: ['', Validators.required.bind(Validators)],
+    password: [
+      '',
+      [
+        Validators.required.bind(Validators),
+        Validators.minLength(8).bind(Validators),
+        Validators.pattern(PASSWORD_REGEX).bind(Validators),
+      ],
+    ],
   });
 
   loginLoading = false;

--- a/frontend/src/app/users/user-form.component.ts
+++ b/frontend/src/app/users/user-form.component.ts
@@ -8,6 +8,9 @@ import { ToasterService } from '../toaster.service';
 import { UserService } from './user.service';
 import { type CreateUser } from './user.model';
 
+const PASSWORD_REGEX =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/;
+
 @Component({
   imports: [CommonModule, ReactiveFormsModule],
   selector: 'app-user-form',
@@ -25,7 +28,11 @@ import { type CreateUser } from './user.model';
       </label>
       <label>
         Password:
-        <input type="password" formControlName="password" />
+        <input
+          type="password"
+          formControlName="password"
+          placeholder="Password (8+ chars, upper & lower case, number, special)"
+        />
       </label>
       <label>
         First Name:
@@ -87,7 +94,14 @@ export class UserFormComponent {
     email: ['', [Validators.required, Validators.email]],
     firstName: [''],
     lastName: [''],
-    password: ['', Validators.required],
+    password: [
+      '',
+      [
+        Validators.required.bind(Validators),
+        Validators.minLength(8).bind(Validators),
+        Validators.pattern(PASSWORD_REGEX).bind(Validators),
+      ],
+    ],
     phone: [''],
     role: ['customer'],
     username: ['', Validators.required],


### PR DESCRIPTION
## Summary
- enforce backend password complexity on owner signup
- require strong passwords when accepting invitations
- validate passwords in admin user creation form

## Testing
- `npm test -w frontend` *(fails: No binary for ChromeHeadless browser)*
- `npm test -w rflandscaperpro-backend`
- `npm run lint` *(fails: Keyv is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68b60e9eb1648325bb8fa29ad29989e9