### PR TITLE
test: include first and last name in owner signup

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -62,15 +62,16 @@ describe('AuthController', () => {
     expect(result).toEqual(resultPayload);
   });
 
-  it('signs up a new owner', async () => {
-    const dto: SignupOwnerDto = {
-      companyName: 'Acme Co',
-      email: 'owner@example.com',
-      name: 'Owner',
-      password: 'Password1!',
-    };
-    const response: { access_token: string } = { access_token: 'jwt' };
-    authService.signupOwner.mockResolvedValue(response);
+    it('signs up a new owner', async () => {
+      const dto: SignupOwnerDto = {
+        companyName: 'Acme Co',
+        email: 'owner@example.com',
+        firstName: 'Owner',
+        lastName: 'User',
+        password: 'Password1!',
+      };
+      const response: { access_token: string } = { access_token: 'jwt' };
+      authService.signupOwner.mockResolvedValue(response);
 
     const result = await controller.signupOwner(dto);
 

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -131,23 +131,24 @@ describe('AuthService.signupOwner', () => {
     });
     userCreationService.createUser.mockResolvedValue(user);
 
-    await service.signupOwner({
-      companyName: 'ACME',
-      email: 'owner@example.com',
-      name: 'owner',
-      password: 'Password123!',
-    });
+      await service.signupOwner({
+        companyName: 'ACME',
+        email: 'owner@example.com',
+        firstName: 'owner',
+        lastName: 'owner',
+        password: 'Password123!',
+      });
 
-    expect(userCreationService.createUser).toHaveBeenCalledWith({
-      company: { name: 'ACME' },
-      email: new Email('owner@example.com'),
-      firstName: 'owner',
-      isVerified: true,
-      lastName: 'owner',
-      password: 'Password123!',
-      role: UserRole.CompanyOwner,
-      username: 'owner',
-    });
+      expect(userCreationService.createUser).toHaveBeenCalledWith({
+        company: { name: 'ACME' },
+        email: new Email('owner@example.com'),
+        firstName: 'owner',
+        isVerified: true,
+        lastName: 'owner',
+        password: 'Password123!',
+        role: UserRole.CompanyOwner,
+        username: 'owner',
+      });
     expect(loginSpy).toHaveBeenCalledWith(user);
   });
 });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -147,12 +147,12 @@ export class AuthService {
     const user = await this.userCreationService.createUser({
       company: { name: dto.companyName },
       email: new Email(dto.email),
-      firstName: dto.name,
+      firstName: dto.firstName,
       isVerified: true,
-      lastName: dto.name,
+      lastName: dto.lastName,
       password: dto.password,
       role: UserRole.CompanyOwner,
-      username: dto.name,
+      username: dto.firstName,
     });
 
     return this.login(user);

--- a/backend/src/auth/dto/signup-owner.dto.ts
+++ b/backend/src/auth/dto/signup-owner.dto.ts
@@ -7,7 +7,12 @@ export class SignupOwnerDto {
   @ApiProperty()
   @IsString()
   @IsNotEmpty()
-  name: string;
+  firstName: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  lastName: string;
 
   @ApiProperty()
   @IsEmail()

--- a/backend/test/auth-login.e2e-spec.ts
+++ b/backend/test/auth-login.e2e-spec.ts
@@ -34,6 +34,8 @@ describe('Auth login endpoint (e2e)', () => {
       email: new Email('verified@example.com'),
       id: 1,
       isVerified: true,
+      firstName: 'Verified',
+      lastName: 'User',
       password: hashed,
       role: UserRole.Customer,
       username: 'verified',

--- a/backend/test/auth-signup-owner.e2e-spec.ts
+++ b/backend/test/auth-signup-owner.e2e-spec.ts
@@ -49,7 +49,8 @@ describe('Auth signup-owner endpoint (e2e)', () => {
       .send({
         companyName: 'Acme Co',
         email: 'owner@example.com',
-        name: 'Owner',
+        firstName: 'Owner',
+        lastName: 'User',
         password: 'Password1!',
       })
       .expect(201)
@@ -69,7 +70,8 @@ describe('Auth signup-owner endpoint (e2e)', () => {
       .send({
         companyName: 'Acme Co',
         email: 'owner@example.com',
-        name: 'Owner',
+        firstName: 'Owner',
+        lastName: 'User',
         password: 'Password1!',
       })
       .expect(409);


### PR DESCRIPTION
## Summary
- require `firstName` and `lastName` for owner signup
- map owner signup names in `AuthService`
- update auth e2e and unit tests for new fields

## Testing
- `npm test -w rflandscaperpro-backend`
- `npm run test:e2e -w rflandscaperpro-backend`


------
https://chatgpt.com/codex/tasks/task_e_68b616a5e92483258628e56f5669adfa