### PR TITLE
feat(frontend): omit auth header on refresh

### DIFF
--- a/frontend/src/app/api.service.spec.ts
+++ b/frontend/src/app/api.service.spec.ts
@@ -50,4 +50,15 @@ describe('ApiService auth interceptor', () => {
     expect(req.request.headers.has('X-Company-ID')).toBeFalse();
     req.flush({ access_token: 'xyz' });
   });
+
+  it('should not attach auth token on refresh but include company header', () => {
+    localStorage.setItem('token', 'abc');
+    localStorage.setItem('companyId', '1');
+    const http = TestBed.inject(HttpClient);
+    http.post(`${environment.apiUrl}/auth/refresh`, {}).subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/auth/refresh`);
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    expect(req.request.headers.get('X-Company-ID')).toBe('1');
+    req.flush({ access_token: 'xyz' });
+  });
 });

--- a/frontend/src/app/auth.interceptor.ts
+++ b/frontend/src/app/auth.interceptor.ts
@@ -10,10 +10,11 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
 
   const isLogin = req.url.includes('/auth/login');
   const isSwitchCompany = req.url.includes('/auth/switch-company');
+  const isRefresh = req.url.includes('/auth/refresh');
 
   const headers: Record<string, string> = {};
 
-  if (token && !isLogin) {
+  if (token && !isLogin && !isRefresh) {
     headers['Authorization'] = `Bearer ${token}`;
   }
 


### PR DESCRIPTION
## Summary
- avoid adding Authorization header to /auth/refresh requests
- test refresh route to ensure Authorization header is skipped while company header remains

## Testing
- `npm test -w frontend` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b6676b4e548325903eee04dd8a0b87