### PR TITLE
feat(auth): store tokens in session storage

### DIFF
--- a/frontend/src/app/api.service.spec.ts
+++ b/frontend/src/app/api.service.spec.ts
@@ -22,17 +22,17 @@ describe('ApiService auth interceptor', () => {
     });
     service = TestBed.inject(ApiService);
     httpMock = TestBed.inject(HttpTestingController);
-    localStorage.clear();
+    sessionStorage.clear();
   });
 
   afterEach(() => {
     httpMock.verify();
-    localStorage.clear();
+    sessionStorage.clear();
   });
 
   it('should attach auth token and company header', () => {
-    localStorage.setItem('token', 'abc');
-    localStorage.setItem('companyId', '1');
+    sessionStorage.setItem('token', 'abc');
+    sessionStorage.setItem('companyId', '1');
     service.getHealth().subscribe();
     const req = httpMock.expectOne(`${environment.apiUrl}/health`);
     expect(req.request.headers.get('Authorization')).toBe('Bearer abc');
@@ -41,8 +41,8 @@ describe('ApiService auth interceptor', () => {
   });
 
   it('should not attach auth token or company header on login', () => {
-    localStorage.setItem('token', 'abc');
-    localStorage.setItem('companyId', '1');
+    sessionStorage.setItem('token', 'abc');
+    sessionStorage.setItem('companyId', '1');
     const http = TestBed.inject(HttpClient);
     http.post(`${environment.apiUrl}/auth/login`, { email: 'a', password: 'b' }).subscribe();
     const req = httpMock.expectOne(`${environment.apiUrl}/auth/login`);

--- a/frontend/src/app/auth/auth.service.spec.ts
+++ b/frontend/src/app/auth/auth.service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { of } from 'rxjs';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService token management', () => {
+  let service: AuthService;
+  let httpSpy: jasmine.SpyObj<HttpClient>;
+
+  function createService(): AuthService {
+    httpSpy = jasmine.createSpyObj<HttpClient>('HttpClient', ['post']);
+    httpSpy.post.and.returnValue(of(void 0));
+    TestBed.configureTestingModule({
+      providers: [AuthService, { provide: HttpClient, useValue: httpSpy }],
+    });
+    return TestBed.inject(AuthService);
+  }
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    service = createService();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    TestBed.resetTestingModule();
+  });
+
+  it('should clear token on logout', () => {
+    service.handleAuth({ access_token: 'abc' });
+    expect(service.getToken()).toBe('abc');
+
+    service.logout().subscribe();
+    expect(sessionStorage.getItem('token')).toBeNull();
+    expect(service.getToken()).toBeNull();
+  });
+
+  it('should not persist token across browser restarts', () => {
+    service.handleAuth({ access_token: 'abc' });
+    expect(sessionStorage.getItem('token')).toBe('abc');
+
+    sessionStorage.clear();
+    TestBed.resetTestingModule();
+    service = createService();
+    expect(service.getToken()).toBeNull();
+  });
+});

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -8,8 +8,9 @@ import { environment } from '../../environments/environment';
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private http = inject(HttpClient);
-  private hasLocalStorage(): boolean {
-    return typeof localStorage !== 'undefined';
+  private inMemoryToken: string | null = null;
+  private hasSessionStorage(): boolean {
+    return typeof sessionStorage !== 'undefined';
   }
   private readonly roles = signal<string[]>(this.getRolesFromToken());
   private readonly company = signal<number | null>(this.getCompanyFromStorage());
@@ -29,13 +30,14 @@ export class AuthService {
       )
       .pipe(
         tap((res) => {
-          if (this.hasLocalStorage()) {
-            localStorage.setItem('token', res.access_token);
-            this.roles.set(this.getRolesFromToken(res.access_token));
-            const company = this.getCompanyFromToken(res.access_token);
-            this.setCompany(company ?? null);
-            this.setCompanies([]);
+          if (this.hasSessionStorage()) {
+            sessionStorage.setItem('token', res.access_token);
           }
+          this.inMemoryToken = res.access_token;
+          this.roles.set(this.getRolesFromToken(res.access_token));
+          const company = this.getCompanyFromToken(res.access_token);
+          this.setCompany(company ?? null);
+          this.setCompanies([]);
         }),
       );
   }
@@ -51,11 +53,12 @@ export class AuthService {
       .post<{ access_token: string }>(`${environment.apiUrl}/auth/switch-company`, { companyId })
       .pipe(
         tap((res) => {
-          if (this.hasLocalStorage()) {
-            localStorage.setItem('token', res.access_token);
-            this.roles.set(this.getRolesFromToken(res.access_token));
-            this.setCompany(companyId);
+          if (this.hasSessionStorage()) {
+            sessionStorage.setItem('token', res.access_token);
           }
+          this.inMemoryToken = res.access_token;
+          this.roles.set(this.getRolesFromToken(res.access_token));
+          this.setCompany(companyId);
         }),
       );
   }
@@ -107,16 +110,17 @@ export class AuthService {
     res: { access_token: string; companies?: CompanyMembership[] },
     companyHint?: number,
   ): void {
-    if (this.hasLocalStorage()) {
-      localStorage.setItem('token', res.access_token);
-      this.roles.set(this.getRolesFromToken(res.access_token));
-      const company = this.getCompanyFromToken(res.access_token) ?? companyHint ?? null;
-      const companies =
-        res.companies ??
-        (company ? [{ companyId: company, companyName: '', role: CompanyUserRole.WORKER }] : []);
-      this.setCompany(company);
-      this.setCompanies(companies);
+    if (this.hasSessionStorage()) {
+      sessionStorage.setItem('token', res.access_token);
     }
+    this.inMemoryToken = res.access_token;
+    this.roles.set(this.getRolesFromToken(res.access_token));
+    const company = this.getCompanyFromToken(res.access_token) ?? companyHint ?? null;
+    const companies =
+      res.companies ??
+      (company ? [{ companyId: company, companyName: '', role: CompanyUserRole.WORKER }] : []);
+    this.setCompany(company);
+    this.setCompanies(companies);
   }
 
   logout(): Observable<void> {
@@ -124,11 +128,12 @@ export class AuthService {
       .post<void>(`${environment.apiUrl}/auth/logout`, {})
       .pipe(
         tap(() => {
-          if (this.hasLocalStorage()) {
-            localStorage.removeItem('token');
-            localStorage.removeItem('companyId');
-            localStorage.removeItem('companies');
+          if (this.hasSessionStorage()) {
+            sessionStorage.removeItem('token');
+            sessionStorage.removeItem('companyId');
+            sessionStorage.removeItem('companies');
           }
+          this.inMemoryToken = null;
           this.roles.set([]);
           this.company.set(null);
           this.companies.set([]);
@@ -136,11 +141,26 @@ export class AuthService {
       );
   }
 
-  getToken(): string | null {
-    if (!this.hasLocalStorage()) {
-      return null;
+  private retrieveToken(): string | null {
+    if (this.hasSessionStorage()) {
+      const token = sessionStorage.getItem('token');
+      if (token) {
+        this.inMemoryToken = token;
+        return token;
+      }
     }
-    return localStorage.getItem('token');
+    if (typeof document !== 'undefined') {
+      const match = document.cookie.match(/(?:^|; )token=([^;]+)/);
+      if (match) {
+        this.inMemoryToken = match[1];
+        return match[1];
+      }
+    }
+    return this.inMemoryToken;
+  }
+
+  getToken(): string | null {
+    return this.retrieveToken();
   }
 
   isAuthenticated(): boolean {
@@ -156,37 +176,38 @@ export class AuthService {
   }
 
   setCompany(company: number | null): void {
-    if (this.hasLocalStorage()) {
+    if (this.hasSessionStorage()) {
       if (company !== null) {
-        localStorage.setItem('companyId', String(company));
+        sessionStorage.setItem('companyId', String(company));
       } else {
-        localStorage.removeItem('companyId');
+        sessionStorage.removeItem('companyId');
       }
     }
     this.company.set(company);
   }
 
   private setCompanies(companies: CompanyMembership[]): void {
-    if (this.hasLocalStorage()) {
-      localStorage.setItem('companies', JSON.stringify(companies));
+    if (this.hasSessionStorage()) {
+      sessionStorage.setItem('companies', JSON.stringify(companies));
     }
     this.companies.set(companies);
   }
 
   private getCompanyFromStorage(): number | null {
-    if (!this.hasLocalStorage()) {
-      return null;
+    if (!this.hasSessionStorage()) {
+      const token = this.retrieveToken();
+      return token ? this.getCompanyFromToken(token) : null;
     }
-    const stored = localStorage.getItem('companyId');
+    const stored = sessionStorage.getItem('companyId');
     if (stored) {
       const parsed = Number(stored);
       return Number.isNaN(parsed) ? null : parsed;
     }
-    const token = localStorage.getItem('token');
+    const token = this.retrieveToken();
     if (token) {
       const company = this.getCompanyFromToken(token);
       if (company !== null) {
-        localStorage.setItem('companyId', String(company));
+        sessionStorage.setItem('companyId', String(company));
         return company;
       }
     }
@@ -194,10 +215,10 @@ export class AuthService {
   }
 
   private getCompaniesFromStorage(): CompanyMembership[] {
-    if (!this.hasLocalStorage()) {
+    if (!this.hasSessionStorage()) {
       return [];
     }
-    const raw = localStorage.getItem('companies');
+    const raw = sessionStorage.getItem('companies');
     try {
       return raw ? (JSON.parse(raw) as CompanyMembership[]) : [];
     } catch {


### PR DESCRIPTION
## Summary
- store authentication tokens in sessionStorage with in-memory/cookie fallback
- ensure logout clears session data
- cover session token handling with new unit tests and update existing specs

## Testing
- `npm test -w frontend` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b66784e06c83258f1c6490035aa9e6