### PR TITLE
feat(frontend): send credentials for auth endpoints

### DIFF
--- a/frontend/src/app/auth/auth.service.spec.ts
+++ b/frontend/src/app/auth/auth.service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { AuthService } from './auth.service';
+import { environment } from '../../environments/environment';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AuthService],
+    });
+
+    service = TestBed.inject(AuthService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('should include credentials on login', () => {
+    service.login({ email: 'test@example.com', password: 'pw' }).subscribe();
+
+    const req = http.expectOne(`${environment.apiUrl}/auth/login`);
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush({ access_token: 'token' });
+  });
+
+  it('should include credentials on refresh token', () => {
+    service.refreshToken().subscribe();
+
+    const req = http.expectOne(`${environment.apiUrl}/auth/refresh`);
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush({ access_token: 'token' });
+  });
+
+  it('should include credentials on logout', () => {
+    service.logout().subscribe();
+
+    const req = http.expectOne(`${environment.apiUrl}/auth/logout`);
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush(null);
+  });
+});

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -26,6 +26,7 @@ export class AuthService {
       .post<{ access_token: string }>(
         `${environment.apiUrl}/auth/login`,
         data,
+        { withCredentials: true },
       )
       .pipe(
         tap((res) => {
@@ -99,7 +100,11 @@ export class AuthService {
 
   refreshToken(): Observable<{ access_token: string }> {
     return this.http
-      .post<{ access_token: string }>(`${environment.apiUrl}/auth/refresh`, {})
+      .post<{ access_token: string }>(
+        `${environment.apiUrl}/auth/refresh`,
+        {},
+        { withCredentials: true },
+      )
       .pipe(tap((res) => this.handleAuth(res)));
   }
 
@@ -121,7 +126,11 @@ export class AuthService {
 
   logout(): Observable<void> {
     return this.http
-      .post<void>(`${environment.apiUrl}/auth/logout`, {})
+      .post<void>(
+        `${environment.apiUrl}/auth/logout`,
+        {},
+        { withCredentials: true },
+      )
       .pipe(
         tap(() => {
           if (this.hasLocalStorage()) {


### PR DESCRIPTION
## Summary
- include cookies in login, refresh token, and logout calls
- add unit tests asserting withCredentials on auth service requests

## Testing
- `npm test -w frontend` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b6672617808325b27ebb1b2ef4fdd1