### PR TITLE
feat: clean migrations in reset script

### DIFF
--- a/backend/scripts/reset-db.ts
+++ b/backend/scripts/reset-db.ts
@@ -1,8 +1,15 @@
+import fs from 'node:fs/promises';
 import dataSource from '../src/data-source';
 
-async function reset(seed: boolean): Promise<void> {
+async function reset(seed: boolean, cleanMigrations: boolean): Promise<void> {
   const ds = await dataSource.initialize();
   try {
+    if (cleanMigrations) {
+      await fs.rm('src/migrations', { recursive: true, force: true });
+      console.log(
+        'Migrations cleaned. Regenerate them before running migrations.',
+      );
+    }
     await ds.dropDatabase();
     await ds.runMigrations();
   } finally {
@@ -16,8 +23,9 @@ async function reset(seed: boolean): Promise<void> {
 }
 
 const shouldSeed = process.argv.includes('--seed');
+const cleanMigrations = process.argv.includes('--clean-migrations');
 
-reset(shouldSeed).catch((err) => {
+reset(shouldSeed, cleanMigrations).catch((err) => {
   console.error('Failed to reset database:', err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- support `--clean-migrations` flag in `reset-db.ts`
- delete `src/migrations` when flag is used and log reminder

## Testing
- `npm test -w rflandscaperpro-backend`
- `npm run lint -w rflandscaperpro-backend` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6499b1e508325903b421c3628d47b