### PR TITLE
Fix owner signup DTO and tests

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -66,9 +66,9 @@ describe('AuthController', () => {
     const dto: SignupOwnerDto = {
       companyName: 'Acme Co',
       email: 'owner@example.com',
-      name: 'Owner',
-      password: 'Password1!',
       firstName: 'Owner',
+      lastName: 'User',
+      password: 'Password1!',
       phone: '5551234567',
     };
     const response: { access_token: string } = { access_token: 'jwt' };

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -128,30 +128,28 @@ describe('AuthService.signupOwner', () => {
       email: 'owner@example.com',
       id: 1,
       role: UserRole.CompanyOwner,
-      username: 'owner',
+      username: 'Owner',
     });
     userCreationService.createUser.mockResolvedValue(user);
 
     await service.signupOwner({
       companyName: 'ACME',
       email: 'owner@example.com',
-      username: 'owner',
       password: 'Password123!',
       firstName: 'Owner',
-      lastName: 'owner',
+      lastName: 'User',
       phone: '5551234567',
     });
 
     expect(userCreationService.createUser).toHaveBeenCalledWith({
       company: { name: 'ACME' },
       email: new Email('owner@example.com'),
-      firstName: 'owner',
       isVerified: true,
-      lastName: 'owner',
+      firstName: 'Owner',
+      lastName: 'User',
       password: 'Password123!',
       role: UserRole.CompanyOwner,
-      username: 'owner',
-      firstName: 'Owner',
+      username: 'Owner',
       phone: new PhoneNumber('5551234567'),
     });
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -153,8 +153,6 @@ export class AuthService {
       password: dto.password,
       role: UserRole.CompanyOwner,
       username: dto.firstName,
-      firstName: dto.firstName,
-      lastName: dto.lastName,
       phone: dto.phone ? new PhoneNumber(dto.phone) : undefined,
     });
 

--- a/backend/src/auth/dto/signup-owner.dto.ts
+++ b/backend/src/auth/dto/signup-owner.dto.ts
@@ -24,16 +24,6 @@ export class SignupOwnerDto {
   @ApiPropertyOptional()
   @IsString()
   @IsOptional()
-  firstName?: string;
-
-  @ApiPropertyOptional()
-  @IsString()
-  @IsOptional()
-  lastName?: string;
-
-  @ApiPropertyOptional()
-  @IsString()
-  @IsOptional()
   phone?: string;
 
   @ApiProperty()

--- a/backend/test/auth-signup-owner.e2e-spec.ts
+++ b/backend/test/auth-signup-owner.e2e-spec.ts
@@ -52,7 +52,6 @@ describe('Auth signup-owner endpoint (e2e)', () => {
         firstName: 'Owner',
         lastName: 'User',
         password: 'Password1!',
-        firstName: 'Owner',
         phone: '5551234567',
       })
       .expect(201)
@@ -62,9 +61,9 @@ describe('Auth signup-owner endpoint (e2e)', () => {
         expect(signupOwner).toHaveBeenCalledWith({
           companyName: 'Acme Co',
           email: 'owner@example.com',
-          name: 'Owner',
-          password: 'Password1!',
           firstName: 'Owner',
+          lastName: 'User',
+          password: 'Password1!',
           phone: '5551234567',
         });
       });
@@ -82,7 +81,6 @@ describe('Auth signup-owner endpoint (e2e)', () => {
         firstName: 'Owner',
         lastName: 'User',
         password: 'Password1!',
-        firstName: 'Owner',
         phone: '5551234567',
       })
       .expect(409);


### PR DESCRIPTION
## Summary
- remove duplicate first/last name fields from `SignupOwnerDto`
- streamline owner signup logic to use proper fields
- align owner signup unit and e2e tests with updated DTO

## Testing
- `npm run test:e2e -w rflandscaperpro-backend`
- `npm test -w rflandscaperpro-backend`


------
https://chatgpt.com/codex/tasks/task_e_68b61b3f4fa48325a179ff67198849da