### PR TITLE
feat: allow migration generation without schema changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:shared": "npm run build -w @rflp/shared",
     "build:backend": "npm run build -w rflandscaperpro-backend",
     "build:frontend": "npm run build:browser -w frontend",
-    "migration:generate": "npm run migration:generate -w rflandscaperpro-backend",
+    "migration:generate": "npm run migration:generate -w rflandscaperpro-backend --",
     "migration:run": "npm run migration:run -w rflandscaperpro-backend",
     "migration:revert": "npm run migration:revert -w rflandscaperpro-backend",
     "seed": "npm run seed -w rflandscaperpro-backend",


### PR DESCRIPTION
## Summary
- add `--allow-empty` flag to `generate-migration.mjs` so migrations can be attempted even when no schema changes are detected
- pass arguments through root `migration:generate` npm script for parameterized use

## Testing
- `npm test -w rflandscaperpro-backend`
- `npm run lint` *(fails: Keyv is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68b63829a9308325aab35e4905f53c9f