### PR TITLE
test: verify auth requests include credentials

### DIFF
--- a/frontend/src/app/auth/auth.service.spec.ts
+++ b/frontend/src/app/auth/auth.service.spec.ts
@@ -1,6 +1,9 @@
-import { TestBed } from '@angular/core/testing';
 import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
+
+import { environment } from '../../environments/environment';
 import { AuthService } from './auth.service';
 
 describe('AuthService token management', () => {
@@ -44,5 +47,56 @@ describe('AuthService token management', () => {
     service = createService();
     expect(service.getToken()).toBeNull();
 
+  });
+
+  it('should reflect authentication status based on token presence', () => {
+    expect(service.isAuthenticated()).toBeFalse();
+    service.handleAuth({ access_token: 'abc' });
+    expect(service.isAuthenticated()).toBeTrue();
+  });
+});
+
+describe('AuthService HTTP requests', () => {
+  let service: AuthService;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AuthService],
+    });
+    service = TestBed.inject(AuthService);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    controller.verify();
+    sessionStorage.clear();
+    TestBed.resetTestingModule();
+  });
+
+  it('should send login request with credentials', () => {
+    service.login({ email: 'a', password: 'b' }).subscribe();
+
+    const req = controller.expectOne(`${environment.apiUrl}/auth/login`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush({ access_token: 'token' });
+  });
+
+  it('should send refresh request with credentials', () => {
+    service.refreshToken().subscribe();
+
+    const req = controller.expectOne(`${environment.apiUrl}/auth/refresh`);
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush({ access_token: 'token' });
+  });
+
+  it('should send logout request with credentials', () => {
+    service.logout().subscribe();
+
+    const req = controller.expectOne(`${environment.apiUrl}/auth/logout`);
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush({});
   });
 });


### PR DESCRIPTION
## Summary
- expand auth service unit tests to verify withCredentials for login, refresh and logout requests
- add authentication status test for token presence

## Testing
- `npm run lint`
- `CHROME_BIN=$(which chromium-browser) npm test` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b66abfc3248325a044b5f9516a433f