### PR TITLE
fix: handle spaces in Windows run scripts

### DIFF
--- a/scripts/run-script.js
+++ b/scripts/run-script.js
@@ -12,7 +12,11 @@ const ext = process.platform === 'win32' ? '.ps1' : '.sh';
 const command = process.platform === 'win32' ? 'powershell' : 'bash';
 const scriptPath = path.join(__dirname, `${scriptName}${ext}`);
 
-const result = spawnSync(command, [scriptPath, ...process.argv.slice(3)], {
+const args = process.platform === 'win32'
+  ? ['-ExecutionPolicy', 'Bypass', '-File', scriptPath, ...process.argv.slice(3)]
+  : [scriptPath, ...process.argv.slice(3)];
+
+const result = spawnSync(command, args, {
   stdio: 'inherit',
 });
 if (result.error) {


### PR DESCRIPTION
## Summary
- ensure run-script works with Windows paths containing spaces

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Keyv is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68b657b1914c8325b7823cdce0423d4c