### PR TITLE
feat: add database truncate script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,8 @@
     "seed:dev": "cross-env NODE_ENV=development npm run seed",
     "seed:drop": "ts-node -r tsconfig-paths/register src/seed.ts --drop",
     "seed:drop:dev": "cross-env NODE_ENV=development npm run seed:drop",
-    "db:reset": "ts-node -r tsconfig-paths/register scripts/reset-db.ts"
+    "db:reset": "ts-node -r tsconfig-paths/register scripts/reset-db.ts",
+    "db:truncate": "ts-node -r tsconfig-paths/register scripts/truncate-db.ts"
   },
   "dependencies": {
     "@rflp/shared": "file:../shared",

--- a/backend/scripts/truncate-db.ts
+++ b/backend/scripts/truncate-db.ts
@@ -1,0 +1,23 @@
+import dataSource from '../src/data-source';
+
+async function truncate(): Promise<void> {
+  await dataSource.initialize();
+
+  const tables: Array<{ tablename: string }> = await dataSource.query(
+    "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename <> 'migrations';",
+  );
+
+  if (tables.length > 0) {
+    const tableNames = tables.map((t) => `"${t.tablename}"`).join(', ');
+    await dataSource.query(`TRUNCATE ${tableNames} CASCADE;`);
+  }
+
+  await dataSource.destroy();
+
+  console.log('Database truncated.');
+}
+
+truncate().catch((err) => {
+  console.error('Failed to truncate database:', err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "seed": "npm run seed -w rflandscaperpro-backend",
     "seed:drop": "npm run seed:drop -w rflandscaperpro-backend",
     "db:reset": "npm run db:reset -w rflandscaperpro-backend",
+    "db:truncate": "npm run db:truncate -w rflandscaperpro-backend",
     "lint": "eslint . --cache --cache-location .eslintcache --fix",
     "lint:types": "eslint . --ext .ts --config eslint.types.config.mjs",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary
- add script to truncate user tables and close DataSource
- expose db:truncate npm script in backend and root packages

## Testing
- `npx eslint backend/scripts/truncate-db.ts --fix`
- `npm test -w rflandscaperpro-backend`


------
https://chatgpt.com/codex/tasks/task_e_68b640cbf5488325a7cf4453f357c6bb