### PR TITLE
feat(db): optional sync flag

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -106,6 +106,12 @@ npm run seed:dev
 # Reset the database schema (uses DB_* env vars)
 npm run db:reset
 
+# Reset and seed the database
+npm run db:reset:seed
+
+# Auto-create tables when migrations are missing
+DB_SYNC=true npm run db:reset:seed
+
 # Check for pending schema changes without modifying the database
 npm run db:check-schema
 
@@ -338,6 +344,12 @@ npm run seed:dev
 
 # Reset the database schema (uses DB_* env vars)
 npm run db:reset
+
+# Reset and seed the database
+npm run db:reset:seed
+
+# Auto-create tables when migrations are missing
+DB_SYNC=true npm run db:reset:seed
 
 # Check for pending schema changes without modifying the database
 npm run db:check-schema

--- a/backend/env.example
+++ b/backend/env.example
@@ -19,6 +19,8 @@ DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=your_password
 DB_NAME=rflandscaperpro
+# Enable auto schema creation when migrations are missing (development only)
+DB_SYNC=false
 
 # Authentication
 # JWT_SECRET is required; the application will not start without it

--- a/backend/src/database/typeorm.config.ts
+++ b/backend/src/database/typeorm.config.ts
@@ -49,6 +49,7 @@ function commonOptions({
   password,
   port,
   ssl,
+  synchronize,
   username,
 }: {
   host: string;
@@ -58,6 +59,7 @@ function commonOptions({
   database: string;
   ssl: boolean;
   logging: DataSourceOptions['logging'];
+  synchronize: boolean;
 }): DataSourceOptions {
   const entities = [join(__dirname, '..', '**', '*.entity.{ts,js}')];
   const migrations = [
@@ -88,8 +90,8 @@ function commonOptions({
 
     // proper top-level SSL flag/object for TypeORM
     ssl: ssl ? { rejectUnauthorized: false } : false,
-    // Never block boot:
-    synchronize: false,
+    // Allow explicit schema sync when requested
+    synchronize,
 
     type: 'postgres',
 
@@ -110,6 +112,7 @@ export function buildTypeOrmOptions(cfg: ConfigService): DataSourceOptions {
   const password = cfg.get<string>('DB_PASSWORD')!;
   const database = cfg.get<string>('DB_NAME')!;
   const ssl = toBool(cfg.get('DB_SSL'), nodeEnv === 'production');
+  const synchronize = toBool(cfg.get('DB_SYNC'));
 
   const logging = parseLogging(cfg.get<string>('TYPEORM_LOGGING'));
   if (!host || !username || !password || !database) {
@@ -125,6 +128,7 @@ export function buildTypeOrmOptions(cfg: ConfigService): DataSourceOptions {
     password,
     port,
     ssl,
+    synchronize,
     username,
   });
 }
@@ -154,6 +158,7 @@ export function buildTypeOrmOptionsFromEnv(): DataSourceOptions {
   const password = process.env.DB_PASSWORD;
   const database = process.env.DB_NAME;
   const ssl = toBool(process.env.DB_SSL, nodeEnv === 'production');
+  const synchronize = toBool(process.env.DB_SYNC);
 
   if (!host || !username || !password || !database) {
     throw new Error(
@@ -170,6 +175,7 @@ export function buildTypeOrmOptionsFromEnv(): DataSourceOptions {
     password,
     port,
     ssl,
+    synchronize,
     username,
   });
 }


### PR DESCRIPTION
## Summary
- allow enabling TypeORM synchronize via `DB_SYNC`
- document using `DB_SYNC=true npm run db:reset:seed`
- add `DB_SYNC` to environment example

## Testing
- `npm run lint -w rflandscaperpro-backend` *(fails: 2 errors, 39 warnings)*
- `npm test -w rflandscaperpro-backend` *(fails: Nest can't resolve dependencies in multiple specs)*

------
https://chatgpt.com/codex/tasks/task_e_68b6498533a883259fe64eda799db624