### PR TITLE
refactor: convert db script to ES module

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -37,8 +37,8 @@
     "db:reset:seed": "ts-node -r tsconfig-paths/register scripts/reset-db.ts --seed",
     "db:check-schema": "ts-node -r tsconfig-paths/register scripts/check-schema.ts",
     "seed:sample": "ts-node -r tsconfig-paths/register scripts/seed-sample-data.ts",
-    "db:dump": "node ./scripts/run-db-script.js dump",
-    "db:restore": "node ./scripts/run-db-script.js restore",
+    "db:dump": "node ./scripts/run-db-script.mjs dump",
+    "db:restore": "node ./scripts/run-db-script.mjs restore",
     "db:truncate": "ts-node -r tsconfig-paths/register scripts/truncate-db.ts"
   },
   "dependencies": {

--- a/backend/scripts/run-db-script.mjs
+++ b/backend/scripts/run-db-script.mjs
@@ -1,17 +1,22 @@
 #!/usr/bin/env node
-const { spawnSync } = require('child_process');
-const path = require('path');
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
 
 const action = process.argv[2];
 if (!['dump', 'restore'].includes(action)) {
-  console.error('Usage: node run-db-script.js <dump|restore> [args]');
+  const script = path.basename(process.argv[1]);
+  console.error(`Usage: node ${script} <dump|restore> [args]`);
   process.exit(1);
 }
 
 const scriptName = action === 'dump' ? 'dump-db' : 'restore-db';
 const ext = process.platform === 'win32' ? '.ps1' : '.sh';
 const command = process.platform === 'win32' ? 'powershell' : 'bash';
-const scriptPath = path.join(__dirname, `${scriptName}${ext}`);
+const scriptPath = path.join(dirname, `${scriptName}${ext}`);
 
 const result = spawnSync(command, [scriptPath, ...process.argv.slice(3)], { stdio: 'inherit' });
 if (result.error) {


### PR DESCRIPTION
## Summary
- convert run-db-script to an ES module and resolve its own path
- update backend database npm scripts to use the new `.mjs` file

## Testing
- `npx eslint backend/scripts/run-db-script.mjs --no-cache`
- `npm test -w rflandscaperpro-backend`
- `npm run lint -- --no-cache` *(fails: A `require()` style import is forbidden in scripts/run-script.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b6523ca62083259123771f002ec0d3