### PR TITLE
feat: include equipment type in UI and payload

### DIFF
--- a/frontend/src/app/equipment/equipment-detail.component.ts
+++ b/frontend/src/app/equipment/equipment-detail.component.ts
@@ -27,6 +27,20 @@ import { EquipmentService, type CreateEquipment } from './equipment.service';
           {{ form.controls.name.errors | json }}
         </div>
         <label>
+          Type:
+          <select formControlName="type">
+            <option *ngFor="let t of equipmentTypes" [value]="t">{{ t }}</option>
+          </select>
+        </label>
+        <div
+          *ngIf="
+            form.controls.type.errors &&
+            (form.controls.type.dirty || form.controls.type.touched)
+          "
+        >
+          {{ form.controls.type.errors | json }}
+        </div>
+        <label>
           Status:
           <input formControlName="status" />
         </label>
@@ -53,9 +67,11 @@ export class EquipmentDetailComponent {
   private fb = inject(FormBuilder);
 
   equipmentId?: number;
+  equipmentTypes = ['mower', 'trimmer', 'blower', 'tractor', 'truck', 'trailer', 'other'];
 
   form = this.fb.nonNullable.group({
     name: ['', Validators.required.bind(Validators)],
+    type: ['', Validators.required.bind(Validators)],
     status: ['', Validators.required.bind(Validators)],
   });
 

--- a/frontend/src/app/equipment/equipment-list.component.ts
+++ b/frontend/src/app/equipment/equipment-list.component.ts
@@ -14,7 +14,7 @@ import { type Equipment, EquipmentService } from './equipment.service';
     <input type="text" [(ngModel)]="filter" placeholder="Search equipment" />
     <ul>
       <li *ngFor="let item of filteredEquipment()" [routerLink]="[item.id]">
-        {{ item.name }} - {{ item.status }}
+        {{ item.name }} - {{ item.type }} - {{ item.status }}
       </li>
     </ul>
     <a [routerLink]="['new']">Add Equipment</a>
@@ -31,6 +31,8 @@ export class EquipmentListComponent {
 
   filteredEquipment(): Equipment[] {
     const term = this.filter.toLowerCase();
-    return this.equipments.filter((e) => e.name.toLowerCase().includes(term));
+    return this.equipments.filter(
+      (e) => e.name.toLowerCase().includes(term) || e.type.toLowerCase().includes(term),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- require an equipment type when creating or editing equipment
- show equipment type in equipment list and search

## Testing
- `npm test -w rflandscaperpro-backend`
- `npm test -w frontend` *(fails: No binary for ChromeHeadless browser)*
- `npm run lint` *(fails: Keyv is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68b62de5ddfc8325927b36b2b881336f