### PR TITLE
feat: add database dump and restore scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -34,8 +34,8 @@
     "seed:drop": "ts-node -r tsconfig-paths/register src/seed.ts --drop",
     "seed:drop:dev": "cross-env NODE_ENV=development npm run seed:drop",
     "db:reset": "ts-node -r tsconfig-paths/register scripts/reset-db.ts",
-    "db:dump": "./scripts/dump-db.sh",
-    "db:restore": "./scripts/restore-db.sh"
+    "db:dump": "node ./scripts/run-db-script.js dump",
+    "db:restore": "node ./scripts/run-db-script.js restore"
   },
   "dependencies": {
     "@rflp/shared": "file:../shared",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,9 @@
     "seed:dev": "cross-env NODE_ENV=development npm run seed",
     "seed:drop": "ts-node -r tsconfig-paths/register src/seed.ts --drop",
     "seed:drop:dev": "cross-env NODE_ENV=development npm run seed:drop",
-    "db:reset": "ts-node -r tsconfig-paths/register scripts/reset-db.ts"
+    "db:reset": "ts-node -r tsconfig-paths/register scripts/reset-db.ts",
+    "db:dump": "./scripts/dump-db.sh",
+    "db:restore": "./scripts/restore-db.sh"
   },
   "dependencies": {
     "@rflp/shared": "file:../shared",

--- a/backend/scripts/dump-db.ps1
+++ b/backend/scripts/dump-db.ps1
@@ -1,0 +1,33 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = 'Stop'
+
+function Load-Env($path) {
+    Get-Content $path | ForEach-Object {
+        if ($_ -match '^([^#][^=]*)=(.*)$') {
+            [Environment]::SetEnvironmentVariable($matches[1], $matches[2])
+        }
+    }
+}
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BackendDir = Split-Path -Parent $ScriptDir
+Set-Location $BackendDir
+
+$envFile = if ($env:NODE_ENV) { ".env.$($env:NODE_ENV)" } else { '.env.development' }
+if (Test-Path $envFile) {
+    Load-Env $envFile
+} elseif (Test-Path '.env') {
+    Load-Env '.env'
+}
+
+$BackupDir = Join-Path $BackendDir 'backups'
+New-Item -ItemType Directory -Path $BackupDir -Force | Out-Null
+
+$Timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$OutFile = Join-Path $BackupDir "$($env:DB_NAME)-$Timestamp.sql"
+
+Write-Output "Dumping database $env:DB_NAME to $OutFile"
+[Environment]::SetEnvironmentVariable('PGPASSWORD', $env:DB_PASSWORD)
+pg_dump -h $env:DB_HOST -p $env:DB_PORT -U $env:DB_USERNAME -d $env:DB_NAME -f $OutFile
+
+Write-Output 'Backup completed.'

--- a/backend/scripts/dump-db.sh
+++ b/backend/scripts/dump-db.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$BACKEND_DIR"
+
+ENV_FILE=".env.${NODE_ENV:-development}"
+if [ -f "$ENV_FILE" ]; then
+  export $(grep -v '^#' "$ENV_FILE" | xargs)
+elif [ -f ".env" ]; then
+  export $(grep -v '^#' ".env" | xargs)
+fi
+
+BACKUP_DIR="$BACKEND_DIR/backups"
+mkdir -p "$BACKUP_DIR"
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OUT_FILE="$BACKUP_DIR/${DB_NAME}-${TIMESTAMP}.sql"
+
+echo "Dumping database $DB_NAME to $OUT_FILE"
+PGPASSWORD=${DB_PASSWORD:-} pg_dump -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" "$DB_NAME" > "$OUT_FILE"
+
+echo "Backup completed."

--- a/backend/scripts/restore-db.ps1
+++ b/backend/scripts/restore-db.ps1
@@ -1,0 +1,49 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = 'Stop'
+
+function Load-Env($path) {
+    Get-Content $path | ForEach-Object {
+        if ($_ -match '^([^#][^=]*)=(.*)$') {
+            [Environment]::SetEnvironmentVariable($matches[1], $matches[2])
+        }
+    }
+}
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BackendDir = Split-Path -Parent $ScriptDir
+Set-Location $BackendDir
+
+$envFile = if ($env:NODE_ENV) { ".env.$($env:NODE_ENV)" } else { '.env.development' }
+if (Test-Path $envFile) {
+    Load-Env $envFile
+} elseif (Test-Path '.env') {
+    Load-Env '.env'
+}
+
+$BackupDir = Join-Path $BackendDir 'backups'
+
+if ($args.Count -eq 0) {
+    Write-Output 'Available backups:'
+    Get-ChildItem $BackupDir | ForEach-Object { $_.Name }
+    $BackupFile = Read-Host 'Enter backup file name to restore'
+} else {
+    $BackupFile = $args[0]
+}
+
+$FullPath = Join-Path $BackupDir $BackupFile
+if (-not (Test-Path $FullPath)) {
+    Write-Output "Backup file '$FullPath' not found."
+    exit 1
+}
+
+$Confirm = Read-Host "This will overwrite database '$env:DB_NAME'. Continue? [y/N]"
+if ($Confirm -notmatch '^[Yy]$') {
+    Write-Output 'Aborted.'
+    exit 0
+}
+
+Write-Output "Restoring from $FullPath..."
+[Environment]::SetEnvironmentVariable('PGPASSWORD', $env:DB_PASSWORD)
+psql -h $env:DB_HOST -p $env:DB_PORT -U $env:DB_USERNAME -d $env:DB_NAME -f $FullPath
+
+Write-Output 'Restore complete.'

--- a/backend/scripts/restore-db.sh
+++ b/backend/scripts/restore-db.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$BACKEND_DIR"
+
+ENV_FILE=".env.${NODE_ENV:-development}"
+if [ -f "$ENV_FILE" ]; then
+  export $(grep -v '^#' "$ENV_FILE" | xargs)
+elif [ -f ".env" ]; then
+  export $(grep -v '^#' ".env" | xargs)
+fi
+
+BACKUP_DIR="$BACKEND_DIR/backups"
+
+if [ $# -eq 0 ]; then
+  echo "Available backups:"
+  ls "$BACKUP_DIR"
+  read -p "Enter backup file name to restore: " BACKUP_FILE
+else
+  BACKUP_FILE="$1"
+fi
+
+FULL_PATH="$BACKUP_DIR/$BACKUP_FILE"
+
+if [ ! -f "$FULL_PATH" ]; then
+  echo "Backup file '$FULL_PATH' not found."
+  exit 1
+fi
+
+read -p "This will overwrite database '$DB_NAME'. Continue? [y/N] " CONFIRM
+if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+echo "Restoring from $FULL_PATH..."
+PGPASSWORD=${DB_PASSWORD:-} psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" "$DB_NAME" < "$FULL_PATH"
+
+echo "Restore complete."

--- a/backend/scripts/run-db-script.js
+++ b/backend/scripts/run-db-script.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const action = process.argv[2];
+if (!['dump', 'restore'].includes(action)) {
+  console.error('Usage: node run-db-script.js <dump|restore> [args]');
+  process.exit(1);
+}
+
+const scriptName = action === 'dump' ? 'dump-db' : 'restore-db';
+const ext = process.platform === 'win32' ? '.ps1' : '.sh';
+const command = process.platform === 'win32' ? 'powershell' : 'bash';
+const scriptPath = path.join(__dirname, `${scriptName}${ext}`);
+
+const result = spawnSync(command, [scriptPath, ...process.argv.slice(3)], { stdio: 'inherit' });
+if (result.error) {
+  console.error(result.error);
+}
+process.exit(result.status ?? 1);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "seed": "npm run seed -w rflandscaperpro-backend",
     "seed:drop": "npm run seed:drop -w rflandscaperpro-backend",
     "db:reset": "npm run db:reset -w rflandscaperpro-backend",
+    "db:dump": "npm run db:dump -w rflandscaperpro-backend",
+    "db:restore": "npm run db:restore -w rflandscaperpro-backend",
     "lint": "eslint . --cache --cache-location .eslintcache --fix",
     "lint:types": "eslint . --ext .ts --config eslint.types.config.mjs",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary
- add bash scripts to dump and restore PostgreSQL database using environment variables and `.env.*` files
- expose db dump and restore utilities through backend and root npm scripts

## Testing
- `npm test -w rflandscaperpro-backend`


------
https://chatgpt.com/codex/tasks/task_e_68b640d6eccc8325b31eefbc4867a5f2