### PR TITLE
Require username field for owner signup

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -68,6 +68,7 @@ describe('AuthController', () => {
       email: 'owner@example.com',
       firstName: 'Owner',
       lastName: 'User',
+      username: 'owner',
       password: 'Password1!',
       phone: '5551234567',
     };

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -128,7 +128,7 @@ describe('AuthService.signupOwner', () => {
       email: 'owner@example.com',
       id: 1,
       role: UserRole.CompanyOwner,
-      username: 'Owner',
+      username: 'owner',
     });
     userCreationService.createUser.mockResolvedValue(user);
 
@@ -138,6 +138,7 @@ describe('AuthService.signupOwner', () => {
       password: 'Password123!',
       firstName: 'Owner',
       lastName: 'User',
+      username: 'owner',
       phone: '5551234567',
     });
 
@@ -149,7 +150,7 @@ describe('AuthService.signupOwner', () => {
       lastName: 'User',
       password: 'Password123!',
       role: UserRole.CompanyOwner,
-      username: 'Owner',
+      username: 'owner',
       phone: new PhoneNumber('5551234567'),
     });
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -152,7 +152,7 @@ export class AuthService {
       lastName: dto.lastName,
       password: dto.password,
       role: UserRole.CompanyOwner,
-      username: dto.firstName,
+      username: dto.username,
       phone: dto.phone ? new PhoneNumber(dto.phone) : undefined,
     });
 

--- a/backend/src/auth/dto/signup-owner.dto.ts
+++ b/backend/src/auth/dto/signup-owner.dto.ts
@@ -21,6 +21,12 @@ export class SignupOwnerDto {
   @IsNotEmpty()
   lastName: string;
 
+  @ApiProperty({ description: 'Username must be unique' })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(3, { message: 'Username must be at least 3 characters long' })
+  username: string;
+
   @ApiPropertyOptional()
   @IsString()
   @IsOptional()

--- a/backend/test/auth-signup-owner.e2e-spec.ts
+++ b/backend/test/auth-signup-owner.e2e-spec.ts
@@ -51,6 +51,7 @@ describe('Auth signup-owner endpoint (e2e)', () => {
         email: 'owner@example.com',
         firstName: 'Owner',
         lastName: 'User',
+        username: 'owner',
         password: 'Password1!',
         phone: '5551234567',
       })
@@ -63,6 +64,7 @@ describe('Auth signup-owner endpoint (e2e)', () => {
           email: 'owner@example.com',
           firstName: 'Owner',
           lastName: 'User',
+          username: 'owner',
           password: 'Password1!',
           phone: '5551234567',
         });
@@ -80,6 +82,7 @@ describe('Auth signup-owner endpoint (e2e)', () => {
         email: 'owner@example.com',
         firstName: 'Owner',
         lastName: 'User',
+        username: 'owner',
         password: 'Password1!',
         phone: '5551234567',
       })

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -54,12 +54,12 @@ export class AuthService {
   }
 
   signupOwner(data: {
-    name: string;
+    username: string;
     email: string;
     password: string;
     companyName: string;
-    firstName?: string;
-    lastName?: string;
+    firstName: string;
+    lastName: string;
     phone?: string;
   }): Observable<{ access_token: string }> {
     return this.http

--- a/frontend/src/app/auth/signup-owner/signup-owner.component.ts
+++ b/frontend/src/app/auth/signup-owner/signup-owner.component.ts
@@ -19,7 +19,7 @@ const PASSWORD_REGEX =
       <small>Company details are required to create a company owner account.</small>
     </p>
     <form [formGroup]="form" (ngSubmit)="submit()">
-      <input type="text" formControlName="name" placeholder="Username" />
+      <input type="text" formControlName="username" placeholder="Username" />
       <input type="text" formControlName="firstName" placeholder="First Name" />
       <input type="text" formControlName="lastName" placeholder="Last Name" />
       <input type="tel" formControlName="phone" placeholder="Phone" />
@@ -43,9 +43,15 @@ export class SignupOwnerComponent {
   form = this.fb.nonNullable.group({
     companyName: ['', Validators.required.bind(Validators)],
     email: ['', [Validators.required.bind(Validators), Validators.email.bind(Validators)]],
-    name: ['', Validators.required.bind(Validators)],
-    firstName: [''],
-    lastName: [''],
+    username: [
+      '',
+      [
+        Validators.required.bind(Validators),
+        Validators.minLength(3).bind(Validators),
+      ],
+    ],
+    firstName: ['', Validators.required.bind(Validators)],
+    lastName: ['', Validators.required.bind(Validators)],
     phone: [''],
     password: [
       '',


### PR DESCRIPTION
## Summary
- Add mandatory `username` to owner signup DTO and service logic
- Update Angular owner signup form and auth service to use `username` and require first/last names
- Adjust backend tests for new username requirement

## Testing
- `npm test -w rflandscaperpro-backend`
- `npm run test:e2e -w rflandscaperpro-backend`
- `npm test -w frontend` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run lint` *(fails: Keyv is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68b628f8c5848325a063a960669e0812